### PR TITLE
Tweak markdown formatting

### DIFF
--- a/Hello_Markdown_Doc.py
+++ b/Hello_Markdown_Doc.py
@@ -14,7 +14,7 @@ Output to %s
 """
 
 from typing import Callable
-from inspect import getmembers, isfunction, signature
+from inspect import getdoc, getmembers, isfunction, signature
 import Python_BMP.BITMAPlib as m
 import webbrowser as web
 
@@ -35,7 +35,23 @@ def isPublic(s: str) -> bool:
 
 
 def meta(f: Callable):
-    return f'**def {f.__name__}{signature(f)}:**\n>{f.__doc__}\n'
+    fqname = ".".join((f.__module__, f.__qualname__))
+    d = getdoc(f) or ""
+    d1 = d.split("\n\n")[0]
+    d2 = d[len(d1)+2:].replace("\n", "\n    ")
+    return "\x0a".join([
+      f"### [`{f.__qualname__}`](#{fqname})",
+      "",
+      "```py",
+      f"def {f.__name__}{signature(f)}:",
+      "```",
+      "",
+      d1,
+      "",
+      f"    {d2}",
+      "",
+    ])
+    
 
 
 def main():
@@ -52,4 +68,3 @@ def main():
 
 if __name__=="__main__":
         main()
-

--- a/Hello_Markdown_Doc.py
+++ b/Hello_Markdown_Doc.py
@@ -40,7 +40,7 @@ def meta(f: Callable):
     d1 = d.split("\n\n")[0]
     d2 = d[len(d1)+2:].replace("\n", "\n    ")
     return "\x0a".join([
-      f"### [`{f.__qualname__}`](#{fqname})",
+      f"### [`{f.__qualname__}`](#{f.__qualname__})",
       "",
       "```py",
       f"def {f.__name__}{signature(f)}:",

--- a/docs/BitmapLib_Doc.html
+++ b/docs/BitmapLib_Doc.html
@@ -1,0 +1,8577 @@
+<h1>Python BMP Public API</h1>
+<h3><a href="#Python_BMP.BITMAPlib._1bmof"><code>_1bmof</code></a></h3>
+<p><code>py
+def _1bmof(bmp: array.array, x: int, y: int) -&gt; int:</code></p>
+<p>Get the offset in a byte array
+with 1 bit color data given x and y data</p>
+<pre><code>Args:
+    bmp : unsigned byte array
+          with bmp format
+    x, y: unsigned int value
+          of location in
+          x-axis and y-axis
+
+Returns:
+    int value of offset to that data in byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._1bmofhd"><code>_1bmofhd</code></a></h3>
+<p><code>py
+def _1bmofhd(bmp: array.array, x: int, y: int) -&gt; int:</code></p>
+<p>Get the offset in a byte array
+    with 1 bit color data given
+    x and y with adjustments
+    made for a bmp header</p>
+<pre><code>Args:
+    bmp : unsigned byte array
+          with bmp format
+    x, y: unsigned int value
+          of location in
+          x-axis and y-axis
+
+Returns:
+    int value of offset to that data in byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._24bmof"><code>_24bmof</code></a></h3>
+<p><code>py
+def _24bmof(bmp: array.array, x: int, y: int) -&gt; int:</code></p>
+<p>Get the offset in a byte array with RGB data given x and y</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    x,y: unsigned int value
+         of location in
+         x-axis and y-axis
+
+Returns:
+    int value of offset to that data in byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._24bmofhd"><code>_24bmofhd</code></a></h3>
+<p><code>py
+def _24bmofhd(bmp: array.array, x: int, y: int) -&gt; int:</code></p>
+<p>Get the offset in a byte array
+with RGB data given x and y with bmp header</p>
+<pre><code>Args:
+    bmp:  unsigned byte array
+          with bmp format
+    x, y: unsigned int value
+          of location in
+          x-axis and y-axis
+
+Returns:
+    int value of offset to that data in byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._4bmof"><code>_4bmof</code></a></h3>
+<p><code>py
+def _4bmof(bmp: array.array, x: int, y: int) -&gt; int:</code></p>
+<p>Get the offset in a byte array
+with 4 bit color data given x and y data</p>
+<pre><code>Args:
+    bmp:  unsigned byte array
+          with bmp format
+    x, y: unsigned int value
+          of location in
+          x-axis and y-axis
+
+Returns:
+    int value of offset to that data in byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._4bmofhd"><code>_4bmofhd</code></a></h3>
+<p><code>py
+def _4bmofhd(bmp: array.array, x: int, y: int) -&gt; int:</code></p>
+<p>Get the offset in a byte array
+with 4 bit color data given
+x and y with adjustments
+made due to a header</p>
+<pre><code>Args:
+    bmp : unsigned byte array
+          with bmp format
+    x, y: unsigned int value
+          of location in
+          x-axis and y-axis
+
+Returns:
+    int value of offset to that data in byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._8bmof"><code>_8bmof</code></a></h3>
+<p><code>py
+def _8bmof(bmp: array.array, x: int, y: int) -&gt; int:</code></p>
+<p>Get the offset in a byte array
+with 8 bit color data given x and y data</p>
+<pre><code>Args:
+    bmp:  unsigned byte array
+          with bmp format
+    x, y: unsigned int value
+          of location in
+          x-axis and y-axis
+
+Returns:
+    int value of offset to
+    that data in byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._8bmofhd"><code>_8bmofhd</code></a></h3>
+<p><code>py
+def _8bmofhd(bmp: array.array, x: int, y: int) -&gt; int:</code></p>
+<p>Get the offset in a byte array
+with 8 bit color data given
+x and y with adjustments
+made for a bmp header</p>
+<pre><code>Args:
+    bmp : unsigned byte array
+          with bmp format
+    x, y: unsigned int value
+          of location in
+          x-axis and y-axis
+
+Returns:
+    int value of offset to
+    that data in byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._bmmeta"><code>_bmmeta</code></a></h3>
+<p><code>py
+def _bmmeta(x: int, y: int, bits: int) -&gt; tuple:</code></p>
+<p>Computes bitmap meta data</p>
+<pre><code>Args:
+    x, y : unsigned int
+           values of the
+           x and y dimension
+    bits : bit depth (1, 4, 8, 24)
+
+Returns:
+    unsigned int values for
+    (filesize, headersize,
+    xdim, ydim, bitdepth)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._BMoffset"><code>_BMoffset</code></a></h3>
+<p><code>py
+def _BMoffset(bmp: array.array, x: int, y: int) -&gt; int:</code></p>
+<p>Returns the offset given a bmp and (x, y) coordinates</p>
+<pre><code>Args:
+    bmp : unsigned byte array
+          with bmp format
+    x, y: unsigned int location
+          in x-axis and y-axis
+
+Returns:
+    unsigned int offset to data in buffer
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._BMoffsethd"><code>_BMoffsethd</code></a></h3>
+<p><code>py
+def _BMoffsethd(bmp: array.array, x: int, y: int) -&gt; int:</code></p>
+<p>Returns the offset given a bmp
+and (x, y) coordinates with header considered</p>
+<pre><code>Args:
+    bmp : unsigned byte array
+          with bmp format
+    x, y: unsigned int location
+          in x-axis and y-axis
+
+Returns:
+    unsigned int offset to data in buffer
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._cmpimglines"><code>_cmpimglines</code></a></h3>
+<p><code>py
+def _cmpimglines(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Callable):</code></p>
+<h3><a href="#Python_BMP.BITMAPlib._flsz"><code>_flsz</code></a></h3>
+<p><code>py
+def _flsz(bmp: array.array) -&gt; int:</code></p>
+<p>Get the file size of a win bmp
+    from its bmp header</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    unsigned int value of size
+    of the bmp header
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._fnwithpar2vertslice"><code>_fnwithpar2vertslice</code></a></h3>
+<p><code>py
+def _fnwithpar2vertslice(bmp: array.array, x: int, y1: int, y2: int, func: Callable, funcparam):</code></p>
+<p>Apply a user defined function to vertical slices</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y1, y2 : unsigned int
+                x and y coordinates
+    func      : user defined function
+    funcparam : parameters of
+                the user defined
+                function
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._getbmflsz"><code>_getbmflsz</code></a></h3>
+<p><code>py
+def _getbmflsz(x: int, y: int, bits: int) -&gt; int:</code></p>
+<p>Computes bitmap file size</p>
+<pre><code>Args:
+    x, y: unsigned int value
+          of x and y dimensions
+    bits: bit depth (1, 4, 8, 24)
+
+Returns:
+    int value of file size
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._getBMofffunc"><code>_getBMofffunc</code></a></h3>
+<p><code>py
+def _getBMofffunc(bmp: array.array):</code></p>
+<p>Returns the correct function
+to use in computing the offset
+in a given bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    function to compute offsets
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._getBMoffhdfunc"><code>_getBMoffhdfunc</code></a></h3>
+<p><code>py
+def _getBMoffhdfunc(bmp: array.array):</code></p>
+<p>Returns the correct function
+to use in computing offsets
+with headers in a given bmp</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    function to compute offsets with headers
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._getclrbits"><code>_getclrbits</code></a></h3>
+<p><code>py
+def _getclrbits(bmp: array.array) -&gt; int:</code></p>
+<p>Get the bit depth of BMP</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    int value of bit depth
+    (1, 4, 8, 24) bits
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._hdsz"><code>_hdsz</code></a></h3>
+<p><code>py
+def _hdsz(bmp: array.array) -&gt; int:</code></p>
+<p>Get the header size of a BMP</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    int value of header size
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._pdbytes"><code>_pdbytes</code></a></h3>
+<p><code>py
+def _pdbytes(x: int, bits: int) -&gt; int:</code></p>
+<p>Get the number of bytes used to pad for
+32-bit alignment given x dimension and bit depth</p>
+<pre><code>Args:
+    x   : unsigned int value of
+          x-dimension
+    bits: unsigned int value of
+          bit depth (1, 4, 8, 24)
+
+Returns:
+    int value of number of pad bytes
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._setflsz"><code>_setflsz</code></a></h3>
+<p><code>py
+def _setflsz(bmp: array.array, size: int):</code></p>
+<p>Set the file size of a BMP</p>
+<pre><code>Args:
+    bmp  : unsigned byte array
+           with bmp format
+    size : unsigned int value
+           of size of
+           the bmp file
+
+Returns:
+    byref modified unsigned byte array
+    with new file size
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._sethdsz"><code>_sethdsz</code></a></h3>
+<p><code>py
+def _sethdsz(bmp: array.array, hdsize: int):</code></p>
+<p>Set the header size of a win bmp</p>
+<pre><code>Args:
+    bmp   : unsigned byte array
+            with bmp format
+    hdsize: unsigned int value
+            of size of the
+            bmp header
+
+Returns:
+    byref modified byte array
+    with new header size
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._setmeta"><code>_setmeta</code></a></h3>
+<p><code>py
+def _setmeta(bmpmeta: list) -&gt; array.array:</code></p>
+<p>Creates a new bitmap
+    with the properties set
+    by bmpmeta to
+    a new unsigned byte array</p>
+<pre><code>Args:
+    bmpmeta: [filesize, hdrsize,
+              x, y, bits]
+
+Returns:
+    unsigned byte array with bmp format
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._setx"><code>_setx</code></a></h3>
+<p><code>py
+def _setx(bmp: array.array, xmax: int):</code></p>
+<p>Sets the x value stored in the windows bmp header</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    int: value of x dimension
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._sety"><code>_sety</code></a></h3>
+<p><code>py
+def _sety(bmp: array.array, ymax: int):</code></p>
+<p>Sets the y value stored in the windows bmp header</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    int: value of y dimension
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._use24bitfn2reg"><code>_use24bitfn2reg</code></a></h3>
+<p><code>py
+def _use24bitfn2reg(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Callable, funcparam):</code></p>
+<p>Apply func(funcparam) to a rectangular area
+in a 24-bit bitmap</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangular area
+    func          : user defined
+                    function
+    funcparam     : parameters of
+                    the function
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._use24btbyrefclrfn2regnsv"><code>_use24btbyrefclrfn2regnsv</code></a></h3>
+<p><code>py
+def _use24btbyrefclrfn2regnsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable, funcparam):</code></p>
+<p>Apply a 24-bit byref
+color modification function
+to a rectangular area and save</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2:  the rectangular
+                     area
+    func           : user defined
+                     function
+    funcparam      : function
+                     parameters
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._use24btclrfn"><code>_use24btclrfn</code></a></h3>
+<p><code>py
+def _use24btclrfn(ExistingBMPfile: str, NewBMPfile: str, func: Callable, funcparam):</code></p>
+<p>Apply a user provided color adjustment function
+to a 24-bit bitmap</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save the
+                     changes in
+    func           : user defined
+                     function
+    funcparam      : parameters of
+                     the function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._use24btclrfntocircregion"><code>_use24btclrfntocircregion</code></a></h3>
+<p><code>py
+def _use24btclrfntocircregion(ExistingBMPfile: str, NewBMPfile: str, func: Callable, x: int, y: int, r: int):</code></p>
+<p>Apply a no parameter color adjustment function
+to a circular area (24-bit only)</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x, y, r        : center (x, y)
+                     and radius r
+    func           : user defined
+                     function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._use24btclrfnwithpar2circreg"><code>_use24btclrfnwithpar2circreg</code></a></h3>
+<p><code>py
+def _use24btclrfnwithpar2circreg(ExistingBMPfile: str, NewBMPfile: str, func: Callable, x: int, y: int, r: int, funcparam):</code></p>
+<p>Apply a user provided color adjustment function
+to a circular area (24-bit only)</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x, y, r        : center (x,y)
+                     and radius r
+    func           : user defined
+                     function
+    funcparam      : parameters of
+                     the function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._use24btfn2circreg"><code>_use24btfn2circreg</code></a></h3>
+<p><code>py
+def _use24btfn2circreg(bmp: array.array, x: int, y: int, r: int, func: Callable, funcparam):</code></p>
+<p>Apply function func to a
+circular region with center at
+(x, y) and a radius r that is
+within a 24-bit bitmap</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y, r   : center (x, y)
+                and radius r
+                of the circular area
+    func      : function to apply
+    funcparam : parameters of the
+                function
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._use24btfnwithparnsv"><code>_use24btfnwithparnsv</code></a></h3>
+<p><code>py
+def _use24btfnwithparnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable, funcparam):</code></p>
+<p>Apply a 24-bit only function with parameters and save</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    func           : user defined
+                     function
+    funcparam      : parameters of
+                     the function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usebyref24btfn2reg"><code>_usebyref24btfn2reg</code></a></h3>
+<p><code>py
+def _usebyref24btfn2reg(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Callable, funcparam):</code></p>
+<p>Apply byref func(funcparam) to a rectangular area
+in a 24-bit bitmap</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangular area
+    func          : user defined
+                    function
+    funcparam     : parameters of
+                    the function
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usebyref24btfn2regnsv"><code>_usebyref24btfn2regnsv</code></a></h3>
+<p><code>py
+def _usebyref24btfn2regnsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable):</code></p>
+<p>Apply a 24-bit byref function
+with no parameters to a
+rectangular area and save</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+    func           : user defined
+                     function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usebyreffn2regnsv"><code>_usebyreffn2regnsv</code></a></h3>
+<p><code>py
+def _usebyreffn2regnsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable):</code></p>
+<p>Apply a byref function
+with no parameters to a
+rectangular region and save</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+    func           : user defined
+                     function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usebyreffnsv"><code>_usebyreffnsv</code></a></h3>
+<p><code>py
+def _usebyreffnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable):</code></p>
+<p>Apply a by-ref function with no parameters and save</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    func           : user defined
+                     function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usebyreffnwithpar2regnsv"><code>_usebyreffnwithpar2regnsv</code></a></h3>
+<p><code>py
+def _usebyreffnwithpar2regnsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable, funcparam):</code></p>
+<p>Apply a 24-bit byref function
+to a rectangular area and save</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : the rectangular
+                     area
+    func           : user defined
+                     function
+    funcparam      : function
+                     parameters
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usebyreffnwithparnsv"><code>_usebyreffnwithparnsv</code></a></h3>
+<p><code>py
+def _usebyreffnwithparnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable, funcparam):</code></p>
+<h3><a href="#Python_BMP.BITMAPlib._usebyrefnopar24bitfn2reg"><code>_usebyrefnopar24bitfn2reg</code></a></h3>
+<p><code>py
+def _usebyrefnopar24bitfn2reg(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Callable):</code></p>
+<p>Apply a func to a rectangular area in a 24-bit bitmap</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: the rectangular
+                    area
+    func          : user defined
+                    function
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._useclradjfn"><code>_useclradjfn</code></a></h3>
+<p><code>py
+def _useclradjfn(ExistingBMPfile: str, NewBMPfile: str, func: Callable, funcparam):</code></p>
+<p>Apply a user provided color adjustmen function
+to an existing bitmap</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    func           : user defined
+                     function
+    funcparam      : parameters of
+                     the function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usefn2circreg"><code>_usefn2circreg</code></a></h3>
+<p><code>py
+def _usefn2circreg(ExistingBMPfile: str, NewBMPfile: str, func: Callable, x: int, y: int, r: int):</code></p>
+<p>Apply a user provided function (no parameters)
+to a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x, y, r        : center (x, y)
+                     and radius r
+    func           : user defined
+                     function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usefn2regsv"><code>_usefn2regsv</code></a></h3>
+<p><code>py
+def _usefn2regsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable):</code></p>
+<p>Apply a function withno parameters to a
+rectangular area and save</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+    func           : user defined
+                     function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usefnsv"><code>_usefnsv</code></a></h3>
+<p><code>py
+def _usefnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable):</code></p>
+<p>Apply a function with no parameters and save</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    func           : user defined
+                     function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usefnwithpar2circreg"><code>_usefnwithpar2circreg</code></a></h3>
+<p><code>py
+def _usefnwithpar2circreg(ExistingBMPfile: str, NewBMPfile: str, func: Callable, x: int, y: int, r: int, funcparam):</code></p>
+<p>Apply a user provided function with parameters
+to a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x, y, r        : center (x,y)
+                     and radius r
+    func           : user defined
+                     function
+    funcparam      : parameters of
+                     the function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usenopar24btfn2circreg"><code>_usenopar24btfn2circreg</code></a></h3>
+<p><code>py
+def _usenopar24btfn2circreg(bmp: array.array, x: int, y: int, r: int, func: Callable):</code></p>
+<p>Apply a no parameter function
+to a circular region with
+center at (x, y) and a radius r
+in a 24-bit bitmap</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of the circular area
+    func   : function to apply
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usenoparclradjfn"><code>_usenoparclradjfn</code></a></h3>
+<p><code>py
+def _usenoparclradjfn(ExistingBMPfile: str, NewBMPfile: str, func: Callable):</code></p>
+<p>Apply a user provided no parameter color
+    adjustment function to an existing bitmap</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    func           : user defined
+                     function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._usenoparfn2circreg"><code>_usenoparfn2circreg</code></a></h3>
+<p><code>py
+def _usenoparfn2circreg(bmp: array.array, x: int, y: int, r: int, func: Callable):</code></p>
+<p>Apply a no parameter function
+to a circular region with a
+center at (x,y) and a radius r</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x,y)
+             and radius r
+             of the
+             circular area
+    func   : function
+             to apply
+             to the area
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._xbytes"><code>_xbytes</code></a></h3>
+<p><code>py
+def _xbytes(x: int, bits: int) -&gt; int:</code></p>
+<p>Get the number of bytes in
+a bmp row given x dimension and bit depth</p>
+<pre><code>Args:
+    x   : unsigned int value of
+          x-dimension
+    bits: unsigned int value of
+          bit depth (1, 4, 8, 24)
+
+Returns:
+    int value of number of bytes in a row
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib._xchrcnt"><code>_xchrcnt</code></a></h3>
+<p><code>py
+def _xchrcnt(bmp: array.array) -&gt; int:</code></p>
+<p>Get the chars or bytes in row of a BMP</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    count of bytes or
+    chars in a row (x dim)
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.addvect"><code>addvect</code></a></h3>
+<p><code>py
+def addvect(u: list[numbers.Number], v: list[numbers.Number]) -&gt; list[numbers.Number]:</code></p>
+<p>Add vectors u and v by adding their components</p>
+<pre><code>Args:
+    u, v: list of ints or floats
+
+Returns:
+    list of ints or floats
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.addvectinlist"><code>addvectinlist</code></a></h3>
+<p><code>py
+def addvectinlist(vlist: list[list[numbers.Number]]) -&gt; numbers.Number:</code></p>
+<p>Gets the sum of the vectors in a list of vectors</p>
+<pre><code>Args:
+    vlist: list of vectors
+
+Returns:
+    list or vector
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.adjustbrightness2file"><code>adjustbrightness2file</code></a></h3>
+<p><code>py
+def adjustbrightness2file(ExistingBMPfile: str, NewBMPfile: str, percentadj: float):</code></p>
+<p>Apply a brightness adjustment to the image in a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    percentadj     : can be a
+                     positive or
+                     negative value
+                     (signed float)
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.adjustbrightnessinregion2file"><code>adjustbrightnessinregion2file</code></a></h3>
+<p><code>py
+def adjustbrightnessinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, percentadj: float):</code></p>
+<p>Brightness adjustment to rectangular area in a 24-bit BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+    percentadj     : can be a
+                     positive or
+                     negative
+                     adjustment
+                    (signed float)
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.adjustcolordicttopal"><code>adjustcolordicttopal</code></a></h3>
+<p><code>py
+def adjustcolordicttopal(bmp: array.array, colordict: dict):</code></p>
+<p>Adjust a color dictionary to match
+as closely as possible a bitmap palette</p>
+<pre><code>Args:
+    bmp      : unsigned byte array
+               with bmp format
+    colordict: dictionary of colors
+
+Returns:
+    byref modified dictionary of colors
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.adjustthresholdinregion2file"><code>adjustthresholdinregion2file</code></a></h3>
+<p><code>py
+def adjustthresholdinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, lumrange: list):</code></p>
+<p>Threshold adjust in a rectangular area in a 24-bit BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+    lumrange       : (byte:byte)
+                     threshold to
+                     apply
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.bufresize.adjustxbufsize"><code>adjustxbufsize</code></a></h3>
+<p><code>py
+def adjustxbufsize(bmp: array.array, x1: int, x2: int) -&gt; int:</code></p>
+<p>Returns a 32 -bit padded
+    int buffer size for a
+    buffer with the bit depth
+    stored in byte number 28
+    of the bitmap bmp and an
+    int length of x2 - x1 + 1</p>
+<pre><code>Args:
+    bmp   : unsigned byte array
+            with bmp format
+    x1, x2: int params for
+            a x coord line
+            in the bitmap
+
+Returns:
+    int adjusted buffer size
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.andvect"><code>andvect</code></a></h3>
+<p><code>py
+def andvect(u: list[int], v: list[int]) -&gt; list[int]:</code></p>
+<p>Bitwise and operation of between
+the elements of two lists of ints</p>
+<pre><code>Args:
+    v      : list[int]
+    bitmask: int
+
+Returns:
+    list[int]
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.anglebetween2Dlines"><code>anglebetween2Dlines</code></a></h3>
+<p><code>py
+def anglebetween2Dlines(u: list[numbers.Number, numbers.Number], v: list[numbers.Number, numbers.Number]) -&gt; float:</code></p>
+<p>Compute the angle between two lines of vectors</p>
+<pre><code>Args:
+    u, v: list[Number, Number]
+
+Returns:
+    float angle in radians
+</code></pre>
+<h3><a href="#Python_BMP.colors.applybrightnessadjtoBGRbuf"><code>applybrightnessadjtoBGRbuf</code></a></h3>
+<p><code>py
+def applybrightnessadjtoBGRbuf(buf: array.array, percentadj: float) -&gt; array.array:</code></p>
+<p>Apply a brightness adjustment
+    to a BGR buffer</p>
+<pre><code>Args:
+    buf: unsigned byte array
+         holding BGR data
+
+    percentadj: float brightness
+                adjust can be
+                positive or
+                negative
+
+Returns:
+    unsigned byte array
+    holding brightness adjusted
+    BGR data
+</code></pre>
+<h3><a href="#Python_BMP.colors.applycolorfiltertoBGRbuf"><code>applycolorfiltertoBGRbuf</code></a></h3>
+<p><code>py
+def applycolorfiltertoBGRbuf(buf: array.array, rgbfactors: list[float, float, float]):</code></p>
+<p>Apply a color filter to a
+    BGR buffer</p>
+<pre><code>Args:
+    buf: unsigned byte array
+         holding BGR data
+
+    rgbfactors: color filter as
+                  [r: float,
+                   g: float,
+                   b: float]
+
+Returns:
+    byref unsigned byte array
+    holding color BGR data
+</code></pre>
+<h3><a href="#Python_BMP.colors.applygammaBGRbuf"><code>applygammaBGRbuf</code></a></h3>
+<p><code>py
+def applygammaBGRbuf(buf: array.array, gamma: float):</code></p>
+<p>Apply a gamma adjustment to a
+    BGR buffer</p>
+<pre><code>Args:
+    buf: unsigned byte array
+         holding BGR data
+
+    gamma: float gamma adjust
+
+Returns:
+    byref unsigned byte array
+    holding gamma adjusted
+    BGR data
+</code></pre>
+<h3><a href="#Python_BMP.colors.applymonochromefiltertoBGRbuf"><code>applymonochromefiltertoBGRbuf</code></a></h3>
+<p><code>py
+def applymonochromefiltertoBGRbuf(buf: array.array):</code></p>
+<p>Apply a monochrome filter to a
+    BGR buffer</p>
+<pre><code>Args:
+    buf: unsigned byte array
+         holding BGR data
+
+    rgbfactors: color filter as
+                  [r: float,
+                   g: float,
+                   b: float]
+
+Returns:
+    byref unsigned byte array
+    holding mono BGR data
+</code></pre>
+<h3><a href="#Python_BMP.colors.applythresholdadjtoBGRbuf"><code>applythresholdadjtoBGRbuf</code></a></h3>
+<p><code>py
+def applythresholdadjtoBGRbuf(buf: array.array, lumrange: list) -&gt; array.array:</code></p>
+<p>Apply a threshold adjustment
+    to a BGR buffer</p>
+<pre><code>Args:
+    buf: unsigned byte array
+         holding BGR data
+
+    lumrange: [min: int, max: int]
+              brightness threshold
+
+Returns:
+    unsigned byte array
+    holding threshold adjusted
+    BGR data
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.arcvert"><code>arcvert</code></a></h3>
+<p><code>py
+def arcvert(x: int, y: int, r: int, startdegangle: float, enddegangle: float):</code></p>
+<p>Returns a list[(int, int)] of 2D vertices
+along a path defined by radius r as it
+traces an arc with origin set at (x, y)</p>
+<pre><code>Args:
+    x, y: int centerpoint
+              coordinates
+    r   : int radius
+
+    startangle: degree start of arc
+    endangle  : degree end of arc
+
+Yields:
+    list of vertices of the arc
+    list[[x: int, y: int]]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.autocropimg2file"><code>autocropimg2file</code></a></h3>
+<p><code>py
+def autocropimg2file(ExistingBMPfile: str, NewBMPfile: str, similaritythreshold: float):</code></p>
+<p>Perform an auto crop to the image in a bitmap file</p>
+<pre><code>Args:
+    ExistingBMPfile    : Whole path to
+                         existing file
+    NewBMPfile         : New file to
+                         save changes in
+    similaritythreshold: used to tune
+                         autocrop
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.beziercurve"><code>beziercurve</code></a></h3>
+<p><code>py
+def beziercurve(bmp: array.array, pntlist: list[list[numbers.Number, numbers.Number]], penradius: int, color: int):</code></p>
+<p>Draws a Bezier Curve</p>
+<pre><code>Args:
+    bmp      : unsigned byte array
+               with bmp format
+    pntlist  : [(x,y)...]
+               the control points
+    penradius: radius of pen
+    color    : color of the
+               bezier curve
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.BMPbitBLTget"><code>BMPbitBLTget</code></a></h3>
+<p><code>py
+def BMPbitBLTget(bmp: array.array, offset: int, bufsize: int) -&gt; array.array:</code></p>
+<p>Gets [offset: offset + bufsize] to a new array</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    offset : unsigned int
+             address in buffer
+    bufsize: unsigned int
+             size of buffer
+
+Returns:
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.BMPbitBLTput"><code>BMPbitBLTput</code></a></h3>
+<p><code>py
+def BMPbitBLTput(bmp: array.array, offset: int, arraybuf: array.array):</code></p>
+<p>Sets offset in array to arraybuf</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    offset  : unsigned int
+              address in buffer
+    arraybuf: unsigned byte array
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.bottomrightcoord"><code>bottomrightcoord</code></a></h3>
+<p><code>py
+def bottomrightcoord(bmp: array.array) -&gt; tuple:</code></p>
+<p>Gets the maximum bottom right coordinates of a bmp</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    tuple (x:int,y:int)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.brightnessadjcircregion2file"><code>brightnessadjcircregion2file</code></a></h3>
+<p><code>py
+def brightnessadjcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, percentadj: float):</code></p>
+<p>Brightness gradient to a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+                     of a circular
+                     region
+                     in which we
+                     apply a
+    percentadj     : brightness
+                     adjustment
+                     that can be
+                     positive
+                     or negative
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.brightnessadjcircregion"><code>brightnessadjcircregion</code></a></h3>
+<p><code>py
+def brightnessadjcircregion(bmp: array.array, x: int, y: int, r: int, percentadj: float):</code></p>
+<p>Brightness adjustment to a circular area</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y, r   : center (x, y)
+                and radius r
+                of the region
+    percentadj: float percent of the
+                brightness adjustment
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.colors.brightnessadjust"><code>brightnessadjust</code></a></h3>
+<p><code>py
+def brightnessadjust(rgb: list[int, int, int], percentadj: float) -&gt; list[int, int, int]:</code></p>
+<p>Apply a brightness adjustment
+    to a rgb</p>
+<pre><code>Args:
+    rgb: color as [r: byte,
+                   g: byte,
+                   b: byte]
+    percentadj: brightness
+                adjustment
+                in percent
+                can be positive
+                or negative
+
+Returns:
+    a brightness adjusted color as
+    [r: byte, g: byte, b: byte]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.brightnesseadjto24bitimage"><code>brightnesseadjto24bitimage</code></a></h3>
+<p><code>py
+def brightnesseadjto24bitimage(bmp: array.array, percentadj: float):</code></p>
+<p>Brightness adjustment to a whole BMP</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    percentadj: float percentage
+                brightness
+                adjustment
+                can be positive
+                or negative
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.brightnesseadjto24bitregion"><code>brightnesseadjto24bitregion</code></a></h3>
+<p><code>py
+def brightnesseadjto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, percentadj: float):</code></p>
+<p>Brightness adjustment to a rectangular area</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines
+                    the rectangle
+    percentadj    : float percentage
+                    brightness adjust
+                    can be positive
+                    or negative
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.bspline"><code>bspline</code></a></h3>
+<p><code>py
+def bspline(bmp: array.array, pntlist: list, penradius: int, color: int, isclosed: bool, curveback: bool):</code></p>
+<p>Draws a Bspline</p>
+<pre><code>Args:
+    bmp      : unsigned byte array
+               with bmp format
+    pntlist  : [(x, y)...]
+               the control points
+    penradius: radius of pen
+    color    : color of curve
+    isclosed : True means the
+               curve is closed
+    curveback: True means
+               extra computation
+               for curve to loop
+               back on itself
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.bsplinevert"><code>bsplinevert</code></a></h3>
+<p><code>py
+def bsplinevert(pntlist: list[list[int, int]], isclosed: bool, curveback: bool) -&gt; list[list[int, int]]:</code></p>
+<p>Creates a list of vertices for a bspline curve</p>
+<pre><code>Args:
+    pntlist: 2D control points
+             for the bspline curve
+             as list[list[x: int,
+                          y: int]]
+
+Returns:
+    list of vertices as
+    list[list[x: int, y: int]]
+</code></pre>
+<h3><a href="#Python_BMP.inttools.buf2int"><code>buf2int</code></a></h3>
+<p><code>py
+def buf2int(buf: array.array) -&gt; int:</code></p>
+<p>Converts an unsigned byte array
+    to an integer value</p>
+<pre><code>Args:
+    buf: unsigned byte array
+
+Returns:
+    unsigned int value
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.centercoord"><code>centercoord</code></a></h3>
+<p><code>py
+def centercoord(bmp: array.array) -&gt; tuple:</code></p>
+<p>Gets the central coordinates of a BMP</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    tuple (x:int,y:int)
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.centerpoint"><code>centerpoint</code></a></h3>
+<p><code>py
+def centerpoint(x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Returns the centerpoint x, y in rectangular area</p>
+<pre><code>Args:
+    x1, y1 : defines the
+    x2, y2   rectangular area
+
+Returns:
+    x: int, y: int centerpoint
+</code></pre>
+<h3><a href="#Python_BMP.chartools.char2int"><code>char2int</code></a></h3>
+<p><code>py
+def char2int(charcodestr: str) -&gt; int:</code></p>
+<p>Packs a string into an int
+    using ascii code</p>
+<pre><code>Args:
+    charcodestr: string
+
+Yields:
+    int value
+</code></pre>
+<h3><a href="#Python_BMP.fileutils.checklink"><code>checklink</code></a></h3>
+<p><code>py
+def checklink(func: Callable):</code></p>
+<p>Decorator to test if the first
+    parameter in a function is
+    a valid file</p>
+<pre><code>Args:
+    function
+
+Returns:
+    caller function
+</code></pre>
+<h3><a href="#Python_BMP.fileutils.checklinks"><code>checklinks</code></a></h3>
+<p><code>py
+def checklinks(func: Callable):</code></p>
+<p>Decorator to test if the two
+    parameters in a function
+    are valid files</p>
+<pre><code>Args:
+    function
+
+Returns:
+    caller function
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.circle2file"><code>circle2file</code></a></h3>
+<p><code>py
+def circle2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, color: int):</code></p>
+<p>Draws a Circle</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x, y, r        : center (x, y)
+                     and radius r
+    color          : color of circle
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.circle"><code>circle</code></a></h3>
+<p><code>py
+def circle(bmp: array.array, x: int, y: int, r: int, color: int, isfilled: bool = None):</code></p>
+<p>Draws a Circle</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    x, y, r : center (x,y)
+              and radius r
+              of the circle
+    color   : color of the circle
+    isfilled: toggles if the
+              circle is filled
+              True -&gt; filled circle
+              False -&gt; circle outline
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.circleinvolutevert"><code>circleinvolutevert</code></a></h3>
+<p><code>py
+def circleinvolutevert(x: int, y: int, a: float, delta: float, lim: float):</code></p>
+<p>Returns (int, int) 2D vertices
+along a path defined by the involute
+of a circle with scaling factor a
+and an origin set at (x, y)</p>
+<pre><code>The involute of a circle is the path
+traced out by a point on a straight
+line that rolls around a circle.
+
+It was studied by Huygens when he was
+considering clocks without pendulums
+that might be used on ships at sea.
+
+Args:
+    x, y : center of the curve
+    a    : scaling factor
+    delta: angle increment in radians
+    lim  : angle limit in radians
+
+Yields:
+    The vertices of the
+    involute of a circle in a list
+    [[x: int, y: int], ...]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.circlevec"><code>circlevec</code></a></h3>
+<p><code>py
+def circlevec(bmp: array.array, v: list, r: int, color: int, isfilled: bool = None):</code></p>
+<p>Draws a circle</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    v       : (x, y) center of
+              the circular region
+    r       : radius of the
+              circular region
+    color   : color of the circle
+    isfilled: toggles if the
+              circle is filled
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.colorfilter2file"><code>colorfilter2file</code></a></h3>
+<p><code>py
+def colorfilter2file(ExistingBMPfile: str, NewBMPfile: str, rgbfactors: list[float, float, float]):</code></p>
+<p>Applies Color Filter rgbfactors to a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    rgbfactors     : (r,g,b) r, g, b
+                     values range
+                     from 0.0 to 1.0
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.colors.colorfilter"><code>colorfilter</code></a></h3>
+<p><code>py
+def colorfilter(rgb: list[int, int, int], rgbfactors: list[float, float, float]) -&gt; list[int, int, int]:</code></p>
+<p>Apply a color filter
+    rgbfactors to rgb</p>
+<pre><code>Args:
+    rgb: color as [r: byte,
+                   g: byte,
+                   b: byte]
+
+    rgbfactors: color filter as
+                  [r: float,
+                   g: float,
+                   b: float]
+
+Returns:
+    a color filtered
+    color as [r: byte,
+              g: byte,
+              b: byte]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.colorfiltercircregion2file"><code>colorfiltercircregion2file</code></a></h3>
+<p><code>py
+def colorfiltercircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, rgbfactors: list[float, float, float]):</code></p>
+<p>Applies a color filter to a circular area in a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+    rgbfactors     : (r, g, b) values
+                     range from 0 to 1
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.colorfiltercircregion"><code>colorfiltercircregion</code></a></h3>
+<p><code>py
+def colorfiltercircregion(bmp: array.array, x: int, y: int, r: int, rgbfactors: list[float, float, float]):</code></p>
+<p>Color Filter to a circular area</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y, r   : center (x, y)
+                and radius r
+                of the region
+    rgbfactors: [r, g, b] range of
+                r, g and b are from
+                0.0 min to 1.0 max
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.colorfilterinregion2file"><code>colorfilterinregion2file</code></a></h3>
+<p><code>py
+def colorfilterinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, rgbfactors: list[float, float, float]):</code></p>
+<p>Color Filter to a Rectangular Area in a 24-bit BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+    rgbfactors     : (r,g,b)
+                     values range
+                     from
+                     0.0 to 1.0
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.colorfilterto24bitimage"><code>colorfilterto24bitimage</code></a></h3>
+<p><code>py
+def colorfilterto24bitimage(bmp: array.array, rgbfactors: list[float, float, float]):</code></p>
+<p>Applies a color filter
+    to a whole image in
+    an in-memory 24 bit bitmap</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    rgbfactors: color filter
+                r,g and b values
+                are from 0.0 to 1.0
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.colorfilterto24bitregion"><code>colorfilterto24bitregion</code></a></h3>
+<p><code>py
+def colorfilterto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, rgbfactors: list[float, float, float]):</code></p>
+<p>Applies a color filter to
+    a rectangular area defined
+    by (x1, y1) and (x2, y2)
+    in a 24-bit bitmap</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangular
+                    region
+    rgbfactors    : color filter
+                    r, g and b
+                    range from
+                    0.0 to 1.0
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.colors.colorfiltertoBGRbuf"><code>colorfiltertoBGRbuf</code></a></h3>
+<p><code>py
+def colorfiltertoBGRbuf(buf: array.array, rgbfactors: list[float, float, float]) -&gt; array.array:</code></p>
+<p>Apply a color filter to a
+    BGR buffer</p>
+<pre><code>Args:
+    buf: unsigned byte array
+         holding BGR data
+
+    rgbfactors: color filter as
+                  [r: float,
+                   g: float,
+                   b: float]
+
+Returns:
+    unsigned byte array
+    holding color BGR data
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.colorhistorgram"><code>colorhistorgram</code></a></h3>
+<p><code>py
+def colorhistorgram(bmp: array.array) -&gt; list:</code></p>
+<p>Creates a color histogram</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    list sorted in descending order of color frequencies
+</code></pre>
+<h3><a href="#Python_BMP.colors.colormix"><code>colormix</code></a></h3>
+<p><code>py
+def colormix(lum: int, RGBfactors: list[float, float, float]) -&gt; int:</code></p>
+<p>Mix a byte luminosity value to
+    an rgb triplet that express
+    a color value in [r, g, b]
+    ratios from 0.0 to 1.0 to
+    obtain an int value for a
+    specific color</p>
+<pre><code>Args:
+    lum       : a byte value for
+                luminosity
+    RGBfactors: list[r: float,
+                     g: float,
+                     b: float]
+                float values from
+                0.0 to 1.0
+
+Returns:
+    int color val
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.conevertandsurface"><code>conevertandsurface</code></a></h3>
+<p><code>py
+def conevertandsurface(vcen: list[float, float, float], r: float, zlen: float, deganglestep: float) -&gt; tuple:</code></p>
+<p>Returns a list of sparse
+    vertices and tiled surfaces
+    for a cone</p>
+<pre><code>Args:
+    vcen       : [x: float, center
+                  y: float, of the
+                  z: float] sphere
+    r           : radius of
+                  conical base
+    zlen        : height of
+                  the cone
+    deganglestep: angle step between
+    vertices that controls how sparse
+    the list will be
+
+Returns:
+    list of vertices and surfaces
+    for plot3Dsolid()
+    see Hello_Cone.py
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.convertbufto24bit"><code>convertbufto24bit</code></a></h3>
+<p><code>py
+def convertbufto24bit(buf: array.array, bgrpalbuf: array.array, bits: int) -&gt; array.array:</code></p>
+<p>Converts 1, 4 and 8-bit buffers to a BGR buffer</p>
+<pre><code>Args:
+    buf      : unsigned byte array
+    bgrpalbuf: BGR palette info
+    bits     : color depth
+               (1, 4, 8)
+
+Returns:
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.convertselection2BMP"><code>convertselection2BMP</code></a></h3>
+<p><code>py
+def convertselection2BMP(buf: array.array):</code></p>
+<p>Converts custom unsigned byte array to bmp format</p>
+<pre><code>Args:
+    buf: unsigned byte array
+
+Returns:
+    unsigned byte array with bmp format
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.copyBMPhdr"><code>copyBMPhdr</code></a></h3>
+<p><code>py
+def copyBMPhdr(bmp: array.array) -&gt; array.array:</code></p>
+<p>Copies the bitmap header of an in-memory bmp
+to a new unsigned byte array</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    unsigned byte array with bmp format
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.CopyBMPxydim2newBMP"><code>CopyBMPxydim2newBMP</code></a></h3>
+<p><code>py
+def CopyBMPxydim2newBMP(bmp: array.array, newbits: int) -&gt; array.array:</code></p>
+<p>Creates a new bitmap with the same dimensions as bmp</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    newbits: bit depth
+             (1, 4, 8, 24)
+
+Returns:
+    unsigned byte array with bitmap layout
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.copycircregion2buf"><code>copycircregion2buf</code></a></h3>
+<p><code>py
+def copycircregion2buf(bmp: array.array, x: int, y: int, r: int) -&gt; list:</code></p>
+<p>Copies a circular region to a
+buffer which is defined by
+centerpoint at (x, y) and radius r</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    x, y, r : center (x, y)
+              and radius r
+              of the circular area
+
+Returns:
+    list with buffer of circular region
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.copycircregion2file"><code>copycircregion2file</code></a></h3>
+<p><code>py
+def copycircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, newxycenterpoint: list):</code></p>
+<p>Copy/Paste of a circular area in a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile : Whole path
+                      to existing file
+    NewBMPfile      : New file to
+                      save changes to
+    x, y, r         : center (x,y)
+                      and radius r
+    newxycenterpoint: (x:int,y:int)
+                      where to paste
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.copycircregion"><code>copycircregion</code></a></h3>
+<p><code>py
+def copycircregion(bmp: array.array, x: int, y: int, r: int, newxy: list):</code></p>
+<p>Copy a circular buffer with center at (x, y)
+and a radius r to a new area with centerpoint at
+newxy [x, y]</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of the
+             circular region
+    newxy :  center of
+             circular area
+             to paste
+             the buffer into
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.copyrect"><code>copyrect</code></a></h3>
+<p><code>py
+def copyrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int) -&gt; array.array:</code></p>
+<p>Copy a rectangular region to a custom buffer</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    custom unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.copyRGBpal"><code>copyRGBpal</code></a></h3>
+<p><code>py
+def copyRGBpal(sourceBMP: array.array, destBMP: array.array):</code></p>
+<p>Copies the RGB palette info from
+a source unsigned byte array to
+a destination unsigned byte array</p>
+<pre><code>Args:
+    sourceBMP and destBMP are both
+    unsigned byte arrays with bmp format
+
+Returns:
+    byref modified destBMP
+    (unsigned byte array)
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.cosaffin"><code>cosaffin</code></a></h3>
+<p><code>py
+def cosaffin(u: list[numbers.Number], v: list[numbers.Number]) -&gt; float:</code></p>
+<p>Compute Cosine Similarity or Cosine Affinity</p>
+<pre><code>Args:
+    u, v : list of ints or floats
+
+Returns:
+    float value
+        proportional vectors = 1
+        orthogonal vectors = 0
+        opposite vectors = -1
+        and values in between
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.crop"><code>crop</code></a></h3>
+<p><code>py
+def crop(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Crops the image to a rectangular
+    region defined by (x1, y1)
+                  and (x2, y2)</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: the rectangular
+                    region
+
+Returns:
+    unsigned byte array
+    with bitmap layout
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.cropBMPandsave"><code>cropBMPandsave</code></a></h3>
+<p><code>py
+def cropBMPandsave(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Crops and saves a rectangular area to a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path
+                     to an
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x1, y1, x2, y2 : the rectagular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.cropBMPandsaveusingrectbnd"><code>cropBMPandsaveusingrectbnd</code></a></h3>
+<p><code>py
+def cropBMPandsaveusingrectbnd(ExistingBMPfile: str, NewBMPfile: str, rectbnd: list):</code></p>
+<p>Crops and saves a rectangular area to a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path
+                     to existing file
+    NewBMPfile     : New file to
+                     save changes in
+    rectbnd        : list defining
+                     a rectangular
+                     region
+                     [(x1, y1),
+                      (x2, y2),
+                      (x3, y3),
+                      (x4, y4)]
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.cubevert"><code>cubevert</code></a></h3>
+<p><code>py
+def cubevert(x: float) -&gt; list[list[float, float, float]]:</code></p>
+<p>Returns a list of vertices
+    for a cube</p>
+<pre><code>Args:
+    x: length of a side
+
+Returns:
+    list (x: float,
+          y: float,
+          z: float)
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.cylindervertandsurface"><code>cylindervertandsurface</code></a></h3>
+<p><code>py
+def cylindervertandsurface(vcen: list[float, float, float], r: float, zlen: float, deganglestep: float) -&gt; tuple:</code></p>
+<p>Returns a list of sparse vertices
+   and tiled surfaces for a cylinder</p>
+<pre><code>Args:
+    vcen       : [x: float, center
+                  y: float, of the
+                  z: float] sphere
+    r           : radius
+    zlen        : height of the
+                  cylinder
+    deganglestep: angle step between
+    vertices that controls how sparse
+    the list will be
+
+Returns:
+    list of vertices and surfaces
+    for plot3Dsolid()
+    see Hello_Coin.py
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.decahedvertandsurface"><code>decahedvertandsurface</code></a></h3>
+<p><code>py
+def decahedvertandsurface(x: float) -&gt; list[list[float, float, float]]:</code></p>
+<p>Returns a list of vertices
+    for a decahedron</p>
+<pre><code>Args:
+    x: min radius of sphere
+       that can hold
+       the decahedron
+
+Returns:
+    list (x: float,
+          y: float,
+          z: float)
+</code></pre>
+<h3><a href="#Python_BMP.dicttools.dict2descorderlist"><code>dict2descorderlist</code></a></h3>
+<p><code>py
+def dict2descorderlist(d: dict) -&gt; list:</code></p>
+<p>Creates a sorted list in
+    decending order from
+    a dictionary with counts</p>
+<pre><code>Args:
+    dict: histogram or
+          frequency count
+
+Returns:
+    list
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.distance"><code>distance</code></a></h3>
+<p><code>py
+def distance(u: list[float], v: list[float]) -&gt; float:</code></p>
+<p>Compute the Distance or length of a vector v
+of arbitrary dimension n in a n-dimensional
+Euclidean space where u and v are both vectors
+with n components</p>
+<pre><code>Args:
+    u, v: list of ints or floats
+
+Returns:
+    float
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.drawarc"><code>drawarc</code></a></h3>
+<p><code>py
+def drawarc(bmp: array.array, x: int, y: int, r: int, startdegangle: float, enddegangle: float, color: int, showoutline: bool, fillcolor: int, isfilled: bool):</code></p>
+<p>Draws an Arc</p>
+<pre><code>Args:
+    bmp        : unsigned
+                 byte array
+                 with bmp format
+    x, y, r    : defines a circle
+                 that contains
+                 the arc
+    color      : color of arc
+    showoutline: True -&gt; draw arc
+                         outline
+    fillcolor  : color of arc
+                 filling
+    isfilled   : True -&gt; set area
+                         inside the
+                         arc to
+                         fillcolor
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.drawvec"><code>drawvec</code></a></h3>
+<p><code>py
+def drawvec(bmp: array.array, u: list, v: list, headsize: int, color: int, penradius: int = None):</code></p>
+<p>Draws a vector (line segment with arrow head)</p>
+<pre><code>Args:
+    bmp      : unsigned byte array
+               with bmp format
+    u        : (x: float, y: float)
+                point 1 origin
+    v        : (x: float, y: float)
+               point 2 has arrow
+    headsize : size of the arrow
+               0 for default size
+    color    : color of the vector
+    penradius: optional parameter
+               for thick arrow
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.ellipse"><code>ellipse</code></a></h3>
+<p><code>py
+def ellipse(bmp: array.array, x: int, y: int, b: int, a: int, color: int, isfilled: bool = None):</code></p>
+<p>Draws an Ellipse</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    x, y    : center of ellipse
+    b, a    : major amd minor axis
+    color   : color of the ellipse
+    isfilled: True -&gt; filled
+                      ellipse
+              False-&gt; one pixel
+                      thick
+                      ellipse
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.ellipsevert"><code>ellipsevert</code></a></h3>
+<p><code>py
+def ellipsevert(x: int, y: int, b: int, a: int) -&gt; list[int, int]:</code></p>
+<p>Returns (int, int) 2D vertices
+along a path defined by major and
+minor axes b and a as it traces
+an ellipse with origin set at (x, y)</p>
+<pre><code>Args:
+    x, y: center of the ellipse
+    b, a: major and minor axes
+
+Returns:
+    The list vertices of an
+    ellipse
+    [[x: int, y: int], ...]
+</code></pre>
+<h3><a href="#Python_BMP.paramchecks.entirecircleinboundary"><code>entirecircleinboundary</code></a></h3>
+<p><code>py
+def entirecircleinboundary(func):</code></p>
+<p>Decorator to ensure that the 2nd,
+    3rd, 4th parameters are ints
+    whose values when interpreted
+    as the centerpoint x, y
+    and radius r of a circle
+    lay within the RGB bitmap.</p>
+<pre><code>Args:
+    function(bmp:array,x:int,y:int,r:int...)
+
+Returns:
+    caller function
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.entirecircleisinboundary"><code>entirecircleisinboundary</code></a></h3>
+<p><code>py
+def entirecircleisinboundary(x: int, y: int, minx: int, maxx: int, miny: int, maxy: int, r: int):</code></p>
+<p>Checks if an entire circle
+is within a rectagular area</p>
+<pre><code>Args:
+    x, y: center of the ellipse
+    xmin, ymin: min (x, y) bounds
+    xmax, ymax: max (x, y) bounds
+    r   : radius of the circle
+
+Returns:
+    boolean value
+    True  -&gt; All (x, y)
+             is in bounds
+    False -&gt; Not all (x, y)
+             is in bounds
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.entireellipseisinboundary"><code>entireellipseisinboundary</code></a></h3>
+<p><code>py
+def entireellipseisinboundary(x: int, y: int, minx: int, maxx: int, miny: int, maxy: int, b: int, a: int):</code></p>
+<p>Checks if an entire ellipse
+is within a rectagular area</p>
+<pre><code>Args:
+    x, y: center of the ellipse
+    xmin, ymin: min (x, y) bounds
+    xmax, ymax: max (x, y) bounds
+    b, a: major and minor axes
+
+Returns:
+    boolean value
+    True  -&gt; All (x, y)
+             is in bounds
+    False -&gt; Not all (x, y)
+             is in bounds
+</code></pre>
+<h3><a href="#Python_BMP.paramchecks.entirerectinboundary"><code>entirerectinboundary</code></a></h3>
+<p><code>py
+def entirerectinboundary(func):</code></p>
+<p>Decorator to ensure that the
+    2nd, 3rd, 4th and 5th
+    parameters are ints whose
+    values when interpreted as
+    x and y coordinates of a
+    rectangle lay within the
+    bitmap.</p>
+<pre><code>Args:
+    function
+
+Returns:
+    caller function
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.enumbits"><code>enumbits</code></a></h3>
+<p><code>py
+def enumbits(byteval: int):</code></p>
+<p>Yields the 8 bits in a byte</p>
+<pre><code>Args:
+    byteval: int value
+             from 0 to 255
+
+Yields:
+    Eight bits that is either
+    int 0 or int 1
+</code></pre>
+<h3><a href="#Python_BMP.chartools.enumletters"><code>enumletters</code></a></h3>
+<p><code>py
+def enumletters(st: str) -&gt; str:</code></p>
+<p>Enumerates the characters
+    in a string</p>
+<pre><code>Args:
+    st: string
+
+Yields:
+    individual characters
+</code></pre>
+<h3><a href="#Python_BMP.chartools.enumreverseletters"><code>enumreverseletters</code></a></h3>
+<p><code>py
+def enumreverseletters(st: str) -&gt; str:</code></p>
+<p>Enumerates the characters in a
+    string in reverse order</p>
+<pre><code>Args:
+    st: string
+
+Yields:
+    individual characters
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.epicycloidvert"><code>epicycloidvert</code></a></h3>
+<p><code>py
+def epicycloidvert(x: int, y: int, a: float, b: float, delta: float, lim: float):</code></p>
+<p>Returns (int, int) 2D vertices
+along a path defined by epicycloid
+traced by a circle of radius b which
+rolls round a circle of radius a
+with an origin set at (x, y)</p>
+<pre><code>Args:
+    x, y : center of epicycloid
+    a    : radius of fixed circle
+    b    : radius of rolling circle
+    delta: angle increment in radians
+    lim  : angle limit in radians
+
+Returns:
+    The vertices of an
+    epicycloid in a list
+    [[x: int, y: int], ...]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.erasealternatehorizontallines"><code>erasealternatehorizontallines</code></a></h3>
+<p><code>py
+def erasealternatehorizontallines(bmp: array.array, int_eraseeverynline: int, int_eraseNthline: int, bytepat: int):</code></p>
+<p>Erase every nth line</p>
+<pre><code>Args:
+    bmp                : unsigned
+                         byte array
+                         with
+                         bmp format
+    int_eraseeverynline: erase every
+                         nth line
+                         in the
+                         region
+    int_eraseNthline   : control
+                         which line
+                         every
+                         n lines
+                         to erase
+    bytepat            : byte pattern
+                         to overwrite
+                         the erased
+                         lines
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.erasealternatehorizontallinesincircregion"><code>erasealternatehorizontallinesincircregion</code></a></h3>
+<p><code>py
+def erasealternatehorizontallinesincircregion(bmp: array.array, x: int, y: int, r: int, int_eraseeverynline: int, int_eraseNthline: int, bytepat: int):</code></p>
+<p>Erase every nth line
+    in a circular region</p>
+<pre><code>Args:
+    bmp                : unsigned
+                         byte array
+                         with bmp
+                         format
+    x, y, r            : (x, y)
+                         centerpoint
+                         and radius r
+                         of the
+                         circular area
+    int_eraseeverynline: erase every
+                         nth line
+                         in the
+                         circular
+                         region
+    int_eraseNthline   : control which
+                         line every
+                         n lines
+                         to erase
+    bytepat            : pattern to
+                         overwrite
+                         the erased
+                         lines
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.erasealternatehorizontallinesinregion"><code>erasealternatehorizontallinesinregion</code></a></h3>
+<p><code>py
+def erasealternatehorizontallinesinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, int_eraseeverynline: int, int_eraseNthline: int, bytepat: int):</code></p>
+<p>Erase every nth line in a rectangular region</p>
+<pre><code>Args:
+    bmp                : unsigned
+                         byte array
+                         with bmp
+                         format
+    x1, y1, x2, y2     : ints that
+                         defines the
+                         rectangular
+                         region
+    int_eraseeverynline: erase every
+                         nth line
+                         in the region
+    int_eraseNthline   : control which
+                         line every
+                         n lines
+                         to erase
+    bytepat            : pattern to
+                         overwrite
+                         the erased
+                         lines
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.eraseeverynthhoriline2file"><code>eraseeverynthhoriline2file</code></a></h3>
+<p><code>py
+def eraseeverynthhoriline2file(ExistingBMPfile: str, NewBMPfile: str, n: int):</code></p>
+<p>Erase every nth line</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path
+                     to existing file
+    NewBMPfile     : New file to
+                     save changes in
+    n              : erase every
+                     nth line
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.eraseeverynthhorilineinccircregion2file"><code>eraseeverynthhorilineinccircregion2file</code></a></h3>
+<p><code>py
+def eraseeverynthhorilineinccircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, n: int):</code></p>
+<p>Erase every nth horzontal line in a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+                     in which we
+    n              : omit every
+                     nth line
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.eraseeverynthhorilineinregion2file"><code>eraseeverynthhorilineinregion2file</code></a></h3>
+<p><code>py
+def eraseeverynthhorilineinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, n: int):</code></p>
+<p>Erase every nth line in a rectangular region</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     an existing
+                     file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+    n              : erase every
+                     nth line
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.eraseeverynthhorilineinregion"><code>eraseeverynthhorilineinregion</code></a></h3>
+<p><code>py
+def eraseeverynthhorilineinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, n: int):</code></p>
+<p>Erase every nth line in a
+    rectangular region</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangular
+                    region
+    n             : erase every
+                    nth line in the
+                    rectangular area
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.eraseeverynthhorizontalline"><code>eraseeverynthhorizontalline</code></a></h3>
+<p><code>py
+def eraseeverynthhorizontalline(bmp: array.array, n: int):</code></p>
+<p>Erase every nth horizontal line</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    n  : erase every nth line
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.eraseeverynthhorizontallineinccircregion"><code>eraseeverynthhorizontallineinccircregion</code></a></h3>
+<p><code>py
+def eraseeverynthhorizontallineinccircregion(bmp: array.array, x: int, y: int, r: int, n: int):</code></p>
+<p>Erase every nth horizontal line in a circular region</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of the circular area
+    n      : erase every nth line
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.fern2file"><code>fern2file</code></a></h3>
+<p><code>py
+def fern2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, color: int):</code></p>
+<p>Fern Fractal in a bounding rectangle</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular region
+    color          : color of the
+                     fern fractal
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.fern"><code>fern</code></a></h3>
+<p><code>py
+def fern(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):</code></p>
+<p>Draws an IFS fern fractal</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: rectangular
+                    area to draw
+                    the fern in
+    color         : color of the
+                    fern fractal
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.fillbackgroundwithgrad"><code>fillbackgroundwithgrad</code></a></h3>
+<p><code>py
+def fillbackgroundwithgrad(bmp: array.array, lumrange: list[int, int], RGBfactors: list[float, float, float], direction: int):</code></p>
+<p>Fills entire bitmap with a linear gradient</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    lumrange  : [byte,byte] that
+                define the range
+                the of gradient
+    RGBfactors: [r,g,b] each item
+                in list are unsigned
+                floats from 0 to 1
+    direction : 0 - vertical
+                1 - horizontal
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.fillboundary"><code>fillboundary</code></a></h3>
+<p><code>py
+def fillboundary(bmp: array.array, bndfilldic: dict, color: int):</code></p>
+<p>Draws lines in a boundary to fill it</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    bndfilldic: boundary dictionary
+    color     : color of fill
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.filledcircle2file"><code>filledcircle2file</code></a></h3>
+<p><code>py
+def filledcircle2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, color: int):</code></p>
+<p>Draws a Filled Circle</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+    color          : color of the
+                     circular region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.filledcircle"><code>filledcircle</code></a></h3>
+<p><code>py
+def filledcircle(bmp: array.array, x: int, y: int, r: int, color: int):</code></p>
+<p>Draws a Filled Circle</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of filled circle
+    color  : color of the
+             filled circle
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.filledellipse"><code>filledellipse</code></a></h3>
+<p><code>py
+def filledellipse(bmp: array.array, x: int, y: int, b: int, a: int, color: int):</code></p>
+<p>Filled Ellipse</p>
+<pre><code>Args:
+    bmp  : unsigned byte array
+           with bmp format
+    x, y : center of ellipse
+    b, a : major amd minor axis
+    color: color of the ellipse
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.filledgradrect"><code>filledgradrect</code></a></h3>
+<p><code>py
+def filledgradrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int], RGBfactors: list[float, float, float], direction: int):</code></p>
+<p>Draw a filled rectangle with a linear gradient</p>
+<pre><code>Args:
+    bmp            : unsigned
+                     byte array
+                     with bmp format
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+    lumrange       : [byte, byte]
+                     defines
+                     the range
+                     of the
+                     gradient
+    RGBfactors     : [r, g, b] items
+                     in list are
+                     unsigned floats
+                     from 0.0 to 1.0
+    direction      : 0 - vertical
+                     1 - horizontal
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.filledparallelogram"><code>filledparallelogram</code></a></h3>
+<p><code>py
+def filledparallelogram(bmp: array.array, p1: list, p2: list, p3: list, color: int):</code></p>
+<p>Creates a filled parallelogram defined by 3 points</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    p1, p2, p3:(x: float, y: float)
+                points that define
+                a parallelogram
+    color     : color of the
+                filled parallelgram
+
+Returns:
+    byref unsigned modified byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.filledrect"><code>filledrect</code></a></h3>
+<p><code>py
+def filledrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):</code></p>
+<p>Draws a Filled Rectangle</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangular
+                    region
+    color         : color of the
+                    rectangle
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.fillpolydata"><code>fillpolydata</code></a></h3>
+<p><code>py
+def fillpolydata(polybnd: list[list[int, int]], xlim: int, ylim: int) -&gt; list:</code></p>
+<p>Generates a list of x values per
+    y values for filling polygon
+    boundaries</p>
+<pre><code>Args:
+    polybnd : list of 2D vertices
+              list[list[x: int,
+                        y: int]]
+              that forms a
+              complete polygon
+              boundary (see
+              def polyboundary)
+    xlim    : Screen limit x dim
+    ylim    : Screen limit x dim
+
+Returns:
+    A dictionary with y values
+    as key and list of x values
+    per key (if within bounds)
+    or an empty list if out of
+    bounds
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.fliphoricircregion2file"><code>fliphoricircregion2file</code></a></h3>
+<p><code>py
+def fliphoricircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Horizontal Flip of a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x, y, r        : center (x,y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.fliphoricircregion"><code>fliphoricircregion</code></a></h3>
+<p><code>py
+def fliphoricircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Flips horizontally a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of circular region
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.fliphorizontal2file"><code>fliphorizontal2file</code></a></h3>
+<p><code>py
+def fliphorizontal2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Flips horizontally the image in a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.fliphorizontal"><code>fliphorizontal</code></a></h3>
+<p><code>py
+def fliphorizontal(bmp: array.array):</code></p>
+<p>Does a horizontal flip of an
+    in-memory bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.fliphorizontalregion2file"><code>fliphorizontalregion2file</code></a></h3>
+<p><code>py
+def fliphorizontalregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Flips horizontally a rectangular area in a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : the rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.fliphorizontalregion"><code>fliphorizontalregion</code></a></h3>
+<p><code>py
+def fliphorizontalregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Does a horizontal flip
+    of a rectangular area</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangular
+                    region
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.fliphorzontalpixelbased"><code>fliphorzontalpixelbased</code></a></h3>
+<p><code>py
+def fliphorzontalpixelbased(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Flips horizontal
+    a rectangular region
+    using pixel addressing
+    (slightly slow)</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangular
+                    region
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.fliphverticalalpixelbased"><code>fliphverticalalpixelbased</code></a></h3>
+<p><code>py
+def fliphverticalalpixelbased(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Flips vertical
+    a rectangular region
+    using pixel addressing
+    (slightly slow)</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: the rectangular
+                    region
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.bufferflip.flipnibbleinbuf"><code>flipnibbleinbuf</code></a></h3>
+<p><code>py
+def flipnibbleinbuf(buf: array.array) -&gt; array.array:</code></p>
+<p>Flips a 4-bit image buffer</p>
+<pre><code>Args:
+    buf: unsigned byte array
+
+Returns:
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.flipvertcircregion2file"><code>flipvertcircregion2file</code></a></h3>
+<p><code>py
+def flipvertcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Vertical Flip of a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.flipvertcircregion"><code>flipvertcircregion</code></a></h3>
+<p><code>py
+def flipvertcircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Vertical Flip of a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of a region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.flipvertical2file"><code>flipvertical2file</code></a></h3>
+<p><code>py
+def flipvertical2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Flips a bitmap file vertically</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.flipvertical"><code>flipvertical</code></a></h3>
+<p><code>py
+def flipvertical(bmp: array.array):</code></p>
+<p>Does an vertical flip of a bmp</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+    with bmp format
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.flipverticalregion2file"><code>flipverticalregion2file</code></a></h3>
+<p><code>py
+def flipverticalregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Flips vertically a rectangular area in a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.flipverticalregion"><code>flipverticalregion</code></a></h3>
+<p><code>py
+def flipverticalregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Flips vertical a rectangular area</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangle
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.flipXY2file"><code>flipXY2file</code></a></h3>
+<p><code>py
+def flipXY2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Flips the x and y coordinates to rotate by 90 degrees</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.flipXY"><code>flipXY</code></a></h3>
+<p><code>py
+def flipXY(bmp: array.array):</code></p>
+<p>Flips the x and y coordinates of
+    an in-memory bitmap for a
+    90 degree rotation</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.flipXYcircregion2file"><code>flipXYcircregion2file</code></a></h3>
+<p><code>py
+def flipXYcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Flips the x and y coordinates of a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.flipXYcircregion"><code>flipXYcircregion</code></a></h3>
+<p><code>py
+def flipXYcircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Flip the X and Y coordinates of a circular area</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    x, y, r : center (x,y) and
+              radius r of region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.flowervert"><code>flowervert</code></a></h3>
+<p><code>py
+def flowervert(cx: int, cy: int, r: int, petals: int, angrot: float):</code></p>
+<p>Returns a list of 2D points for a flower</p>
+<pre><code>Args:
+    cx, cy, r : center (cx,cy)
+                and radius r
+    petals    : number of petals
+    angrot    : angle of rotation
+
+Returns:
+    list[(x: int, y: int)]
+</code></pre>
+<h3><a href="#Python_BMP.paramchecks.func24bitonly"><code>func24bitonly</code></a></h3>
+<p><code>py
+def func24bitonly(func):</code></p>
+<p>Decorator to restrict the
+    use of this function to only
+    24-bit or RGB bitmaps
+    (1st parameter)</p>
+<pre><code>Args:
+    function(bmp:array,...)
+
+Returns:
+    caller function
+</code></pre>
+<h3><a href="#Python_BMP.paramchecks.func24bitonlyandentirecircleinboundary"><code>func24bitonlyandentirecircleinboundary</code></a></h3>
+<p><code>py
+def func24bitonlyandentirecircleinboundary(func):</code></p>
+<p>Decorator to restrict the
+    use of this function to only
+    24-bit bitmaps (1st parameter)
+    and ensure that the 2nd, 3rd,
+    4th parameters are ints whose
+    values when interpreted as
+    x, y and radius of a circle
+    lay within the RGB bitmap.</p>
+<pre><code>Args:
+    function(bmp:array,x:int,y:int,r:int...)
+
+Returns:
+    caller function
+</code></pre>
+<h3><a href="#Python_BMP.paramchecks.func24bitonlyandentirerectinboundary"><code>func24bitonlyandentirerectinboundary</code></a></h3>
+<p><code>py
+def func24bitonlyandentirerectinboundary(func):</code></p>
+<p>Decorator to restrict the
+    use of this function to only
+    24-bit or RGB bitmaps
+    (1st parameter) and ensure that
+    the 2nd, 3rd, 4th and 5th
+    parameters are ints whose
+    values when interpreted as
+    x and y coordinates lay
+    within the RGB bitmap.</p>
+<pre><code>Args:
+    function
+
+Returns:
+    caller function
+</code></pre>
+<h3><a href="#Python_BMP.paramchecks.func8and24bitonlyandentirecircleinboundary"><code>func8and24bitonlyandentirecircleinboundary</code></a></h3>
+<p><code>py
+def func8and24bitonlyandentirecircleinboundary(func):</code></p>
+<p>Decorator to restrict the
+    use of this function to only
+    24-bit or 8-bit bitmaps
+    (1st parameter) and ensure
+    that the 2nd, 3rd, 4th
+    parameters are ints whose
+    values when interpreted as
+    x, y and radius of a circle
+    lay within the RGB bitmap.</p>
+<pre><code>Args:
+    function(bmp:array,x:int,y:int,r:int...)
+
+Returns:
+    caller function
+</code></pre>
+<h3><a href="#Python_BMP.paramchecks.func8and24bitonlyandentirerectinboundary"><code>func8and24bitonlyandentirerectinboundary</code></a></h3>
+<p><code>py
+def func8and24bitonlyandentirerectinboundary(func):</code></p>
+<p>Decorator to restrict the
+    use of this functiom to only
+    24 bit or 8 bit bitmaps
+    (1st parameter) and ensure
+    that the 2nd, 3rd, 4th and
+    5th parameters are ints whose
+    values when interpreted as
+    x and y coordinates of a
+    rectangle lay within
+    the RGB bitmap.</p>
+<pre><code>Args:
+    function
+
+Returns:
+    caller function
+</code></pre>
+<h3><a href="#Python_BMP.proctimer.functimer"><code>functimer</code></a></h3>
+<p><code>py
+def functimer(func):</code></p>
+<p>Function timer Decorator</p>
+<pre><code>Args:
+    function
+
+Returns:
+    caller function
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gammaadj2file"><code>gammaadj2file</code></a></h3>
+<p><code>py
+def gammaadj2file(ExistingBMPfile: str, NewBMPfile: str, gamma: float):</code></p>
+<p>Applies a Gamma Correction</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    gamma          : gamma
+                     correction
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gammaadjto24bitimage"><code>gammaadjto24bitimage</code></a></h3>
+<p><code>py
+def gammaadjto24bitimage(bmp: array.array, gamma: float):</code></p>
+<p>Gamma correction to an in-memory 24-bit BMP</p>
+<pre><code>Args:
+    bmp  : unsigned byte array
+           with bmp format
+    gamma: gamma correction
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gammaadjto24bitregion"><code>gammaadjto24bitregion</code></a></h3>
+<p><code>py
+def gammaadjto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, gamma: float):</code></p>
+<p>Gamma correction to a rectangular area in a 24-bit BMP</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangular
+                    region
+    gamma         : gamma correction
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gammaadjtoregion2file"><code>gammaadjtoregion2file</code></a></h3>
+<p><code>py
+def gammaadjtoregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, gamma: float):</code></p>
+<p>Gamma Correction to a Rectangular Region</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+    gamma          : gamma
+                     correction
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.colors.gammaBGRbuf"><code>gammaBGRbuf</code></a></h3>
+<p><code>py
+def gammaBGRbuf(buf: array.array, gamma: float) -&gt; array.array:</code></p>
+<p>Apply a gamma adjustment to a
+    BGR buffer</p>
+<pre><code>Args:
+    buf: unsigned byte array
+         holding BGR data
+
+    gamma: float gamma adjust
+
+Returns:
+    unsigned byte array
+    holding gamma adjusted
+    BGR data
+</code></pre>
+<h3><a href="#Python_BMP.colors.gammacorrect"><code>gammacorrect</code></a></h3>
+<p><code>py
+def gammacorrect(rgb: list[int, int, int], gamma: float) -&gt; list[int, int, int]:</code></p>
+<p>Apply a gamma factor to a rgb</p>
+<pre><code>Args:
+    rgb: color as [r: byte,
+                   g: byte,
+                   b: byte]
+    gamma  : gamma adjustment
+
+Returns:
+    a gamma adjusted color as
+    [r: byte, g: byte, b: byte]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gammacorrectcircregion2file"><code>gammacorrectcircregion2file</code></a></h3>
+<p><code>py
+def gammacorrectcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, gamma: float):</code></p>
+<p>Gamma Adjust to a circular area in a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path
+                     to existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+                     of a circular
+                     region
+    gamma          : gamma
+                     adjustment
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gammacorrectcircregion"><code>gammacorrectcircregion</code></a></h3>
+<p><code>py
+def gammacorrectcircregion(bmp: array.array, x: int, y: int, r: int, gamma: float):</code></p>
+<p>Gamma correction to a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of the region
+    gamma  : float value of the
+             gamma adjustment
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.charts.genpiechartdata"><code>genpiechartdata</code></a></h3>
+<p><code>py
+def genpiechartdata(dlist: list):</code></p>
+<p>Preprocess data to make
+    it suitable for a pie chart</p>
+<pre><code>Args:
+    dlist: [[20, c['red']],
+            [30, c['brightyellow']],
+            ...]
+
+Returns:
+    list and large value (if any)
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.gensides"><code>gensides</code></a></h3>
+<p><code>py
+def gensides(pointlists: list[list, list], transvect: list[float, float, float], sides: list[list[float]]) -&gt; tuple:</code></p>
+<p>Generates a list of polygons
+and normals from 3D polygon
+and side data to a list of
+sides and normals with
+with the hidden surfaces
+removed that is suitable
+for rendering on a 2D surface
+and also applies a
+3D translation vector for
+positioning</p>
+<h3><a href="#Python_BMP.BITMAPlib.getallRGBpal"><code>getallRGBpal</code></a></h3>
+<p><code>py
+def getallRGBpal(bmp: array.array) -&gt; list[list[int, int, int]]:</code></p>
+<p>Gets the RGB palette of a bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    [(r: byte, g: byte, b: byte), ...]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.getBGRpalbuf"><code>getBGRpalbuf</code></a></h3>
+<p><code>py
+def getBGRpalbuf(bmp: array.array):</code></p>
+<p>Gets bitmap palette as stored in the bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    unsigned byte array (BGR)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.getBMPimgbytes"><code>getBMPimgbytes</code></a></h3>
+<p><code>py
+def getBMPimgbytes(bmp: array.array) -&gt; list:</code></p>
+<p>Gets the raw image buffer of a bmp without the header</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    list of unsigned bytes
+</code></pre>
+<h3><a href="#Python_BMP.fonts.getcharfont"><code>getcharfont</code></a></h3>
+<p><code>py
+def getcharfont(charbuf: list, character: str) -&gt; list:</code></p>
+<h3><a href="#Python_BMP.colordict.getcolorname2HSLdict"><code>getcolorname2HSLdict</code></a></h3>
+<p><code>py
+def getcolorname2HSLdict() -&gt; dict:</code></p>
+<h3><a href="#Python_BMP.colordict.getcolorname2RGBdict"><code>getcolorname2RGBdict</code></a></h3>
+<p><code>py
+def getcolorname2RGBdict() -&gt; dict:</code></p>
+<h3><a href="#Python_BMP.charts.getdatalisttotal"><code>getdatalisttotal</code></a></h3>
+<p><code>py
+def getdatalisttotal(dlist: list[numbers.Number]) -&gt; numbers.Number:</code></p>
+<p>Returns the total of a
+    list of ints or floats</p>
+<pre><code>Args:
+    dlist: list of ints or floats
+
+Returns:
+    float or int
+</code></pre>
+<h3><a href="#Python_BMP.colors.getdefaultbitpal"><code>getdefaultbitpal</code></a></h3>
+<p><code>py
+def getdefaultbitpal(bits: int) -&gt; list:</code></p>
+<p>Gets the standard bitmap palette
+    for a  specified bit depth bits</p>
+<pre><code>Args:
+    bits: int value (1, 4, 8, 24)
+
+Returns:
+    list of palette entries
+</code></pre>
+<h3><a href="#Python_BMP.colors.getdefaultlumrange"><code>getdefaultlumrange</code></a></h3>
+<p><code>py
+def getdefaultlumrange() -&gt; dict:</code></p>
+<p>Gets the default luminosity
+    ranges lookup</p>
+<pre><code>Returns:
+    a dict for default
+    luminosity ranges
+</code></pre>
+<h3><a href="#Python_BMP.funcmeta.getfuncmetastr"><code>getfuncmetastr</code></a></h3>
+<p><code>py
+def getfuncmetastr(f: Callable):</code></p>
+<h3><a href="#Python_BMP.fractals.getIFSparams"><code>getIFSparams</code></a></h3>
+<p><code>py
+def getIFSparams() -&gt; dict:</code></p>
+<h3><a href="#Python_BMP.BITMAPlib.getimagedgevert"><code>getimagedgevert</code></a></h3>
+<p><code>py
+def getimagedgevert(bmp: array.array, similaritythreshold: int):</code></p>
+<p>Find edges in an image</p>
+<pre><code>Args:
+    bmp                : unsigned
+                         byte array
+                         with bmp
+                         format
+    similaritythreshold: how close
+                         to the color
+                         before we
+                         yield it
+
+Yields:
+    [(x: int, y: int),...]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.getimageregionbyRGB"><code>getimageregionbyRGB</code></a></h3>
+<p><code>py
+def getimageregionbyRGB(bmp: array.array, rgb: list[int, int, int], similaritythreshold: int):</code></p>
+<p>Select a region by color</p>
+<pre><code>Args:
+    bmp                 :unsigned
+                         byte array
+                         with bmp
+                         format
+    rgb                 :(r: byte,
+                          g: byte,
+                          b: byte)
+    similaritythreshold: controls
+                         the edge
+                         detection
+                         sensitivity
+
+Returns:
+    list of vertices
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.getmaxcolors"><code>getmaxcolors</code></a></h3>
+<p><code>py
+def getmaxcolors(bmp: array.array) -&gt; int:</code></p>
+<p>Get the maximum number of colors supported by a BMP</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    int value
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.getmaxx"><code>getmaxx</code></a></h3>
+<p><code>py
+def getmaxx(bmp: array.array) -&gt; int:</code></p>
+<p>Gets the x value stored in the windows bmp header</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    int value of x bmp dimension
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.getmaxxy"><code>getmaxxy</code></a></h3>
+<p><code>py
+def getmaxxy(bmp: array.array) -&gt; tuple:</code></p>
+<p>Gets the max x and y values stored in the bmp header</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    tuple (x:int,y:int)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.getmaxxyandbits"><code>getmaxxyandbits</code></a></h3>
+<p><code>py
+def getmaxxyandbits(bmp: array.array) -&gt; tuple:</code></p>
+<p>Returns bitmap metadata
+   (x-dimension, y-dimension, bit depth)</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    (x-dimension, y-dimension, bit depth)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.getmaxy"><code>getmaxy</code></a></h3>
+<p><code>py
+def getmaxy(bmp: array.array) -&gt; int:</code></p>
+<p>Gets the y value stored in the windows bmp header</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    int value of y bmp dimension
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.getneighborcolorlist"><code>getneighborcolorlist</code></a></h3>
+<p><code>py
+def getneighborcolorlist(bmp: array.array, v: list):</code></p>
+<h3><a href="#Python_BMP.colordict.getRGBfactors"><code>getRGBfactors</code></a></h3>
+<p><code>py
+def getRGBfactors() -&gt; dict:</code></p>
+<h3><a href="#Python_BMP.BITMAPlib.getRGBpal"><code>getRGBpal</code></a></h3>
+<p><code>py
+def getRGBpal(bmp: array.array, c: int) -&gt; list[int, int, int]:</code></p>
+<p>Gets the [R, G, B] values
+    of color c in a bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    c  : unsigned int color
+
+Returns:
+    [R: byte, G: byte, B:byte]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.getRGBxybit"><code>getRGBxybit</code></a></h3>
+<p><code>py
+def getRGBxybit(bmp: array.array, x: int, y: int) -&gt; list[int, int, int]:</code></p>
+<p>Gets [R:byte, G:byte, B:byte]
+of pixel at (x, y) in a bitmap</p>
+<pre><code>Args:
+    bmp : unsigned byte array
+          with bmp format
+    x, y: unsigned int
+          locations in x and y
+
+Returns:
+    [R: byte, G: byte, B: byte]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.getRGBxybitvec"><code>getRGBxybitvec</code></a></h3>
+<p><code>py
+def getRGBxybitvec(bmp: array.array, v: list) -&gt; list:</code></p>
+<p>Gets the RGB of a pixel at (x,y) in a BMP</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    v  : pixel location
+         (x:int, y:int)
+
+Returns:
+    [R: byte, G: byte, B: byte]
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.getshapesidedict"><code>getshapesidedict</code></a></h3>
+<p><code>py
+def getshapesidedict() -&gt; dict:</code></p>
+<p>Returns a dictionary of side
+    or polygon definitions for
+    simple solids</p>
+<pre><code>Returns:
+    dictionary of side or polygon
+    definitions for basic solids
+</code></pre>
+<h3><a href="#Python_BMP.X11colordict.getX11colorname2HSLdict"><code>getX11colorname2HSLdict</code></a></h3>
+<p><code>py
+def getX11colorname2HSLdict() -&gt; dict:</code></p>
+<h3><a href="#Python_BMP.X11colordict.getX11colorname2RGBdict"><code>getX11colorname2RGBdict</code></a></h3>
+<p><code>py
+def getX11colorname2RGBdict() -&gt; dict:</code></p>
+<h3><a href="#Python_BMP.X11colordict.getX11RGBfactors"><code>getX11RGBfactors</code></a></h3>
+<p><code>py
+def getX11RGBfactors() -&gt; dict:</code></p>
+<h3><a href="#Python_BMP.XKCDcolordict.getXKCDcolorname2HSLdict"><code>getXKCDcolorname2HSLdict</code></a></h3>
+<p><code>py
+def getXKCDcolorname2HSLdict() -&gt; dict:</code></p>
+<h3><a href="#Python_BMP.XKCDcolordict.getXKCDcolorname2RGBdict"><code>getXKCDcolorname2RGBdict</code></a></h3>
+<p><code>py
+def getXKCDcolorname2RGBdict() -&gt; dict:</code></p>
+<h3><a href="#Python_BMP.XKCDcolordict.getXKCDRGBfactors"><code>getXKCDRGBfactors</code></a></h3>
+<p><code>py
+def getXKCDRGBfactors() -&gt; dict:</code></p>
+<h3><a href="#Python_BMP.BITMAPlib.getxybit"><code>getxybit</code></a></h3>
+<p><code>py
+def getxybit(bmp: array.array, x: int, y: int) -&gt; int:</code></p>
+<p>Gets color of pixel at (x, y) in a BMP</p>
+<pre><code>Args:
+    bmp : unsigned byte array
+          with bmp format
+    x, y: unsigned int
+          locations in x and y
+
+Returns:
+    unsigned int color value
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.getxybitvec"><code>getxybitvec</code></a></h3>
+<p><code>py
+def getxybitvec(bmp: array.array, v: list) -&gt; int:</code></p>
+<p>Gets color of pixel at (x, y)</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    v  : (x: int, y: int)
+         pixel coordinates
+
+Returns:
+    unsigned int color value
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gradcircle"><code>gradcircle</code></a></h3>
+<p><code>py
+def gradcircle(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):</code></p>
+<p>Filled Circle with Gradient</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y, r   : center (x, y)
+                and radius r
+    lumrange  : [byte,byte] range of
+                the gradient
+    rgbfactors: [r, g, b] range are
+                from 0.0 to 1.0
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gradellipse"><code>gradellipse</code></a></h3>
+<p><code>py
+def gradellipse(bmp: array.array, x: int, y: int, b: int, a: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):</code></p>
+<p>Ellipical gradient</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : center of ellipse
+    b, a      : major amd minor axis
+    lumrange  : [byte:byte] controls
+                the range of the
+                luminosity gradient
+    rgbfactors: [r, g, b] range
+                are from 0.0 to 1.0
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gradthickcircle"><code>gradthickcircle</code></a></h3>
+<p><code>py
+def gradthickcircle(bmp: array.array, x: int, y: int, r: int, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):</code></p>
+<p>Thick Circle with a Gradient</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y, r   : center (x, y)
+                and radius r
+    penradius : radius of the
+                round pen
+    lumrange  : [byte,byte] range
+                of the luminosity
+                gradient
+    rgbfactors: [r,g,b] range are
+                from 0.0 to 1.0
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gradthickellipserot"><code>gradthickellipserot</code></a></h3>
+<p><code>py
+def gradthickellipserot(bmp: array.array, x: int, y: int, b: int, a: int, degrot: float, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):</code></p>
+<p>Thick Ellipse with a Gradient fill</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : center of ellipse
+    b, a      : major amd minor axis
+    degrot    : rotation of
+                the ellipse in degrees
+    penradius : defines the
+                thickness of the pen
+    lumrange  : [byte:byte] sets
+                the range of the
+                luminosity gradient
+    rgbfactors: [r, g, b] range are
+                from 0.0 min to 1.0 max
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gradthickplotpoly"><code>gradthickplotpoly</code></a></h3>
+<p><code>py
+def gradthickplotpoly(bmp: array.array, vertlist: list, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):</code></p>
+<p>Draws a polygon of a given gradient and thickness</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    vertlist  : [(x,y)...] the
+                list of vertices
+    penradius : radius of pen
+    lumrange  : [byte,byte] range
+                of the gradient
+    RGBfactors: [r, g, b] value
+                range from
+                0.0 to 1.0
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gradthickroundline"><code>gradthickroundline</code></a></h3>
+<p><code>py
+def gradthickroundline(bmp: array.array, p1: list, p2: list, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):</code></p>
+<p>Draw a Thick Rounded Line with a Gradient</p>
+<pre><code>Args:
+    bmp      : unsigned byte array
+               with bmp format
+    p1, p2   : (x, y) endpoints
+                of the line
+    penradius: radius of pen
+    lumrange : list of two
+               byte values
+               [gradstart,gradend]
+               that define the
+               luminosity gradient
+    RGBfactors: [r, g, b]
+                each item
+                in list is an
+                unsigned float
+                with a range
+                from 0.0 to 1.0
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.gradvert"><code>gradvert</code></a></h3>
+<p><code>py
+def gradvert(bmp: array.array, vertlist: list[list[int, int]], penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):</code></p>
+<p>List of 2d vertices as spheres of a given color</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    vertlist  : [(x, y), ...]
+                list of vertices
+    penradius : radius of
+                the spheres
+    lumrange  : [byte, byte] sets
+                the luminosity
+                gradient
+    RGBfactors: (r, g, b)
+                values range from
+                min 0.0 to 1.0 max
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.hexahedravert"><code>hexahedravert</code></a></h3>
+<p><code>py
+def hexahedravert(x: float) -&gt; list[list[float, float, float]]:</code></p>
+<p>Returns a list of vertices
+    for a hexahedron</p>
+<pre><code>Args:
+    x: length of a side
+
+Returns:
+    list (x: float,
+          y: float,
+          z: float)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.horibrightnessgrad2circregion2file"><code>horibrightnessgrad2circregion2file</code></a></h3>
+<p><code>py
+def horibrightnessgrad2circregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, lumrange: list[int, int]):</code></p>
+<p>Horizontal brightness gradient to a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+                     of a circular
+                     region in which
+                     we apply a
+    lumrange       : brightness gradient
+                     (byte, byte) adjust
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.horibrightnessgrad2circregion"><code>horibrightnessgrad2circregion</code></a></h3>
+<p><code>py
+def horibrightnessgrad2circregion(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int]):</code></p>
+<p>Horizontal brightness gradient adjustment to a circular area</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    x, y, r : center (x, y)
+              and radius r
+              of a circular area
+    lumrange: [byte, byte] the
+              luminosity range
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.horiline"><code>horiline</code></a></h3>
+<p><code>py
+def horiline(bmp: array.array, y: int, x1: int, x2: int, color: int):</code></p>
+<p>Draw a Horizontal Line</p>
+<pre><code>Args:
+    bmp   : unsigned byte array
+            with bmp format
+    y     : constant y value
+            of the line
+    x1    : starts at x1
+    x2    : ends at x2
+    color : color of the line
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.horilinevert"><code>horilinevert</code></a></h3>
+<p><code>py
+def horilinevert(bmp: array.array, vlist: list[list[int, int]], linelen: int, xadj: int, color: int):</code></p>
+<p>Horizontal line marks at vertices in vlist</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    vlist  : [(x, y), ...]
+             the list of
+             2D vertices
+    linelen: length of the
+             vertical lines
+    xadj   : sets an adjustment
+             for x coordinates
+    color  : color of the line
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.horitransformincircregion"><code>horitransformincircregion</code></a></h3>
+<p><code>py
+def horitransformincircregion(bmp: array.array, x: int, y: int, r: int, trans: str):</code></p>
+<p>Horizontal transform to a circular area</p>
+<pre><code>Args:
+    bmp  :   unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r of region
+    trans:   single letter
+             transform code
+             'L' -&gt; mirror left
+             'R' -&gt; mirror right
+             'F' -&gt; flip
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.horizontalbrightnessgrad2file"><code>horizontalbrightnessgrad2file</code></a></h3>
+<p><code>py
+def horizontalbrightnessgrad2file(ExistingBMPfile: str, NewBMPfile: str, lumrange: list[int, int]):</code></p>
+<p>Horizontal brightness gradient to a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    lumrange       : (byte:byte)
+                     defines the
+                     brightness
+                     gradient
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.horizontalbrightnessgradregion2file"><code>horizontalbrightnessgradregion2file</code></a></h3>
+<p><code>py
+def horizontalbrightnessgradregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):</code></p>
+<p>Horizontal brightness gradient to a rectangular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2 ,y2 : defines the
+                     rectangular
+                     region
+    lumrange       : (byte:byte)
+                     brightness
+                     gradient
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.horizontalbrightnessgradto24bitimage"><code>horizontalbrightnessgradto24bitimage</code></a></h3>
+<p><code>py
+def horizontalbrightnessgradto24bitimage(bmp: array.array, lumrange: list[int, int]):</code></p>
+<p>Applies a horizontal brightness
+    gradient to a 24-bit bitmap</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    lumrange: [byte,byte]
+              the range of the
+              luminosity gradient
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.horizontalbrightnessgradto24bitregion"><code>horizontalbrightnessgradto24bitregion</code></a></h3>
+<p><code>py
+def horizontalbrightnessgradto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):</code></p>
+<p>Apply a horizontal brightness gradient
+to a rectangular area in a 24-bit bitmap</p>
+<pre><code>Args:
+    bmp            : unsigned
+                     byte array
+                     with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangular
+                    region
+    lumrange      : (byte: byte)
+                    defines
+                    the brightness
+                    gradient
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.horizontalbulkswap"><code>horizontalbulkswap</code></a></h3>
+<p><code>py
+def horizontalbulkswap(bmp: array.array, x1: int, y1: int, x2: int, y2: int, swapfunc: Callable):</code></p>
+<p>Applies function swapfunc
+    to a rectangular area</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: the rectangular
+                    region
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.horizontalvert"><code>horizontalvert</code></a></h3>
+<p><code>py
+def horizontalvert(y: int, x1: int, x2: int, dx: int) -&gt; list[list[int, int]]:</code></p>
+<p>Creates a list of int vertices along
+a horizontal line with int step dx</p>
+<pre><code>Args:
+    y : int constant y
+    x1: int start point
+    x2: int end point
+    dx: int x step increment
+
+Returns:
+    list of int vertices
+    [(x, y), ...]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.hypotrochoidvert"><code>hypotrochoidvert</code></a></h3>
+<p><code>py
+def hypotrochoidvert(x: int, y: int, a: float, b: float, c: float, delta: float, lim: float):</code></p>
+<p>Returns (int, int) 2D vertices
+along a path defined by a hypotrochoid
+traced by a point with distance c from
+the center of circle of radius b
+which rolls round a circle of radius a
+with an origin set at (x, y)</p>
+<pre><code>Args:
+    x, y : center of hypotrochoid
+    a    : radius of fixed circle
+    b    : radius of rolling circle
+    c    : distance of pen from the
+           center of circle with
+           radius b
+    delta: angle increment in radians
+    lim  : angle limit in radians
+
+Returns:
+    The vertices of an
+    hypotrochoid in a list
+    [[x: int, y: int], ...]
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.icosahedvertandsurface"><code>icosahedvertandsurface</code></a></h3>
+<p><code>py
+def icosahedvertandsurface(x: float) -&gt; list[list[list[float, float, float]], tuple]:</code></p>
+<p>Returns a list of vertices
+    and surfaces for an icosahedron</p>
+<pre><code>Args:
+    x: min radius of sphere
+       that can hold
+       the icosahedron
+
+Returns:
+    list (x: float,
+          y: float,
+          z: float)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.IFS"><code>IFS</code></a></h3>
+<p><code>py
+def IFS(bmp: array.array, IFStransparam: tuple, x1: int, y1: int, x2: int, y2: int, xscale: int, yscale: int, xoffset: int, yoffset: int, color: int, maxiter: int):</code></p>
+<p>Draw an Interated Function System Fractal</p>
+<pre><code>Args:
+    bmp            : unsigned
+                     byte array
+                     with bmp format
+    IFStransparam  : see fractals.py
+    x1, y1, x2, y2 : rectangular
+                     region
+                     to draw in
+    xscale,yscale  : scaling factors
+    xoffset,yoffset: used to move
+                     the fractal
+    color          : color of fractal
+    maxiter        : when to break
+                     color compute
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.conditionaltools.iif"><code>iif</code></a></h3>
+<p><code>py
+def iif(boolcond: bool, trueval: &lt;built-in function any&gt;, falseval: &lt;built-in function any&gt;) -&gt; &lt;built-in function any&gt;:</code></p>
+<p>Returns trueval if
+    boolcond is true
+    else return falseval</p>
+<pre><code>Args:
+    boolcond: an expression that
+              evaluates as either
+              True or False
+    trueval : value to return if
+              boolcond evaluates
+              to True
+    falseval: value to return if
+              boolcond evaluates
+              to False
+
+Returns:
+    a value depending on boolcond
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.imagecomp"><code>imagecomp</code></a></h3>
+<p><code>py
+def imagecomp(inputfile1: str, inputfile2: str, diff_file: str, func: Callable):</code></p>
+<p>Perform a bitwise comparison of two bitmap files
+with the same x and y dimensions and bit depth
+using a user defined bitwise comparator function</p>
+<pre><code>Args:
+    Inputfile1: path to bmp file
+    Inputfile2: path to bmp file
+    diff_file : New file to save
+                comparison in
+    func      : User provided
+                bitwise function
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.imagediff"><code>imagediff</code></a></h3>
+<p><code>py
+def imagediff(inputfile1: str, inputfile2: str, diff_file: str):</code></p>
+<p>Compares 2 files and saves diff to a bitmap file</p>
+<pre><code>Args:
+    inputfile1: Whole paths
+    inputfile2 to existing files
+
+    diff_file: New file
+               to store diff
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.imgregionbyRGB2file"><code>imgregionbyRGB2file</code></a></h3>
+<p><code>py
+def imgregionbyRGB2file(ExistingBMPfile: str, NewBMPfile: str, edgeradius: int, edgecolor: int, rgb: list[int, int, int], similaritythreshold: float, showedgeonly: bool):</code></p>
+<p>Gets an image region by rgb in a bitmap file</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    edgeradius     : radius of pen
+                     for the edge
+    edgecolor      : color of edge
+    rgb            : (r: byte,
+                      g: byte,
+                      b: byte)
+                     color to select
+    similaritythreshold: how close
+                         the color
+                         is to rgb
+                         before
+                         selection
+    showedgeonly: True-&gt; only edges
+             False-&gt; edge and image
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.colors.int2BGRarr"><code>int2BGRarr</code></a></h3>
+<p><code>py
+def int2BGRarr(i: int) -&gt; array.array:</code></p>
+<p>Returns a bgr array from
+    int i color input</p>
+<pre><code>Args:
+    i: color value
+
+Returns:
+    unsigned byte BGR array
+</code></pre>
+<h3><a href="#Python_BMP.inttools.int2buf"><code>int2buf</code></a></h3>
+<p><code>py
+def int2buf(cnt: int, value: int) -&gt; array.array:</code></p>
+<p>Converts an integer value to an
+    unsigned byte array</p>
+<pre><code>Args:
+    cnt   : uint length of int data
+    value : value of uint data
+
+Returns:
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.colors.int2RGB"><code>int2RGB</code></a></h3>
+<p><code>py
+def int2RGB(i: int):</code></p>
+<p>Break down int color i to its
+    byte valued r, g and b
+    components</p>
+<pre><code>Args:
+    i: int color value
+
+Returns:
+    r: byte, g: byte, b: byte
+</code></pre>
+<h3><a href="#Python_BMP.colors.int2RGBarr"><code>int2RGBarr</code></a></h3>
+<p><code>py
+def int2RGBarr(i: int) -&gt; array.array:</code></p>
+<p>Returns a rgb array from
+    int i color input</p>
+<pre><code>Args:
+    i: color value
+
+Returns:
+    unsigned byte RGB array
+</code></pre>
+<h3><a href="#Python_BMP.colors.int2RGBlist"><code>int2RGBlist</code></a></h3>
+<p><code>py
+def int2RGBlist(i: int) -&gt; list[int, int, int]:</code></p>
+<p>Break down int color i to its
+    byte valued r, g and b
+    components in a list</p>
+<pre><code>Args:
+    i: int color value
+
+Returns:
+    [r: byte, g: byte, b: byte]
+</code></pre>
+<h3><a href="#Python_BMP.paramchecks.intcircleparam24bitonly"><code>intcircleparam24bitonly</code></a></h3>
+<p><code>py
+def intcircleparam24bitonly(func):</code></p>
+<p>Decorator to test if 2nd, 3rd,
+    4th parameters in a function
+    that renders circle are ints
+    and restrict the use of this
+    function to only 24-bit or
+    RGB bitmaps (1st parameter)</p>
+<pre><code>Args:
+    function(bmp:array,x,y,r....)
+
+Returns:
+    caller function
+</code></pre>
+<h3><a href="#Python_BMP.paramchecks.intcircleparam"><code>intcircleparam</code></a></h3>
+<p><code>py
+def intcircleparam(func):</code></p>
+<p>Decorator to test if the
+    2nd, 3rd, 4th parameters
+    in a function that renders
+    circle are ints</p>
+<pre><code>Args:
+    function(bmp:array,x,y,r....)
+
+Returns:
+    caller function
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.intlinevec"><code>intlinevec</code></a></h3>
+<p><code>py
+def intlinevec(bmp: array.array, u: list, v: list, color: int):</code></p>
+<p>Draw a line in a bitmap</p>
+<pre><code>Args:
+    bmp   : unsigned byte array
+            with bmp format
+    u, v  : (x: int, y: int) points
+            that defines the line
+    color : color of the line
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.intplotvecxypoint"><code>intplotvecxypoint</code></a></h3>
+<p><code>py
+def intplotvecxypoint(bmp: array.array, v: list[int, int], c: int):</code></p>
+<p>Sets the color of a pixel at (x, y)</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    v  : (x:int, y:int)
+         pixel coordinates
+    c  : unsigned int
+         color value
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.intscalarmulvect"><code>intscalarmulvect</code></a></h3>
+<p><code>py
+def intscalarmulvect(vec: list[numbers.Number], scalarval: numbers.Number) -&gt; list[int]:</code></p>
+<p>Scales a vector by multiplying a scalar value (float)
+to all components of the vector or a list of numbers
+then rounds off values in the list to a whole number</p>
+<pre><code>Args:
+    v        : the vector or
+               a list of
+               ints or floats
+    scalarval: scalar value
+               (float or int)
+
+Returns:
+    list of ints
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.invertbits2file"><code>invertbits2file</code></a></h3>
+<p><code>py
+def invertbits2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Inverts the bits in a bmp file</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.colors.invertbitsinbuffer"><code>invertbitsinbuffer</code></a></h3>
+<p><code>py
+def invertbitsinbuffer(buf: array.array) -&gt; array.array:</code></p>
+<p>Flips all the bits in an
+    unsigned byte array</p>
+<pre><code>Args:
+    buf: unsigned byte array
+
+Returns:
+    bit flipped unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.invertbitsincircregion2file"><code>invertbitsincircregion2file</code></a></h3>
+<p><code>py
+def invertbitsincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Inverts bits in a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.invertbitsincircregion"><code>invertbitsincircregion</code></a></h3>
+<p><code>py
+def invertbitsincircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Inverts the bits in a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x,y)
+             and radius r
+             of the region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.invertimagebits"><code>invertimagebits</code></a></h3>
+<p><code>py
+def invertimagebits(bmp: array.array):</code></p>
+<p>Inverts the bits in a bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.invertregion2file"><code>invertregion2file</code></a></h3>
+<p><code>py
+def invertregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Inverts the bits in a rectangular area in a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : the rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.invertregion"><code>invertregion</code></a></h3>
+<p><code>py
+def invertregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Inverts the bits in a
+    rectangular region defined
+    by (x1,y1) and (x2,y2)</p>
+<pre><code>Args:
+    bmp          :  unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: the rectangle
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.isdefaultpal"><code>isdefaultpal</code></a></h3>
+<p><code>py
+def isdefaultpal(bmp: array.array) -&gt; bool:</code></p>
+<p>Checks if bitmap has a default RGB color palette</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    True if default
+    False if not default
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.isinBMPrectbnd"><code>isinBMPrectbnd</code></a></h3>
+<p><code>py
+def isinBMPrectbnd(bmp: array.array, x: int, y: int) -&gt; bool:</code></p>
+<p>Checks if (x,y) coordinates are within the BMP</p>
+<pre><code>Args:
+    bmp : unsigned byte array
+          with bmp format
+    x, y: unsigned int value
+          of location
+          in x-axis and y-axis
+
+Returns:
+    True if within bounds
+    False if out of bounds
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.isinrange"><code>isinrange</code></a></h3>
+<p><code>py
+def isinrange(value: numbers.Number, highlimit: numbers.Number, lowlimit: numbers.Number) -&gt; bool:</code></p>
+<p>Checks is value is within high and low limits</p>
+<pre><code>Args:
+    value    : numeric variable
+               to check
+    highlimit: upper limit of
+               the variable
+    lowlimit : lower limit of
+               the variable
+
+Returns:
+    True if within bounds
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.isinrectbnd"><code>isinrectbnd</code></a></h3>
+<p><code>py
+def isinrectbnd(x: int, y: int, xmin: int, ymin: int, xmax: int, ymax: int) -&gt; bool:</code></p>
+<p>Checks if the x and y values
+lie within the rectangular area
+defined by xmin, ymin and xmax, ymax</p>
+<pre><code>Args:
+    x, y: (x,y) coordinates to test
+    xmin, ymin: min (x, y) bounds
+    xmax, ymax: max (x, y) bounds
+
+Returns:
+    boolean value
+    True  -&gt; (x, y) is in bounds
+    False -&gt; (x, y) is out of bounds
+</code></pre>
+<h3><a href="#Python_BMP.colors.isvalidcolorbit"><code>isvalidcolorbit</code></a></h3>
+<p><code>py
+def isvalidcolorbit(bits: int) -&gt; bool:</code></p>
+<p>Checks if bits is in the valid
+    color bits list (1, 4, 8, 24)</p>
+<pre><code>Args:
+    bits: int value
+
+Returns:
+    True if bits in (1, 4, 8, 24)
+    False if other values not in
+          the list above
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.iterbeziercurve"><code>iterbeziercurve</code></a></h3>
+<p><code>py
+def iterbeziercurve(pntlist: list[list[int, int]]) -&gt; list[int, int]:</code></p>
+<p>Yields a list of vertices for a bezier curve
+based on 2D control points in pntlist</p>
+<pre><code>Args:
+    pntlist: 2D control points
+             for the bezier curve
+             as list[list[x: int,
+                          y: int]]
+
+Yields:
+    vertices as list[x: int, y: int]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.iterbspline"><code>iterbspline</code></a></h3>
+<p><code>py
+def iterbspline(pntlist: list[list[int, int]], isclosed: bool, curveback: bool) -&gt; list[int, int]:</code></p>
+<p>Yields a list of vertices for a bspline curve
+based on 2D control points in pntlist</p>
+<pre><code>Args:
+    pntlist: 2D control points
+             for the bspline curve
+             as list[list[x: int,
+                          y: int]]
+
+Yields:
+    vertices as list[x: int, y: int]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.itercircle"><code>itercircle</code></a></h3>
+<p><code>py
+def itercircle(x: int, y: int, r: int) -&gt; list[int, int]:</code></p>
+<p>Yields (int, int) 2D vertices along
+a path defined by radius r as it traces
+a circle with origin set at (x, y)</p>
+<pre><code>Args:
+    x, y: int centerpoint
+              coordinates
+    r   : int radius
+
+Yields:
+    [x: int, y: int]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.itercircleinvolute"><code>itercircleinvolute</code></a></h3>
+<p><code>py
+def itercircleinvolute(x: int, y: int, a: float, delta: float, lim: float):</code></p>
+<p>Yields (int, int) 2D vertices
+along a path defined by the involute
+of a circle with scaling factor a
+and an origin set at (x, y)</p>
+<pre><code>The involute of a circle is the path
+traced out by a point on a straight
+line that rolls around a circle.
+
+It was studied by Huygens when he was
+considering clocks without pendulums
+that might be used on ships at sea.
+
+Args:
+    x, y : center of the curve
+    a    : scaling factor
+    delta: angle increment in radians
+    lim  : angle limit in radians
+
+Yields:
+    The vertices of the
+    involute of a circle
+    [[x: int, y: int], ...]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.itercirclepart"><code>itercirclepart</code></a></h3>
+<p><code>py
+def itercirclepart(r: int) -&gt; list[int, int]:</code></p>
+<p>Yields (int, int) 2D vertices along
+a path defined by radius r as it traces
+one fourth of a circle with origin set
+at (0, 0)</p>
+<pre><code>Args:
+    r: int radius
+
+Yields:
+    [x: int, y: int]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.itercirclepartlineedge"><code>itercirclepartlineedge</code></a></h3>
+<p><code>py
+def itercirclepartlineedge(r: int) -&gt; list[int, int]:</code></p>
+<p>Yields (int, int) 2D vertices along
+a path defined by radius r as it traces
+one fourth of a circle with origin set
+at (0, 0) tuned for generating
+filled circles with horizontal lines
+ and other tasks involving circular areas</p>
+<pre><code>Args:
+    r: int radius
+
+Yields:
+    [x: int, y: int]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.itercirclepartvertlineedge"><code>itercirclepartvertlineedge</code></a></h3>
+<p><code>py
+def itercirclepartvertlineedge(r: int) -&gt; list[int, int]:</code></p>
+<p>Yields (int, int) 2D vertices along
+a path defined by radius r as it traces
+one fourth of a circle with origin set
+at (0, 0) tuned for generating
+filled circles with vertical lines
+and other tasks involving circular areas</p>
+<pre><code>Args:
+    r: int radius
+
+Yields:
+    [x: int, y: int]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.itercopyrect"><code>itercopyrect</code></a></h3>
+<p><code>py
+def itercopyrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int) -&gt; array.array:</code></p>
+<p>Scan a rectangular area and yield scan lines</p>
+<pre><code>Args:
+    bmp            : unsigned
+                     byte array
+                     with bmp format
+    x1, y1, x2, y2 : defines the
+                     rectangle
+
+Yields:
+    unsigned byte array
+    scanlines of the area
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.iterdrawvec"><code>iterdrawvec</code></a></h3>
+<p><code>py
+def iterdrawvec(u: list, v: list, headsize: int):</code></p>
+<p>Yields a vector (line segment with arrow head)</p>
+<pre><code>Args:
+    u       : (x: float, y: float)
+              point 1 origin
+    v       : (x: float, y: float)
+              point 2 has arrow
+    headsize: size of the arrow
+              0 for default size
+
+Yields:
+    ((x1: int, y1: int), (x2: int, y2: int))
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.iterellipse"><code>iterellipse</code></a></h3>
+<p><code>py
+def iterellipse(x: int, y: int, b: int, a: int):</code></p>
+<p>Yields (int, int) 2D vertices along
+a path defined by major and minor axes
+b and a as it traces an ellipse with
+origin set at (x, y)</p>
+<pre><code>Args:
+    b, a: major and minor axes
+
+Yields:
+    [x: int, y: int]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.iterellipsepart"><code>iterellipsepart</code></a></h3>
+<p><code>py
+def iterellipsepart(b: int, a: int):</code></p>
+<p>Yields (int, int) 2D vertices along
+a path defined by major and minor axes
+b and a as it traces one fourth of an
+ellipse with origin set at (0, 0)</p>
+<pre><code>Args:
+    b, a: major and minor axes
+
+Yields:
+    [x: int, y: int]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.iterellipserot"><code>iterellipserot</code></a></h3>
+<p><code>py
+def iterellipserot(x: int, y: int, b: int, a: int, degrot: float):</code></p>
+<p>Yields (int, int) 2D vertices along
+a path defined by major and minor axes
+b and a as it traces an ellipse with origin
+set at (x, y) rotated by degrot degrees</p>
+<pre><code>Args:
+    b, a: major and minor axes
+    degrot: rotation in degrees
+
+Yields:
+    [x: int, y: int]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.iterepicycloid"><code>iterepicycloid</code></a></h3>
+<p><code>py
+def iterepicycloid(x: int, y: int, a: float, b: float, delta: float, lim: float):</code></p>
+<p>Yields (int, int) 2D vertices
+along a path defined by epicycloid
+traced by a circleof radius b which
+rolls round a circle of radius a
+with an origin set at (x, y)</p>
+<pre><code>Args:
+    x, y : center of epicycloid
+    a    : radius of fixed circle
+    b    : radius of rolling circle
+    delta: angle increment in radians
+    lim  : angle limit in radians
+
+Yields:
+    The vertices of an
+    epicycloid
+    [[x: int, y: int], ...]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.iterflower"><code>iterflower</code></a></h3>
+<p><code>py
+def iterflower(cx: int, cy: int, r: int, petals: int, angrot: float):</code></p>
+<p>Yields 2D points for a flower</p>
+<pre><code>Args:
+    cx, cy, r : center (cx,cy)
+                and radius r
+    petals    : number of petals
+    angrot    : angle of rotation
+
+Yields:
+    (x: int, y: int)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.itergetcolorfromrectregion"><code>itergetcolorfromrectregion</code></a></h3>
+<p><code>py
+def itergetcolorfromrectregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Yields color info of
+    a rectangular area</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangle
+
+Yields:
+    ((x: int, y: int), color: int)
+    for all points in area
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.itergetneighbors"><code>itergetneighbors</code></a></h3>
+<p><code>py
+def itergetneighbors(v: list[int, int], mx: int, my: int, includecenter: bool) -&gt; list[int, int]:</code></p>
+<p>Yields the neighboring pixels of point v</p>
+<pre><code>Args:
+    v : (x: int, y: int) point
+    mx: maximum x
+    my: maximum y
+    includecenter: do we yield
+                   point v too
+
+Yields:
+    [x: int, y: int]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.iterhypotrochoid"><code>iterhypotrochoid</code></a></h3>
+<p><code>py
+def iterhypotrochoid(x: int, y: int, a: float, b: float, c: float, delta: float, lim: float):</code></p>
+<p>Yields (int, int) 2D vertices
+along a path defined by a hypotrochoid
+traced by a point from with distance c
+from the center of circle of radius b
+which rolls round a circle of radius a
+with an origin set at (x, y)</p>
+<pre><code>Args:
+    x, y : center of epicycloid
+    a    : radius of fixed circle
+    b    : radius of rolling circle
+    c    : distance of pen from the
+           center of circle with
+           radius b
+    delta: angle increment in radians
+    lim  : angle limit in radians
+
+Yields:
+    The vertices of an
+    epicycloid
+    [[x: int, y: int], ...]
+</code></pre>
+<h3><a href="#Python_BMP.fractals.iterIFS"><code>iterIFS</code></a></h3>
+<p><code>py
+def iterIFS(IFStransparam: tuple, x1: int, y1: int, x2: int, y2: int, xscale: int, yscale: int, xoffset: int, yoffset: int, maxiter: int):</code></p>
+<p>Yield 2D points for an Interated Function System Fractal</p>
+<pre><code>Args:
+    IFStransparam   : see line 19
+    x1, y1, x2, y2  : rectangular
+                      region
+                      to draw in
+    xscale, yscale  : scaling factors
+    xoffset, yoffset: used to move
+                      the fractal
+    maxiter         : when to break
+                      color compute
+
+Yields:
+    (x: int, y: int)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.iterimagecolor"><code>iterimagecolor</code></a></h3>
+<p><code>py
+def iterimagecolor(bmp: array.array, waitmsg: str, rowprocind: str, finishmsg: str):</code></p>
+<p>Yields color information for entire bitmap</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    waitmsg   : what to display
+                in the terminal
+                when process starts
+    rowprocind: string to print in
+                the terminal as a
+                row is processed as
+                a process indicator
+    finishmsg : what to display
+                in the terminal
+                when process ends
+
+Yields:
+    ((x: int, y: int), color: int)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.iterimagedgevert"><code>iterimagedgevert</code></a></h3>
+<p><code>py
+def iterimagedgevert(bmp: array.array, similaritythreshold: float):</code></p>
+<p>Find edges in an image</p>
+<pre><code>Args:
+    bmp                : unsigned
+                         byte array
+                         with
+                         bmp format
+    similaritythreshold: how close
+                         to the color
+                         before we
+                         yield it
+
+Yields:
+    (x: int, y: int)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.iterimageregionvertbyRGB"><code>iterimageregionvertbyRGB</code></a></h3>
+<p><code>py
+def iterimageregionvertbyRGB(bmp: array.array, rgb: list[int, int, int], similaritythreshold: int):</code></p>
+<p>RGB Color selection by color similarity</p>
+<pre><code>Args:
+    bmp                : unsigned
+                         byte array
+                         with bmp
+                         format
+    rgb                : (r: byte,
+                          g: byte,
+                          b: byte)
+    similaritythreshold: how close
+                         to the color
+                         before we
+                         yield it
+
+Yields:
+    ((x: int, y: int), (r: byte, g: byte, b: byte))
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.iterimageRGB"><code>iterimageRGB</code></a></h3>
+<p><code>py
+def iterimageRGB(bmp: array.array, waitmsg: str, rowprocind: str, finishmsg: str):</code></p>
+<p>Yields (r, g, b) information for the entire bitmap</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    waitmsg   : what to display
+                in terminal at
+                process start
+    rowprocind: char to display as
+                a row is processed
+    finishmsg : what to display
+                in terminal at
+                process end
+
+Yields:
+    ((x: int, y: int), (r: byte, g: byte, b: byte))
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.iterline"><code>iterline</code></a></h3>
+<p><code>py
+def iterline(p1: list[int, int], p2: list[int, int]) -&gt; list[int, int]:</code></p>
+<p>Yields (int, int) 2D vertices
+along a line segment defined
+by endpoints p1 and p2</p>
+<pre><code>Args:
+    p1, p2: line endpoints
+            both [x:int, y:int]
+
+Yields:
+    [x:int, y:int]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.iterlissajouscurve"><code>iterlissajouscurve</code></a></h3>
+<p><code>py
+def iterlissajouscurve(x: int, y: int, a: float, b: float, c: float, d: float, e: float, delta: float, lim: float):</code></p>
+<p>Yields (int, int) 2D vertices
+along a path defined by lissajous
+curve axis scaling factors a and b
+and frequency scaling factors
+parameters c and d and
+radian phase shift angle e
+with an origin set at (x, y)</p>
+<pre><code>Args:
+    x, y : center of the curve
+    a, b : axis scaling factors
+    c, d : frequency scaling factors
+    e    : phase shift in radians
+    delta: angle increment in radians
+    lim  : angle limit in radians
+
+Yields:
+    Vertices of a lissajous curve
+    [x: int, y: int]
+</code></pre>
+<h3><a href="#Python_BMP.fractals.itermandelbrot"><code>itermandelbrot</code></a></h3>
+<p><code>py
+def itermandelbrot(x1: int, y1: int, x2: int, y2: int, mandelparam: list[float, float, float, float], maxiter: int):</code></p>
+<p>Yields a Mandelbrot set</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: rectangular area
+                    to draw in
+    mandelparam   : see fractals.py
+    rgbfactors    : [r, b, g] values
+                    range from
+                    0.0 to 1.0
+    maxiter       : when to break
+                    color compute
+
+Yields:
+    (x:int, y: int, c: int)
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.iterparallelogram"><code>iterparallelogram</code></a></h3>
+<p><code>py
+def iterparallelogram(p1: list[int, int], p2: list[int, int], p3: list[int, int]) -&gt; list[int, int]:</code></p>
+<h3><a href="#Python_BMP.primitives2D.iterspirograph"><code>iterspirograph</code></a></h3>
+<p><code>py
+def iterspirograph(x: int, y: int, r: int, l: float, k: float, delta: float, lim: float):</code></p>
+<p>Yields (int, int) 2D vertices
+along a path defined by spirograph
+scaling factor r and dimensionless
+parameters l and k with an origin
+set at (x, y)</p>
+<pre><code>Args:
+    x, y : center of the spirograph
+    r    : spirograph scaling factor
+    l, k : spirograph shape parameters
+    delta: angle increment in radians
+    lim  : angle limit in radians
+
+Yields:
+    The vertices of an
+    spirograph
+    [[x: int, y: int], ...]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.line"><code>line</code></a></h3>
+<p><code>py
+def line(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):</code></p>
+<p>Draw a Line in a bitmap</p>
+<pre><code>Args:
+    bmp   : unsigned byte array
+            with bmp format
+    x1, y1: endpoint 1
+    x2, y2: endpoint 2
+    color : color of the line
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.linevec"><code>linevec</code></a></h3>
+<p><code>py
+def linevec(bmp: array.array, u: list, v: list, color: int):</code></p>
+<p>Draw a line in a bitmap</p>
+<pre><code>Args:
+    bmp  : unsigned byte array
+           with bmp format
+    u, v : (x:float,y:float)
+           the endpoints
+           of the line
+    color: the color of the line
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.lissajouscurvevert"><code>lissajouscurvevert</code></a></h3>
+<p><code>py
+def lissajouscurvevert(x: int, y: int, a: float, b: float, c: float, d: float, e: float, delta: float, lim: float):</code></p>
+<p>Returns (int, int) 2D vertices
+along a path defined by a lissajous curve
+axis scaling factors a and b and
+frequency scaling factors parameters
+c and d and radian phase shift angle e
+with an origin set at (x, y)</p>
+<pre><code>Args:
+    x, y : center of the curve
+    a, b : axis scaling factors
+    c, d : frequency scaling factors
+    e    : phase shift in radians
+    delta: angle increment in radians
+    lim  : angle limit in radians
+
+Returns:
+    Vertices of a lissajous curve
+    in a list [[x: int, y: int], ...]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.listinBMPrecbnd"><code>listinBMPrecbnd</code></a></h3>
+<p><code>py
+def listinBMPrecbnd(bmp: array.array, xylist: list) -&gt; bool:</code></p>
+<p>Checks if a list of (x, y) coordinates are within the BMP</p>
+<pre><code>Args:
+    bmp   : unsigned byte array
+            with bmp format
+    xylist: list of (x, y)
+            coordinates
+            to be checked
+
+Returns:
+    True if within bounds
+    False if out of bounds
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.listinrecbnd"><code>listinrecbnd</code></a></h3>
+<p><code>py
+def listinrecbnd(xylist: list[list[numbers.Number, numbers.Number]], xmin: int, ymin: int, xmax: int, ymax: int) -&gt; bool:</code></p>
+<p>Checks if all the values in a
+list of x and y value pairs
+lie within the rectangular area
+defined by xmin, ymin and xmax, ymax</p>
+<pre><code>Args:
+    x, y: list[list(x,y)] list of
+          x, y pairs to test
+    xmin, ymin: min (x, y) bounds
+    xmax, ymax: max (x, y) bounds
+
+
+Returns:
+    boolean value
+    True  -&gt; All (x, y)
+             is in bounds
+    False -&gt; Not all (x, y)
+             is in bounds
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.loadBMP"><code>loadBMP</code></a></h3>
+<p><code>py
+def loadBMP(filename: str) -&gt; array.array:</code></p>
+<p>Load bitmap to a byte array
+   (uncompressed bitmap only)</p>
+<pre><code>Args:
+    filename: full path to
+              the file to be loaded
+
+Returns:
+    byte array with bmp file contents
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.LSMslope"><code>LSMslope</code></a></h3>
+<p><code>py
+def LSMslope(XYdata: list) -&gt; float:</code></p>
+<p>Slope of a line obtained by Least Squares Method</p>
+<pre><code>Args:
+    XYdata: list of vectors
+    first two values in the
+    list must be [[x, y, ..,], ...]
+
+Returns:
+    float slope of line
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.LSMYint"><code>LSMYint</code></a></h3>
+<p><code>py
+def LSMYint(XYdata: list) -&gt; float:</code></p>
+<p>Returns the y-intercept of a line obtained
+by Least Squares Method</p>
+<pre><code>Args:
+    XYdata: list of vectors
+    first two values in the
+    list must be [[x, y, ..,], ...]
+
+Returns:
+    float y-intercept of line
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.magnifyNtimescircregion2file"><code>magnifyNtimescircregion2file</code></a></h3>
+<p><code>py
+def magnifyNtimescircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, intmagfactor: int):</code></p>
+<p>Magnify a circular region by an integer factor n times</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+    intmagfactor   : int magnification
+                     factor
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.magnifyNtimescircregion"><code>magnifyNtimescircregion</code></a></h3>
+<p><code>py
+def magnifyNtimescircregion(bmp: array.array, x: int, y: int, r: int, n: int):</code></p>
+<p>Magnify a circular region in a bitmap file by int n</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x,y)
+             and radius r
+    n      : int magnification
+             factor
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.colors.makeBGRbuf"><code>makeBGRbuf</code></a></h3>
+<p><code>py
+def makeBGRbuf(bbuf: array.array, gbuf: array.array, rbuf: array.array) -&gt; array.array:</code></p>
+<p>Assemble a BGR buffer from
+    blue, green and red buffers</p>
+<pre><code>Args:
+    bbuf: unsigned byte array
+          for blue data
+    gbuf: unsigned byte array
+          for green data
+    rbuf: unsigned byte array
+          for red data
+
+Returns:
+    unsigned byte array
+    holding BGR data
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.makenewpalfromcolorhist"><code>makenewpalfromcolorhist</code></a></h3>
+<p><code>py
+def makenewpalfromcolorhist(chist: list, colors: int, similaritythreshold: float) -&gt; list:</code></p>
+<p>Creates a new palatte based on a color histogram</p>
+<pre><code>Args:
+    chist              : list sorted in
+                         descending order
+                         of color
+                         frequencies
+    colors             : maximum colors
+                         of new palette
+    similaritythreshold: controls how
+                         close palette
+                         entries can be
+
+Returns:
+    unsigned byte array with bmp format
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mandelbrot"><code>mandelbrot</code></a></h3>
+<p><code>py
+def mandelbrot(bmp: array.array, x1: int, y1: int, x2: int, y2: int, mandelparam: list[float, float, float, float], RGBfactors: list[float, float, float], maxiter: int):</code></p>
+<p>Draw a Mandelbrot set</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: rectangular area
+                    to draw in
+    mandelparam   : see fractals.py
+    rgbfactors    : [r, b, g] values
+                    range from
+                    0.0 to 1.0
+    maxiter       : when to break
+                    color compute
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.fractals.mandelparamdict"><code>mandelparamdict</code></a></h3>
+<p><code>py
+def mandelparamdict() -&gt; dict:</code></p>
+<h3><a href="#Python_BMP.colors.matchRGBtopal"><code>matchRGBtopal</code></a></h3>
+<p><code>py
+def matchRGBtopal(RGB: list, pal: list) -&gt; int:</code></p>
+<p>Color matching from a 24-bit
+    palette to any 1, 4 or 8-bit
+    palette using Euclidean
+    distance minimization
+    in an rgb colorspace for
+    the closest color match</p>
+<pre><code>Args:
+    RGB: color byte values
+         [r: byte,
+          g: byte,
+          b: byte]
+    pal: the bmp palette to match
+
+Returns:
+    int color val (4-bit)
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.mirror"><code>mirror</code></a></h3>
+<p><code>py
+def mirror(pt: float, delta: float):</code></p>
+<p>Mirrors a value in a numberline</p>
+<pre><code>Args:
+    pt   : real value in numberline
+    delta: value to mirror
+
+Returns:
+    pt - delta, pt + delta
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottom2file"><code>mirrorbottom2file</code></a></h3>
+<p><code>py
+def mirrorbottom2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Mirrors the bottom half of a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path
+                     to an existing
+                     file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottom"><code>mirrorbottom</code></a></h3>
+<p><code>py
+def mirrorbottom(bmp: array.array):</code></p>
+<p>Mirrors the bottom-half of a bmp</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomincircregion2file"><code>mirrorbottomincircregion2file</code></a></h3>
+<p><code>py
+def mirrorbottomincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Mirror the bottom-half of a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomincircregion"><code>mirrorbottomincircregion</code></a></h3>
+<p><code>py
+def mirrorbottomincircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Mirror the bottom-half of a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottominregion2file"><code>mirrorbottominregion2file</code></a></h3>
+<p><code>py
+def mirrorbottominregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the bottom-half region in a rectangular area in a bmp</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : the rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottominregion"><code>mirrorbottominregion</code></a></h3>
+<p><code>py
+def mirrorbottominregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirror the bottom-half
+    of a rectangular region</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangle
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomleft2file"><code>mirrorbottomleft2file</code></a></h3>
+<p><code>py
+def mirrorbottomleft2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Mirrors the bottom-left of a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomleft"><code>mirrorbottomleft</code></a></h3>
+<p><code>py
+def mirrorbottomleft(bmp: array.array):</code></p>
+<p>Mirrors the bottom-left part
+    of an in-memory bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomleftincircregion2file"><code>mirrorbottomleftincircregion2file</code></a></h3>
+<p><code>py
+def mirrorbottomleftincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Mirror the bottom-left of a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomleftincircregion"><code>mirrorbottomleftincircregion</code></a></h3>
+<p><code>py
+def mirrorbottomleftincircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Mirror the bottom-left of a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x,y) and
+             radius r of region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomleftinregion2file"><code>mirrorbottomleftinregion2file</code></a></h3>
+<p><code>py
+def mirrorbottomleftinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the bottom-left region in a rectangular area in a bmp</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : the rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomleftinregion"><code>mirrorbottomleftinregion</code></a></h3>
+<p><code>py
+def mirrorbottomleftinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the bottom-left of a
+    rectangular region defined
+    by (x1, y1) and (x2, y2)</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangle
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomright2file"><code>mirrorbottomright2file</code></a></h3>
+<p><code>py
+def mirrorbottomright2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Mirrors the bottom-right of a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomright"><code>mirrorbottomright</code></a></h3>
+<p><code>py
+def mirrorbottomright(bmp: array.array):</code></p>
+<p>Mirrors the bottom right part
+    of an in-memory bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomrightincircregion2file"><code>mirrorbottomrightincircregion2file</code></a></h3>
+<p><code>py
+def mirrorbottomrightincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Mirror the bottom-right of a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomrightincircregion"><code>mirrorbottomrightincircregion</code></a></h3>
+<p><code>py
+def mirrorbottomrightincircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Mirror the bottom-right of a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x,y) and
+             radius r of region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomrightinregion2file"><code>mirrorbottomrightinregion2file</code></a></h3>
+<p><code>py
+def mirrorbottomrightinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the bottom-right region in a rectangular area in a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2  :the rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorbottomrightinregion"><code>mirrorbottomrightinregion</code></a></h3>
+<p><code>py
+def mirrorbottomrightinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the bottom-right of a
+    rectangular region defined by
+    (x1, y1) and (x2, y2)</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: the rectangular
+                    region
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorleft2file"><code>mirrorleft2file</code></a></h3>
+<p><code>py
+def mirrorleft2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Mirrors the left-half of a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorleft"><code>mirrorleft</code></a></h3>
+<p><code>py
+def mirrorleft(bmp: array.array):</code></p>
+<p>Mirrors the left-half of an
+    in-memory bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorleftincircregion2file"><code>mirrorleftincircregion2file</code></a></h3>
+<p><code>py
+def mirrorleftincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Mirror the left-half of a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorleftincircregion"><code>mirrorleftincircregion</code></a></h3>
+<p><code>py
+def mirrorleftincircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Mirrors the top-left of a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y) and
+             radius r of region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorleftinregion2file"><code>mirrorleftinregion2file</code></a></h3>
+<p><code>py
+def mirrorleftinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the left-half region in a rectangular area in a bmp</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorleftinregion"><code>mirrorleftinregion</code></a></h3>
+<p><code>py
+def mirrorleftinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the left-half
+    of a rectangular area</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangle
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorright2file"><code>mirrorright2file</code></a></h3>
+<p><code>py
+def mirrorright2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Mirrors the right half of a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorright"><code>mirrorright</code></a></h3>
+<p><code>py
+def mirrorright(bmp: array.array):</code></p>
+<p>Mirrors the right-half of an
+    in-memory bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorrightincircregion2file"><code>mirrorrightincircregion2file</code></a></h3>
+<p><code>py
+def mirrorrightincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Mirror the right-half of a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorrightincircregion"><code>mirrorrightincircregion</code></a></h3>
+<p><code>py
+def mirrorrightincircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Mirrors the right-half of a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of a region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorrightinregion2file"><code>mirrorrightinregion2file</code></a></h3>
+<p><code>py
+def mirrorrightinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the right-half region in a rectangular area in a bmp</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : the rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrorrightinregion"><code>mirrorrightinregion</code></a></h3>
+<p><code>py
+def mirrorrightinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the right-half of
+    a rectangular area in a bitmap</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangle
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortop2file"><code>mirrortop2file</code></a></h3>
+<p><code>py
+def mirrortop2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Mirrors the top-half of a bitmap</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortop"><code>mirrortop</code></a></h3>
+<p><code>py
+def mirrortop(bmp: array.array):</code></p>
+<p>Mirrors the top-half of a bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortopincircregion2file"><code>mirrortopincircregion2file</code></a></h3>
+<p><code>py
+def mirrortopincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Mirror the top-half of a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortopincircregion"><code>mirrortopincircregion</code></a></h3>
+<p><code>py
+def mirrortopincircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Mirror the top-half of a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r of area
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortopinregion2file"><code>mirrortopinregion2file</code></a></h3>
+<p><code>py
+def mirrortopinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the top-half region in a rectangular area in a bmp</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : the rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortopinregion"><code>mirrortopinregion</code></a></h3>
+<p><code>py
+def mirrortopinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirror the top-half of
+    a rectangular region</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangular
+                    region
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortopleft2file"><code>mirrortopleft2file</code></a></h3>
+<p><code>py
+def mirrortopleft2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Mirrors the top-left of a bitmap</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortopleft"><code>mirrortopleft</code></a></h3>
+<p><code>py
+def mirrortopleft(bmp):</code></p>
+<p>Mirrors the top-left part
+    of an in-memory bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortopleftincircregion2file"><code>mirrortopleftincircregion2file</code></a></h3>
+<p><code>py
+def mirrortopleftincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Mirror the top-left of a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortopleftincircregion"><code>mirrortopleftincircregion</code></a></h3>
+<p><code>py
+def mirrortopleftincircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Mirror the top-left of a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortopleftinregion2file"><code>mirrortopleftinregion2file</code></a></h3>
+<p><code>py
+def mirrortopleftinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the top-left region in a rectangular area in a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : the rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortopleftinregion"><code>mirrortopleftinregion</code></a></h3>
+<p><code>py
+def mirrortopleftinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the top-left of a
+    rectangular region defined by
+    (x1, y1) and (x2, y2)</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangle
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortopright2file"><code>mirrortopright2file</code></a></h3>
+<p><code>py
+def mirrortopright2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Mirrors the top-right of a
+    bitmap file</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path
+                     to existing
+                     file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortopright"><code>mirrortopright</code></a></h3>
+<p><code>py
+def mirrortopright(bmp: array.array):</code></p>
+<p>Mirrors the top-right part
+    of an in-memory bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortoprightincircregion2file"><code>mirrortoprightincircregion2file</code></a></h3>
+<p><code>py
+def mirrortoprightincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Mirror the top-right of a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortoprightincircregion"><code>mirrortoprightincircregion</code></a></h3>
+<p><code>py
+def mirrortoprightincircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Mirror the top-right of a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y) and
+             radius r of region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortoprightinregion2file"><code>mirrortoprightinregion2file</code></a></h3>
+<p><code>py
+def mirrortoprightinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the top-right region in a rectangular area in a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : the rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.mirrortoprightinregion"><code>mirrortoprightinregion</code></a></h3>
+<p><code>py
+def mirrortoprightinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Mirrors the top-right of a
+    rectangular region defined by
+    (x1, y1) and (x2, y2)</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangle
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.monochrome2file"><code>monochrome2file</code></a></h3>
+<p><code>py
+def monochrome2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Applies a monochrome filter to a BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.colors.monochrome"><code>monochrome</code></a></h3>
+<p><code>py
+def monochrome(rgb: list[int, int, int]) -&gt; list[int, int, int]:</code></p>
+<p>Returns a monochrome color
+    based on a 24-bit RGB value</p>
+<pre><code>Args:
+    rgb: color values
+        [r: byte, g: byte, b: byte]
+
+Returns:
+    a gray color (r = g = b)
+    [r: byte, g: byte, b: byte]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.monochromecircregion2file"><code>monochromecircregion2file</code></a></h3>
+<p><code>py
+def monochromecircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Monochrome filter to a circular region</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path
+                     to an existing
+                     file
+    NewBMPfile     : New file to
+                     save changes in
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.colors.monochromefiltertoBGRbuf"><code>monochromefiltertoBGRbuf</code></a></h3>
+<p><code>py
+def monochromefiltertoBGRbuf(buf: array.array) -&gt; array.array:</code></p>
+<p>Apply a monochrome filter to a
+    BGR buffer</p>
+<pre><code>Args:
+    buf: unsigned byte array
+         holding BGR data
+
+    rgbfactors: color filter as
+                  [r: float,
+                   g: float,
+                   b: float]
+
+Returns:
+    unsigned byte array
+    holding mono BGR data
+</code></pre>
+<h3><a href="#Python_BMP.colors.monochromepal"><code>monochromepal</code></a></h3>
+<p><code>py
+def monochromepal(bits: int, rgbfactors: list[float, float, float]) -&gt; list[list[int, int, int]]:</code></p>
+<p>Returns a monochrome palette
+    based on bit depth bits and
+    rgbfactors</p>
+<pre><code>Args:
+    bits      : bit depth
+                (1, 4, 8)
+    rgbfactors: color values
+                0.0 to 1.0
+                [r: float,
+                 g: float,
+                 b: float]
+
+Returns:
+  a palette as
+  list[list[r: int, g: int, b int]]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.monocircle"><code>monocircle</code></a></h3>
+<p><code>py
+def monocircle(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Monochrome filter to a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of the region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.monofilterinregion2file"><code>monofilterinregion2file</code></a></h3>
+<p><code>py
+def monofilterinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Monochrome filter to rectangular area in a 24-bit BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.monofilterto24bitimage"><code>monofilterto24bitimage</code></a></h3>
+<p><code>py
+def monofilterto24bitimage(bmp: array.array):</code></p>
+<p>Applies a mono filter
+    to a 24 bit in-memory bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.monofilterto24bitregion"><code>monofilterto24bitregion</code></a></h3>
+<p><code>py
+def monofilterto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Applies a monochrome filter
+    to a rectangular area
+    defined by (x1, y1) and
+    (x2, y2) in a 24 bit bitmap</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: the rectangle
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.newBMP"><code>newBMP</code></a></h3>
+<p><code>py
+def newBMP(x: int, y: int, colorbits: int) -&gt; array.array:</code></p>
+<p>Creates a new in-memory bitmap</p>
+<pre><code>Args:
+    x, y     : unsigned int values
+               of x and y dims
+    colorbits: bit depth
+               (1, 4, 8, 24) bits
+
+Returns:
+    unsigned byte array with bitmap layout
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.numbervert"><code>numbervert</code></a></h3>
+<p><code>py
+def numbervert(bmp: array.array, vlist: list[list[int, int]], xadj: int, yadj: int, scale: int, valstart: numbers.Number, valstep: numbers.Number, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, suppresszero: bool, suppresslastnum: bool, rightjustify: bool):</code></p>
+<h3><a href="#Python_BMP.solids3D.octahedravert"><code>octahedravert</code></a></h3>
+<p><code>py
+def octahedravert(x: float) -&gt; list[list[float, float, float]]:</code></p>
+<p>Returns a list of vertices
+    for an octrahedron</p>
+<pre><code>Args:
+    x: length of a side
+
+Returns:
+    list (x: float,
+          y: float,
+          z: float)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.outline2file"><code>outline2file</code></a></h3>
+<p><code>py
+def outline2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Applies an outline filter</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.outline"><code>outline</code></a></h3>
+<p><code>py
+def outline(bmp: array.array):</code></p>
+<p>Applies an Outline Filter</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.outlinecircregion2file"><code>outlinecircregion2file</code></a></h3>
+<p><code>py
+def outlinecircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):</code></p>
+<p>Outlines area in a circular region</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x, y, r        : center (x, y)
+                     and radius r
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.outlinecircregion"><code>outlinecircregion</code></a></h3>
+<p><code>py
+def outlinecircregion(bmp: array.array, x: int, y: int, r: int):</code></p>
+<p>Outlines a circular area</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of the region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.outlineregion2file"><code>outlineregion2file</code></a></h3>
+<p><code>py
+def outlineregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Outline filter to rectangular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.outlineregion"><code>outlineregion</code></a></h3>
+<p><code>py
+def outlineregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Outines a rectangular region in a BMP</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines
+                    the rectangular
+                    region
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.pastecirularbuf"><code>pastecirularbuf</code></a></h3>
+<p><code>py
+def pastecirularbuf(bmp: array.array, x: int, y: int, circbuf: list):</code></p>
+<p>Paste a circular buffer with a
+given radius to a centerpoint at (x, y)</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y   : center of circular
+             region
+    circbuf: list generated by
+             copycircregion2buf
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.pasterect"><code>pasterect</code></a></h3>
+<p><code>py
+def pasterect(bmp: array.array, buf: array.array, x1: int, y1: int):</code></p>
+<p>Paste a rectangular area from a buffer to a bmp</p>
+<pre><code>Args:
+    bmp   : unsigned byte array
+            with bmp format
+    buf   : rectangular
+            image buffer
+    x1, y1: point to paste
+            the buffer
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.perspective"><code>perspective</code></a></h3>
+<p><code>py
+def perspective(vlist: list[list[numbers.Number, numbers.Number, numbers.Number]], rotvec: list[list[float, float], list[float, float], list[float, float]], dispvec: list[numbers.Number, numbers.Number, numbers.Number], d: float) -&gt; tuple:</code></p>
+<p>Projects 3D points to 2D and
+    apply rotation and translation
+    vectors</p>
+<pre><code>Args:
+    vlist  : list of 3D vertices
+    rotvec : 3D rotation vector
+    dispvec: 3D translation vector
+    d      : Distance of observer
+             from the screen
+
+Returns:
+    tuple (list, list)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.piechart"><code>piechart</code></a></h3>
+<p><code>py
+def piechart(bmp: array.array, x: int, y: int, r: int, dataandcolorlist: list):</code></p>
+<p>Draw a piechart</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y, r         : center (x, y)
+                      and radius r
+    dataandcolorlist: stuff to plot
+                      + color
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.pixelizenxn"><code>pixelizenxn</code></a></h3>
+<p><code>py
+def pixelizenxn(bmp: array.array, n: int) -&gt; array.array:</code></p>
+<p>Pixelize a whole image with n by n areas
+in which colors are averaged</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    n  : size of pixel blur
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.pixelizenxncircregion2file"><code>pixelizenxncircregion2file</code></a></h3>
+<p><code>py
+def pixelizenxncircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, intpixsize: int):</code></p>
+<p>Apply a Pixel Blur in a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+    intpixsize     : n by n
+                     pixel blur size
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.pixelizenxncircregion"><code>pixelizenxncircregion</code></a></h3>
+<p><code>py
+def pixelizenxncircregion(bmp: array.array, x: int, y: int, r: int, n: int):</code></p>
+<p>Pixelize a circular region in a BMP by n</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+    n      : integer pixellation
+             dimension n by n
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.pixelizenxntofile"><code>pixelizenxntofile</code></a></h3>
+<p><code>py
+def pixelizenxntofile(ExistingBMPfile: str, NewBMPfile: str, n: int):</code></p>
+<p>Pixellate a bitmap file with n by n pixel areas</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plot3d"><code>plot3d</code></a></h3>
+<p><code>py
+def plot3d(bmp: array.array, sides: list[list, list], issolid: bool, RGBfactors: list[float, float], showoutline: bool, outlinecolor: int):</code></p>
+<p>The 3D rendering function</p>
+<pre><code>Args:
+    bmp         : unsigned
+                  byte array
+                  with bmp format
+    sides       : list of polygons
+                  and normals
+    isolid      : toggles solid render
+    RGBfactors  : [r,g,b] r, g, b
+                  range in value
+                  from 0.0 to 1.0
+    showoutine  : toggles the
+                  polygon outline
+    outlinecolor: color of the
+                  polygon outline
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plot3Dsolid"><code>plot3Dsolid</code></a></h3>
+<p><code>py
+def plot3Dsolid(bmp: array.array, vertandsides: list[list, list], issolid: bool, RGBfactors: list[float, float, float], showoutline: bool, outlinecolor: int, rotvect: list[float, float, float], transvect3D: list[float, float, float], d: int, transvect: list[int, int]):</code></p>
+<p>3D solid rendering function</p>
+<pre><code>Args:
+    bmp         : unsigned
+                  byte array
+                  with bmp format
+    sides       : list of polygons
+                  and normals
+    isolid      : toggles the
+                  solid render
+    RGBfactors  : [r,g,b] r, g, b
+                  range in value
+                  from 0.0 to 1.0
+    showoutine  : toggles the
+                  polygon outline
+    outlinecolor: color of the
+                  polygon outline
+    rotvect     : rotation vector
+    transvect3D : 3D translation
+                  vector
+    d           : distance of the
+                  observer from
+                  the screen
+    transvect   : 2D translation
+                  vector for
+                  screen position
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plot8bitpattern"><code>plot8bitpattern</code></a></h3>
+<p><code>py
+def plot8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit pattern</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    bitpattern: list of bytes
+                that makes the pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plot8bitpatternasdots"><code>plot8bitpatternasdots</code></a></h3>
+<p><code>py
+def plot8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit pattern as circles</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    bitpattern: list of bytes
+                that makes the
+                pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.textgraphics.plot8bitpatternastext"><code>plot8bitpatternastext</code></a></h3>
+<p><code>py
+def plot8bitpatternastext(bitpattern: list[int], onechar: str, zerochar: str):</code></p>
+<p>Outputs the bits of a list
+    of bytes to console</p>
+<pre><code>Args:
+    bitpattern: list of bytes
+    onechar   : char to display
+                if bit is 1
+    zeropchar : char to display
+                if bit is 0
+
+Returns:
+    console output
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plot8bitpatternsideway"><code>plot8bitpatternsideway</code></a></h3>
+<p><code>py
+def plot8bitpatternsideway(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit pattern sideways</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to
+                draw the pattern
+    bitpattern: list of bytes that
+                makes the pattern
+    scale     : control how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plot8bitpatternsidewaywithdots"><code>plot8bitpatternsidewaywithdots</code></a></h3>
+<p><code>py
+def plot8bitpatternsidewaywithdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit pattern sideways with dots</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to
+                draw the pattern
+    bitpattern: list of bytes that
+                makes the pattern
+    scale     : control how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plot8bitpatternsidewaywithfn"><code>plot8bitpatternsidewaywithfn</code></a></h3>
+<p><code>py
+def plot8bitpatternsidewaywithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):</code></p>
+<p>Draws a 8-bit pattern sideways with a function</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to
+                draw the pattern
+    bitpattern: list of bytes that
+                makes the pattern
+    scale     : control how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plot8bitpatternupsidedown"><code>plot8bitpatternupsidedown</code></a></h3>
+<p><code>py
+def plot8bitpatternupsidedown(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit pattern upsidedown</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to
+                draw the pattern
+    bitpattern: list of bytes that
+                makes the pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the
+                pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plot8bitpatternupsidedownasdots"><code>plot8bitpatternupsidedownasdots</code></a></h3>
+<p><code>py
+def plot8bitpatternupsidedownasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit pattern upsidedown with dots</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to
+                draw the pattern
+    bitpattern: list of bytes that
+                makes the pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plot8bitpatternupsidedownwithfn"><code>plot8bitpatternupsidedownwithfn</code></a></h3>
+<p><code>py
+def plot8bitpatternupsidedownwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):</code></p>
+<p>Draws a 8-bit pattern upsidedown with a function</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to
+                draw the pattern
+    bitpattern: list of bytes that
+                makes the pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+    fn        : function
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plot8bitpatternwithfn"><code>plot8bitpatternwithfn</code></a></h3>
+<p><code>py
+def plot8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):</code></p>
+<p>8-bit pattern with a function</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    bitpattern: list of bytes
+                that makes the
+                pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.textgraphics.plotbitsastext"><code>plotbitsastext</code></a></h3>
+<p><code>py
+def plotbitsastext(bits: int):</code></p>
+<p>Outputs the bits of byte to
+    console</p>
+<pre><code>Args:
+    bits: byte value
+
+Returns:
+    space for 0
+    *     for 1
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotbmpastext"><code>plotbmpastext</code></a></h3>
+<p><code>py
+def plotbmpastext(bmp: array.array):</code></p>
+<p>Plot a bitmap as text
+(cannot output 24-bit bmp)</p>
+<pre><code>Args:
+    bmp : unsigned byte array
+          with bmp format
+
+Returns:
+    console text output
+    for debug and ascii art
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotcircinsqr"><code>plotcircinsqr</code></a></h3>
+<p><code>py
+def plotcircinsqr(bmp, x, y, d, color):</code></p>
+<p>Draws a circle in an
+    invisible square with side
+    equal to the circle's diameter
+    and positioned by (x, y)
+    at  the upper left
+    of the bounding square</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    d         : diameter of the
+                circle
+ Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotfilledflower"><code>plotfilledflower</code></a></h3>
+<p><code>py
+def plotfilledflower(bmp: array.array, cx: int, cy: int, r: int, petals: float, angrot: float, lumrange: list[int, int], RGBfactors: list[float, float, float]):</code></p>
+<p>Draw a filled flower</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    cx, cy, r : center (cx, cy)
+                and radius r
+    petals    : number of petals
+    angrot    : angle of rotation
+    lumrange  : (byte:byte) range
+                of brightness
+    rgbfactors: [r, g, b] values
+                of r, g and b
+                range from
+                0.0 to 1.0
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotflower"><code>plotflower</code></a></h3>
+<p><code>py
+def plotflower(bmp: array.array, cx: int, cy: int, r: int, petals: float, angrot: float, lumrange: list[int, int], RGBfactors: list[float, float, float]):</code></p>
+<p>Draw a flower</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    cx, cy, r : center (cx,cy)
+                and radius r
+    petals    : number of petals
+    angrot    : angle of rotation
+    lumrange  : (byte:byte) range
+                of brightness for
+                the gradient
+    rgbfactors: [r, g, b] values
+                all range from
+                0.0 to 1.0
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotimgedges"><code>plotimgedges</code></a></h3>
+<p><code>py
+def plotimgedges(bmp: array.array, similaritythreshold: int, edgeradius: int, edgecolor: int):</code></p>
+<p>Draw edges</p>
+<pre><code>Args:
+    bmp                : unsigned
+                         byte array
+                         with bmp
+                         format
+    similaritythreshold: controls
+                         the edge
+                         detection
+                         sensitivity
+    edgeradius         : radius and
+    edgecolor            color of
+                         the pen
+                         used to
+                         draw the
+                         edges
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalic8bitpattern"><code>plotitalic8bitpattern</code></a></h3>
+<p><code>py
+def plotitalic8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit italic pattern</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    bitpattern: list of bytes
+                that makes the
+                pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit
+    color     : color of pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalic8bitpatternasdots"><code>plotitalic8bitpatternasdots</code></a></h3>
+<p><code>py
+def plotitalic8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit italic pattern as dots</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    bitpattern: list of bytes
+                that makes the pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalic8bitpatternsideway"><code>plotitalic8bitpatternsideway</code></a></h3>
+<p><code>py
+def plotitalic8bitpatternsideway(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws an italic 8-bit pattern sideways</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to
+                draw the pattern
+    bitpattern: list of bytes that
+                makes the pattern
+    scale     : control how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalic8bitpatternsidewayasdots"><code>plotitalic8bitpatternsidewayasdots</code></a></h3>
+<p><code>py
+def plotitalic8bitpatternsidewayasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws an italic 8-bit pattern sideways as dots</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to
+                draw the pattern
+    bitpattern: list of bytes that
+                makes the pattern
+    scale     : control how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalic8bitpatternsidewaywithfn"><code>plotitalic8bitpatternsidewaywithfn</code></a></h3>
+<p><code>py
+def plotitalic8bitpatternsidewaywithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):</code></p>
+<p>Draws an Italic 8-bit pattern sideways with a function</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to
+                draw the pattern
+    bitpattern: list of bytes that
+                makes the pattern
+    scale     : control how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalic8bitpatternupdsidedownasdots"><code>plotitalic8bitpatternupdsidedownasdots</code></a></h3>
+<p><code>py
+def plotitalic8bitpatternupdsidedownasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit italic pattern upsidedown as dots</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    bitpattern: list of bytes
+                that makes the pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalic8bitpatternupsidedownwithfn"><code>plotitalic8bitpatternupsidedownwithfn</code></a></h3>
+<p><code>py
+def plotitalic8bitpatternupsidedownwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):</code></p>
+<p>Italic 8-bit pattern upsidedown with a function</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to
+                draw the pattern
+    bitpattern: list of bytes that
+                makes the pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+    fn        : function
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalic8bitpatternwithfn"><code>plotitalic8bitpatternwithfn</code></a></h3>
+<p><code>py
+def plotitalic8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):</code></p>
+<p>Italic 8-bit pattern with a function</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    bitpattern: list of bytes
+                that makes the
+                pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalicstring"><code>plotitalicstring</code></a></h3>
+<p><code>py
+def plotitalicstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a string as Italic</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the
+                      string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                      (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalicstringasdots"><code>plotitalicstringasdots</code></a></h3>
+<p><code>py
+def plotitalicstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a string as Italic dots</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the
+                      string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                      (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalicstringsideway"><code>plotitalicstringsideway</code></a></h3>
+<p><code>py
+def plotitalicstringsideway(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws an Italic String Sideways</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+                      can be an int
+                          or a
+                      list of ints
+    fontbuf         : the font
+                      (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalicstringsidewayasdots"><code>plotitalicstringsidewayasdots</code></a></h3>
+<p><code>py
+def plotitalicstringsidewayasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws an italic string sideways as dots</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                     (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalicstringvertical"><code>plotitalicstringvertical</code></a></h3>
+<p><code>py
+def plotitalicstringvertical(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws an italic string vertically with dots</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                     (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotitalicstringverticalasdots"><code>plotitalicstringverticalasdots</code></a></h3>
+<p><code>py
+def plotitalicstringverticalasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws an italic string vertically with dots</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                     (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotlines"><code>plotlines</code></a></h3>
+<p><code>py
+def plotlines(bmp: array.array, vertlist: list, color: int):</code></p>
+<p>Draws connected lines defined by a list of vertices</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    vertlist: [(x:uint,y:uint),...]
+              list of vertices
+    color   : color of the lines
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotpoly"><code>plotpoly</code></a></h3>
+<p><code>py
+def plotpoly(bmp: array.array, vertlist: list, color: int):</code></p>
+<p>Draws a polygon defined by a list of vertices</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    vertlist: [(x:uint,y:uint),...]
+              list of vertices
+    color   : color of the lines
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotpolyfill"><code>plotpolyfill</code></a></h3>
+<p><code>py
+def plotpolyfill(bmp: array.array, vertlist: list[list[numbers.Number, numbers.Number]], color: int):</code></p>
+<p>Draws a filled polygon with a given color</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    vertlist: [(x, y), ...]
+              list of vertices
+    color   : color of the
+              filled polygon
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotpolyfillist"><code>plotpolyfillist</code></a></h3>
+<p><code>py
+def plotpolyfillist(bmp: array.array, sides: list[list[list[list]], list[list[float, float, float]]], RGBfactors: list[float, float]):</code></p>
+<p>3D polygon rendering function</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    sides     : list of polygons
+                and normals
+    RGBfactors: [r, g, b]
+                r, g, b are
+                float values
+                from 0.0 to 1.0
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotpolylist"><code>plotpolylist</code></a></h3>
+<p><code>py
+def plotpolylist(bmp: array.array, polylist: list, color: int):</code></p>
+<p>Draws a list of polygons of a given color</p>
+<pre><code>Args:
+    bmp      : unsigned byte array
+               with bmp format
+    polytlist: [[(x:uint,y:uint),
+                ...],...]
+               list of polygons
+    color    : color of the lines
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotreverseditalic8bitpattern"><code>plotreverseditalic8bitpattern</code></a></h3>
+<p><code>py
+def plotreverseditalic8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit reversed italic pattern</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    bitpattern: list of bytes
+                that makes the pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotreverseditalic8bitpatternasdots"><code>plotreverseditalic8bitpatternasdots</code></a></h3>
+<p><code>py
+def plotreverseditalic8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit reversed italic pattern as dots</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    bitpattern: list of bytes
+                that makes the pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotreverseditalicstring"><code>plotreverseditalicstring</code></a></h3>
+<p><code>py
+def plotreverseditalicstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a reversed string as Italic</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of font
+    fontbuf         : the font
+                      (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotreverseditalicstringasdots"><code>plotreverseditalicstringasdots</code></a></h3>
+<p><code>py
+def plotreverseditalicstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a Reversed String as Italic dots</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the
+                      string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                      (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotreversestring"><code>plotreversestring</code></a></h3>
+<p><code>py
+def plotreversestring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a string reversed</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                     (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotreversestringasdots"><code>plotreversestringasdots</code></a></h3>
+<p><code>py
+def plotreversestringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a string reversed with dots</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                     (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotRGBxybit"><code>plotRGBxybit</code></a></h3>
+<p><code>py
+def plotRGBxybit(bmp: array.array, x: int, y: int, rgb: list):</code></p>
+<p>Sets pixel at (x, y) in a bitmap to color [R, G, B]</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    x,y: unsigned int locations
+         in x and y
+    rgb: color defined by
+         [R: byte, G: byte, B: byte]
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotRGBxybitvec"><code>plotRGBxybitvec</code></a></h3>
+<p><code>py
+def plotRGBxybitvec(bmp: array.array, v: list, rgb: list):</code></p>
+<p>Sets [R, G, B] of pixel at (x, y)</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    v  : (x: float, y: float)
+    rgb: [R: byte,
+          G: byte,
+          B: byte]
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotrotated8bitpattern"><code>plotrotated8bitpattern</code></a></h3>
+<p><code>py
+def plotrotated8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit pattern with the bits rotated</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : where to draw
+                the pattern
+    bitpattern: list of bytes
+                that make a pattern
+    scale     : control how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the
+                pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotrotated8bitpatternwithdots"><code>plotrotated8bitpatternwithdots</code></a></h3>
+<p><code>py
+def plotrotated8bitpatternwithdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit pattern with the bits rotated</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : where to draw
+                the pattern
+    bitpattern: list of bytes
+                that make a pattern
+    scale     : control how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the
+                pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotrotated8bitpatternwithfn"><code>plotrotated8bitpatternwithfn</code></a></h3>
+<p><code>py
+def plotrotated8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):</code></p>
+<p>Draws a 8-bit pattern with
+the bits rotated with a function</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : where to draw
+                the pattern
+    bitpattern: list of bytes
+                that make a pattern
+    scale     : control how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotrotateditalic8bitpatternwithfn"><code>plotrotateditalic8bitpatternwithfn</code></a></h3>
+<p><code>py
+def plotrotateditalic8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):</code></p>
+<p>Bit rotated Italic 8-bit pattern
+with a function</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    bitpattern: list of bytes
+                that makes the
+                pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotstring"><code>plotstring</code></a></h3>
+<p><code>py
+def plotstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a string</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the
+                      string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+                      (can be an int
+                           or a
+                      list of ints)
+    fontbuf         : the font
+                      (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotstringasdots"><code>plotstringasdots</code></a></h3>
+<p><code>py
+def plotstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a string as Dots</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of the font
+    fontbuf         : the font
+                      (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotstringfunc"><code>plotstringfunc</code></a></h3>
+<p><code>py
+def plotstringfunc(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, orderfunc: Callable, fontrenderfunc: Callable):</code></p>
+<p>Draws a string</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+        `             each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of the font
+    fontbuf         : the font
+                      (see fonts.py)
+    orderfunc       : function that
+                      enumerates
+                      each char
+                      in the
+                      input string
+    fontrenderfunc  : function that
+                      renders the font
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotstringsideway"><code>plotstringsideway</code></a></h3>
+<p><code>py
+def plotstringsideway(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a string sideways</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                     (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotstringsidewayasdots"><code>plotstringsidewayasdots</code></a></h3>
+<p><code>py
+def plotstringsidewayasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a string sideways as dots</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                     (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotstringsidewayfn"><code>plotstringsidewayfn</code></a></h3>
+<p><code>py
+def plotstringsidewayfn(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, fn: Callable):</code></p>
+<p>Draws a string sideways with a function</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                     (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotstringupsidedown"><code>plotstringupsidedown</code></a></h3>
+<p><code>py
+def plotstringupsidedown(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a string upsidedown</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                      (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotstringupsidedownasdots"><code>plotstringupsidedownasdots</code></a></h3>
+<p><code>py
+def plotstringupsidedownasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a string upsidedown as dots</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of the font
+    fontbuf         : the font
+                      (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotstringvertical"><code>plotstringvertical</code></a></h3>
+<p><code>py
+def plotstringvertical(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a string vertically</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                     (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotstringverticalasdots"><code>plotstringverticalasdots</code></a></h3>
+<p><code>py
+def plotstringverticalasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draws a string vertically with dots</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                     (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotstringverticalwithfn"><code>plotstringverticalwithfn</code></a></h3>
+<p><code>py
+def plotstringverticalwithfn(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, fn: Callable):</code></p>
+<p>Draws a string vertically using a function</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                     (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotupsidedownitalic8bitpattern"><code>plotupsidedownitalic8bitpattern</code></a></h3>
+<p><code>py
+def plotupsidedownitalic8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit italic pattern upsidedown</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    bitpattern: list of bytes
+                that makes the pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotupsidedownitalic8bitpatternasdots"><code>plotupsidedownitalic8bitpatternasdots</code></a></h3>
+<p><code>py
+def plotupsidedownitalic8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):</code></p>
+<p>Draws a 8-bit italic pattern upsidedown as dots</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : sets where to draw
+                the pattern
+    bitpattern: list of bytes
+                that makes the pattern
+    scale     : controls how big
+                the pattern is
+    pixspace  : space between
+                each bit in pixels
+    color     : color of the pattern
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotupsidedownitalicstring"><code>plotupsidedownitalicstring</code></a></h3>
+<p><code>py
+def plotupsidedownitalicstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draw an italic string upsidedown</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the
+                      string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                      (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotupsidedownitalicstringasdots"><code>plotupsidedownitalicstringasdots</code></a></h3>
+<p><code>py
+def plotupsidedownitalicstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):</code></p>
+<p>Draw an italic string upsidedown as dots</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    x, y            : sets where to
+                      draw the
+                      string
+    str2plot        : string to draw
+    scale           : control how big
+                      the font is
+    pixspace        : space between
+                      each bit
+    spacebetweenchar: space between
+                      the characters
+    color           : color of
+                      the font
+    fontbuf         : the font
+                      (see fonts.py)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotvecxypoint"><code>plotvecxypoint</code></a></h3>
+<p><code>py
+def plotvecxypoint(bmp: array.array, v: list, c: int):</code></p>
+<p>Sets the color of a pixel
+    at (x, y)</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    v  : (x:float, y:float)
+                or
+         (x:int, y:int)
+    c  : unsigned int
+         color value
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotxybit"><code>plotxybit</code></a></h3>
+<p><code>py
+def plotxybit(bmp: array.array, x: int, y: int, c: int):</code></p>
+<p>Sets pixel at (x, y) in a bitmap to color c</p>
+<pre><code>Args:
+    bmp : unsigned byte array
+          with bmp format
+    x, y: unsigned int
+          locations in x and y
+    c   : unsigned int color
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.plotxypointlist"><code>plotxypointlist</code></a></h3>
+<p><code>py
+def plotxypointlist(bmp: array.array, vlist: list, penradius: int, color: int):</code></p>
+<p>Draws a circle or a point
+depending on the penradius
+with a given color for
+all points in a point list</p>
+<pre><code>Args:
+    bmp      : unsigned byte array
+               with bmp format
+    vlist    : [(x: uint, y: uint) ,...]
+               list of points
+    penradius: radius of the pen
+               (in pixels)
+    color    : color of the pen
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.polar2rectcoord2D"><code>polar2rectcoord2D</code></a></h3>
+<p><code>py
+def polar2rectcoord2D(vpolarcoord: list[float, float]) -&gt; list[float, float]:</code></p>
+<p>Converts from polar coordinates with
+origin at (0, 0) to 2D rectangular coordinates</p>
+<pre><code>Args:
+    vcylindcoord:(r: float,
+              theta: float)
+
+Returns:
+    [x: float,
+     y: float]
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.polyboundary"><code>polyboundary</code></a></h3>
+<p><code>py
+def polyboundary(vertlist: list[list[int, int]]) -&gt; list[list[int, int]]:</code></p>
+<p>Generates a polygon boundary
+    from a list of 2D vertices</p>
+<pre><code>Args:
+    polybnd : list of 2D vertices
+              list[list[x: int,
+                        y: int]]
+
+Returns:
+    list[list[x: int, y: int]]
+    A list of vertices that traces
+    the boundaries of the polygon
+</code></pre>
+<h3><a href="#Python_BMP.colors.probplotRGBto1bit"><code>probplotRGBto1bit</code></a></h3>
+<p><code>py
+def probplotRGBto1bit(rgb: list[int, int, int], brightness: int) -&gt; int:</code></p>
+<p>Use a non deterministic plot
+    to convert 24-bit colors to
+    1-bit</p>
+<pre><code>Args:
+    rgb: color byte values
+         [r: byte,
+          g: byte,
+          b: byte]
+
+Returns:
+    0 or 1
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.range2baseanddelta"><code>range2baseanddelta</code></a></h3>
+<p><code>py
+def range2baseanddelta(lst_range: list[int, int]):</code></p>
+<p>Gets the base and range values in a list of numbers</p>
+<pre><code>Args:
+    lst_range: list[min: int,
+                    max: int]
+
+Returns:
+    minimum value and delta of min and max value
+    in lst_range
+</code></pre>
+<h3><a href="#Python_BMP.inttools.readint"><code>readint</code></a></h3>
+<p><code>py
+def readint(offset: int, cnt: int, arr: int) -&gt; int:</code></p>
+<p>Reads an integer value in an
+    unsigned byte array</p>
+<pre><code>Args:
+    offset: uint starting offset in
+            buffer or array
+            to read from
+    cnt   : uint length of int data
+            to read
+    arr   : unsigned byte array
+            to read int data from
+
+Returns:
+    unsigned int value
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.rectangle2file"><code>rectangle2file</code></a></h3>
+<p><code>py
+def rectangle2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, color: int):</code></p>
+<p>Draws a Rectangle</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular region
+    color          : color of rectangle
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.rectangle"><code>rectangle</code></a></h3>
+<p><code>py
+def rectangle(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):</code></p>
+<p>Draws a Rectangle</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: the rectangular
+                    region
+    color         : color of the
+                    rectangle
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.rectboundarycoords"><code>rectboundarycoords</code></a></h3>
+<p><code>py
+def rectboundarycoords(vlist: list) -&gt; list:</code></p>
+<p>Returns the rectangular bounds of a list of 2D vertices</p>
+<pre><code>Args:
+    vlist: list[(x: int, y :int)]
+
+Yields:
+    ((min(x), min(y)),
+     (max(x), max(y)))
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.recvert"><code>recvert</code></a></h3>
+<p><code>py
+def recvert(x1: int, y1: int, x2: int, y2: int) -&gt; list[list[int, int], list[int, int], list[int, int], list[int, int]]:</code></p>
+<p>Creates a list of vertices for a rectangle</p>
+<pre><code>Args:
+    x1, y1, x1, y2: int values
+
+Returns:
+    list of vertices
+    [(x1, y1), (x2, y1),
+     (x2, y2), (x1, y2)]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.reduce24bitimagebits"><code>reduce24bitimagebits</code></a></h3>
+<p><code>py
+def reduce24bitimagebits(Existing24BMPfile: str, NewBMPfile: str, newbits: int, similaritythreshold: float, usemonopal: bool, RGBfactors: list[float, float, float] = None):</code></p>
+<p>Reduce bits used to encode color in a 24-bit BMP</p>
+<pre><code>Args:
+    ExistingBMPfile    : Whole path
+                         to existing file
+    NewBMPfile         : New file to
+                         save changes in
+    newbits            : can be 1, 4
+                         or 8 bits
+    similaritythreshold: how close can
+                         a color be to
+                         another color
+    usemonopal         : True -&gt; image
+                         will be mono
+    RGBfactors         : (r: float,
+                          b: float,
+                          g: float)
+                         values range
+                         from 0 to 1
+                         used only if
+                         usemonopal
+                         is True
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.regpolygonvert"><code>regpolygonvert</code></a></h3>
+<p><code>py
+def regpolygonvert(cx: int, cy: int, r: int, sides: int, angle: float) -&gt; list[list[int, int]]:</code></p>
+<p>Creates a list of int vertices for a regular polygon</p>
+<pre><code>Args:
+    cx, cy: int center of a circle
+    r     : int radius of a circle
+            that circumscribes the
+            regular polygon
+    sides : int sides of the
+            regular polygon
+    angle:  angle of rotation
+            of the polygon in
+            degrees
+
+Returns:
+    list of int vertices
+    [(x, y), ...]
+</code></pre>
+<h3><a href="#Python_BMP.bufresize.resizebufNtimesbigger"><code>resizebufNtimesbigger</code></a></h3>
+<p><code>py
+def resizebufNtimesbigger(buf: array.array, n: int, bits: int) -&gt; array.array:</code></p>
+<p>Resize a buffer n times bigger
+    given a particular bit depth n</p>
+<pre><code>Args:
+    buf : array to resize
+    n   : resize factor
+    bits: bit depth of
+          color info
+          (1, 4, 8, 24) bits
+
+Returns:
+    list
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.resizeNtimesbigger2file"><code>resizeNtimesbigger2file</code></a></h3>
+<p><code>py
+def resizeNtimesbigger2file(ExistingBMPfile: str, NewBMPfile: str, n: int):</code></p>
+<p>Resize a bitmap file n times bigger</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.resizeNtimesbigger"><code>resizeNtimesbigger</code></a></h3>
+<p><code>py
+def resizeNtimesbigger(bmp: array.array, n: int):</code></p>
+<p>Resize an in-memory bmp
+    n times bigger</p>
+<pre><code>Args:
+    buf : array to resize
+    n   : resize factor
+    bits: bit depth of
+          the color info
+          (1, 4, 8, 24)
+
+Returns:
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.resizeNtimessmaller2file"><code>resizeNtimessmaller2file</code></a></h3>
+<p><code>py
+def resizeNtimessmaller2file(ExistingBMPfile: str, NewBMPfile: str, n: int):</code></p>
+<p>Resize a bitmap file n times smaller</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.resizeNtimessmaller"><code>resizeNtimessmaller</code></a></h3>
+<p><code>py
+def resizeNtimessmaller(bmp: array.array, n: int) -&gt; array.array:</code></p>
+<p>Resize a whole image int n times smaller</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    n  : int resize factor
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.bufresize.resizesmaller24bitbuf"><code>resizesmaller24bitbuf</code></a></h3>
+<p><code>py
+def resizesmaller24bitbuf(buf: array.array) -&gt; array.array:</code></p>
+<p>Resize a 24-bit buffer
+    n times smaller</p>
+<pre><code>Args:
+    buf: unsigned byte array
+    n  : buffer multiplier
+
+Returns:
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.colors.RGB2BGRarr"><code>RGB2BGRarr</code></a></h3>
+<p><code>py
+def RGB2BGRarr(r: int, g: int, b: int) -&gt; array.array:</code></p>
+<p>Returns a bgr array from
+    individual r, g and b color
+    component inputs</p>
+<pre><code>Args:
+    r, g, b: byte color values
+
+Returns:
+    unsigned byte BGR array
+</code></pre>
+<h3><a href="#Python_BMP.colors.RGB2BGRbuf"><code>RGB2BGRbuf</code></a></h3>
+<p><code>py
+def RGB2BGRbuf(buf: array.array):</code></p>
+<p>Convert an RGB buffer
+         to a BGR buffer</p>
+<pre><code>Args:
+    buf: unsigned byte array
+         holding RGB data
+
+Returns:
+    byref unsigned byte array
+    holding BGR data
+</code></pre>
+<h3><a href="#Python_BMP.colors.RGB2HSL"><code>RGB2HSL</code></a></h3>
+<p><code>py
+def RGB2HSL(r: int, g: int, b: int) -&gt; list[int, int, int]:</code></p>
+<p>Converts an RGB value to HSL</p>
+<pre><code>Args:
+    r: unsigned byte red value
+    g: unsigned byte green value
+    b: unsigned byte blue value
+
+Returns:
+    [hue: int,  -&gt;  in degrees
+     sat: int,  -&gt;  percentage
+     lum: int]  -&gt;  percentage
+</code></pre>
+<h3><a href="#Python_BMP.colors.RGB2int"><code>RGB2int</code></a></h3>
+<p><code>py
+def RGB2int(r: int, g: int, b: int) -&gt; int:</code></p>
+<p>Pack byte r, g and b color value
+    components to an int
+    representation for a
+    specific color</p>
+<pre><code>Args:
+    r, g, b: color byte values
+
+Returns:
+    int color val
+</code></pre>
+<h3><a href="#Python_BMP.colors.RGBfactors2RGB"><code>RGBfactors2RGB</code></a></h3>
+<p><code>py
+def RGBfactors2RGB(RGBfactors: list[float, float, float], bytelum: int) -&gt; list[int, int, int]:</code></p>
+<p>Mix a byte luminosity value to
+    an rgb triplet that express
+    a color value in [r, g, b]
+    ratios from 0.0 to 1.0 to
+    obtain byte r, g, b values
+    stored in a list [r, g, b]</p>
+<pre><code>Args:
+    lum       : a byte value for
+                luminosity
+    RGBfactors: list[r: float,
+                     g: float,
+                     b: float]
+                float values from
+                0.0 to 1.0
+
+Returns:
+    [r: byte, g: byte, b: byte]
+</code></pre>
+<h3><a href="#Python_BMP.colors.RGBfactorstoBaseandRange"><code>RGBfactorstoBaseandRange</code></a></h3>
+<p><code>py
+def RGBfactorstoBaseandRange(lumrange: list[int, int], rgbfactors: list[float, float, float]):</code></p>
+<p>Get base color luminosity and
+    luminosity range from color
+    expressed as r, g, b  float
+    values and min and max byte
+    luminosity values</p>
+<pre><code>Args:
+    lumrange: [minval: byte
+               maxval: byte]
+
+    rgbfactors: color  as
+                [r: float,
+                 g: float,
+                 b: float]
+
+Returns:
+    base luminosity as
+    [r: byte, g: byte, b: byte]
+
+    luminosity range as
+    [r: byte, g: byte, b: byte]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.RGBpalbrightnessadjust"><code>RGBpalbrightnessadjust</code></a></h3>
+<p><code>py
+def RGBpalbrightnessadjust(bmp: array.array, percentadj: float) -&gt; list:</code></p>
+<p>Copies the RGB palette info from
+a source unsigned byte array to
+a destination unsigned byte array</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    percentadj: signed float
+                brightness adj in %
+
+Returns:
+    list of modified RGB values
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.rotatebits"><code>rotatebits</code></a></h3>
+<p><code>py
+def rotatebits(bits: int) -&gt; int:</code></p>
+<p>Rotates the bits in a byte</p>
+<pre><code>Args:
+    bits: the int 8 bits to rotate
+
+Returns:
+    int value of rotated 8 bits
+</code></pre>
+<h3><a href="#Python_BMP.bufferflip.rotatebitsinbuf"><code>rotatebitsinbuf</code></a></h3>
+<p><code>py
+def rotatebitsinbuf(buf: array.array) -&gt; array.array:</code></p>
+<p>Does a bit rotate to the bytes
+    in an unsigned byte array</p>
+<pre><code>Args:
+    buf: unsigned byte array
+
+Returns:
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.rotvec3D"><code>rotvec3D</code></a></h3>
+<p><code>py
+def rotvec3D(roll: float, pitch: float, yaw: float) -&gt; tuple:</code></p>
+<p>Returns a 3D rotation vector</p>
+<pre><code>Args:
+    All input arguements are in
+    degrees (roll, pitch, yaw)
+
+Returns:
+    tuple ((float, float),
+           (float, float),
+           (float, float))
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.roundpen"><code>roundpen</code></a></h3>
+<p><code>py
+def roundpen(bmp: array.array, point: list, penradius: int, color: int):</code></p>
+<p>Draws a circle or a point
+depending on the penradius
+with a given color</p>
+<pre><code>Args:
+    bmp      : unsigned byte array
+               with bmp format
+    point    : (x:uint,y:uint)
+               centerpoint
+    penradius: radius of the
+               pen in pixels
+    color    : color of the pen
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.roundvect"><code>roundvect</code></a></h3>
+<p><code>py
+def roundvect(v: list[numbers.Number]) -&gt; list[int]:</code></p>
+<p>Rounds off the components of a vector
+   (list of floats -&gt; list of ints)</p>
+<pre><code>Args:
+    v: list of floats
+
+Returns:
+    list of ints
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.saveBMP"><code>saveBMP</code></a></h3>
+<p><code>py
+def saveBMP(filename: str, bmp: array.array):</code></p>
+<p>Saves bitmap to file</p>
+<pre><code>Args:
+    filename: full path to
+              the file to be saved
+    bmp     : unsigned byte array
+              with the layout of
+              a bitmap file
+Returns:
+    A Bitmap File
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.setBMP2monochrome"><code>setBMP2monochrome</code></a></h3>
+<p><code>py
+def setBMP2monochrome(bmp: array.array, RGBfactors: list[float, float, float]) -&gt; list:</code></p>
+<p>Sets a bitmap to use a monochrome palette</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    RGBfactors: (r, g, b)
+                all values range
+                from 0.0 to 1.0
+
+Returns:
+    list of modified RGB values
+    byref modified byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.setBMPimgbytes"><code>setBMPimgbytes</code></a></h3>
+<p><code>py
+def setBMPimgbytes(bmp: array.array, buf: array.array):</code></p>
+<p>Sets the raw image buffer of a bitmap</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+    buf: array of unsigned bytes
+
+Returns:
+    byref modified  unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.setbmppal"><code>setbmppal</code></a></h3>
+<p><code>py
+def setbmppal(bmp: array.array, pallist: list):</code></p>
+<p>Sets the RGB palette of a bitmap</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    pallist: [(r: byte,
+               g: byte,
+               b: byte), ...]
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.setmax"><code>setmax</code></a></h3>
+<p><code>py
+def setmax(val: numbers.Number, maxval: numbers.Number) -&gt; numbers.Number:</code></p>
+<p>Set the value of val to maxval if val &gt; maxval</p>
+<pre><code>Args:
+    val   : numeric variable
+    maxval: upper limit of variable
+
+Returns:
+    Number
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.setmin"><code>setmin</code></a></h3>
+<p><code>py
+def setmin(val: numbers.Number, minval: numbers.Number) -&gt; numbers.Number:</code></p>
+<p>Set the value of val to minval if val &lt; minval</p>
+<pre><code>Args:
+    val   : numeric variable
+    minval: lower limit of variable
+
+Returns:
+    Number
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.setminmax"><code>setminmax</code></a></h3>
+<p><code>py
+def setminmax(val: numbers.Number, minval: numbers.Number, maxval: numbers.Number) -&gt; numbers.Number:</code></p>
+<p>Set the value of val to minval if val &lt; minval
+or the value of val to maxval if val &gt; maxval</p>
+<pre><code>Args:
+    val   : numeric variable
+    minval: lower limit of variable
+    maxval: upper limit of variable
+
+Returns:
+    Number
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.setnewpalfromsourcebmp"><code>setnewpalfromsourcebmp</code></a></h3>
+<p><code>py
+def setnewpalfromsourcebmp(sourcebmp: array.array, newbmp: array.array, similaritythreshold: float) -&gt; list:</code></p>
+<p>Copies the RGB palette info from
+a source unsigned byte array
+to a destination unsigned byte array
+(source and destination
+can have different bit depths)</p>
+<pre><code>Args:
+    sourceBMP, newBMP  : unsigned
+                         byte arrays
+                         with
+                         bmp format
+    similaritythreshold: how close
+                         can a color
+                         in a palette
+                         entry be to
+                         another color
+
+Returns:
+    byRef modified newBMP
+    (unsigned byte array) and a
+    list of new palette entries
+    based on source bitmap
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.setRGBpal"><code>setRGBpal</code></a></h3>
+<p><code>py
+def setRGBpal(bmp: array.array, c: int, r: int, g: int, b: int):</code></p>
+<p>Sets the r,g,b values of color c in a bitmap</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    r, g, b: unsigned byte values
+             for red, green and
+             blue
+    c      : unsigned int color
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.showsimilarparts"><code>showsimilarparts</code></a></h3>
+<p><code>py
+def showsimilarparts(inputfile1: str, inputfile2: str, diff_file: str):</code></p>
+<p>Compares 2 files and saves the similar parts to a BMP</p>
+<pre><code>Args:
+    inputfile1: Whole paths
+    inputfile2  to existing files
+
+    diff_file : New file to
+                store similar parts
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.sortrecpoints"><code>sortrecpoints</code></a></h3>
+<p><code>py
+def sortrecpoints(x1: int, y1: int, x2: int, y2: int):</code></p>
+<p>Sorts the x and y values that sets a rectangular area</p>
+<pre><code>Args:
+    x1, x2: int x coordinates
+    y1, y2: int y coordinates
+
+Returns:
+    sorted coordinates
+    x1, y1, x2, y2
+    such that
+    x1 &lt; x2 and y1 &lt; y2
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.sphere2file"><code>sphere2file</code></a></h3>
+<p><code>py
+def sphere2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, rgbfactors: list[float, float, float]):</code></p>
+<p>Renders a sphere</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x, y, r        : center (x, y)
+                     and radius r
+    rgbfactors     : (r, g, b)
+                     values
+                     range from
+                     0.0 to 1.0
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.sphere"><code>sphere</code></a></h3>
+<p><code>py
+def sphere(bmp: array.array, x: int, y: int, r: int, rgbfactors: list[float, float, float]):</code></p>
+<p>Draws a Rendered Sphere</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : center of sphere
+                in the image
+    r         : radius of sphere
+                in pixels
+    rgbfactors: (r,g,b) r, g and b
+                values range from
+                0.0 to 1.0
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.spherevertandsurface"><code>spherevertandsurface</code></a></h3>
+<p><code>py
+def spherevertandsurface(vcen: list[float, float, float], r: float, deganglestep: float) -&gt; tuple:</code></p>
+<p>Returns a list of sparse
+    vertices and tiled surfaces
+    for a sphere</p>
+<pre><code>Args:
+    vcen       : [x: float, center
+                  y: float, of the
+                  z: float] sphere
+    r           : spherical radius
+    deganglestep: angle step between
+    vertices that controls how sparse
+    the list will be
+
+Returns:
+    list of vertices and surfaces
+    for plot3Dsolid()
+    see Hello_DiscoBall.py
+    and Hello_Globe.py
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.spiralcontrolpointsvert"><code>spiralcontrolpointsvert</code></a></h3>
+<p><code>py
+def spiralcontrolpointsvert(x: int, y: int, step: int, growthfactor: float, turns: int):</code></p>
+<p>Returns a list of 2D vertices of a Square Spiral</p>
+<pre><code>Args:
+    x, y: int centerpoint
+              coordinates
+    step: int step increment
+    growthfactor: float multiplier
+                  to step increment
+                  to make exponential
+                  spirals
+    turns: number of turns of the
+           spiral
+
+Returns:
+    list of vertices of the spiral
+    list[[x: int, y: int]]
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.spirographvert"><code>spirographvert</code></a></h3>
+<p><code>py
+def spirographvert(x: int, y: int, r: int, l: float, k: float, delta: float, lim: float):</code></p>
+<p>Returns a list(int, int) of
+2D vertices along a path defined
+by a spirograph with scaling factor r
+and dimensionless parametersl and k
+with an origin set at (x, y)</p>
+<pre><code>Args:
+    x, y : center of the spirograph
+    r    : spirograph scaling factor
+    l, k : spirograph shape parameters
+    delta: angle increment in radians
+    lim  : angle limit in radians
+
+Returns:
+    The vertices of an
+    spirograph in a list
+    [[x: int, y: int], ...]
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.subvect"><code>subvect</code></a></h3>
+<p><code>py
+def subvect(u: list[numbers.Number], v: list[numbers.Number]) -&gt; list[numbers.Number]:</code></p>
+<p>Subtracts vectors u and v by subtracting their components</p>
+<pre><code>Args:
+    u, v: list of ints or floats
+
+Returns:
+    list of ints or floats
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.surfplot3Dvertandsurface"><code>surfplot3Dvertandsurface</code></a></h3>
+<p><code>py
+def surfplot3Dvertandsurface(x1: int, y1: int, x2: int, y2: int, step: int, fnxy: Callable) -&gt; tuple:</code></p>
+<p>Does a 3D surface plot of a
+    function z = fnxy(x, y)</p>
+<pre><code>Args:
+    x1, y1, x2, y2: set drawing area
+    fnxy          : fnxy(x, y)
+                    Callable
+                    (lambda or fn)
+
+Returns:
+    list of vertices and surfaces
+    for plot3Dsolid()
+    see Hello_3D_surfaceplot.py
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.swapcolors"><code>swapcolors</code></a></h3>
+<p><code>py
+def swapcolors(bmp: array.array, p1: list, p2: list):</code></p>
+<p>Swaps the colors of two points in a BMP</p>
+<pre><code>Args:
+    bmp   : unsigned byte array
+            with bmp format
+    p1, p2: endpoints of the
+            line(x: uint, y: uint)
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.conditionaltools.swapif"><code>swapif</code></a></h3>
+<p><code>py
+def swapif(val1: &lt;built-in function any&gt;, val2: &lt;built-in function any&gt;, boolcond: bool):</code></p>
+<p>Swaps val1 and val2 if
+    boolcond is true</p>
+<pre><code>Args:
+    boolcond  : an expression that
+                evaluates as either
+                True or False
+    val1, val2: values to swap if
+                boolcond is True
+
+Returns:
+    values depending on boolcond
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.swapxy"><code>swapxy</code></a></h3>
+<p><code>py
+def swapxy(v: list) -&gt; list:</code></p>
+<p>Swaps the first two values in a list</p>
+<pre><code>Args:
+    list[x, y]
+
+Returns:
+    list[y, x]
+</code></pre>
+<h3><a href="#Python_BMP.solids3D.tetrahedravert"><code>tetrahedravert</code></a></h3>
+<p><code>py
+def tetrahedravert(x: float) -&gt; list[list[float, float, float]]:</code></p>
+<p>Returns a list of vertices
+    for a tetrahedron</p>
+<pre><code>Args:
+    x: length of a side
+
+Returns:
+    list (x: float,
+          y: float,
+          z: float)
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.thickcircle"><code>thickcircle</code></a></h3>
+<p><code>py
+def thickcircle(bmp: array.array, x: int, y: int, r: int, penradius: int, color: int):</code></p>
+<p>Draws a Thick Circle</p>
+<pre><code>Args:
+    bmp      : unsigned byte array
+               with bmp format
+    x, y, r  : center (x, y)
+               and radius r
+    penradius: radius of round pen
+    color    : color of the circle
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.thickellipserot"><code>thickellipserot</code></a></h3>
+<p><code>py
+def thickellipserot(bmp: array.array, x: int, y: int, b: int, a: int, degrot: float, penradius: int, color: int):</code></p>
+<p>Draws a Thick Ellipse</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : center of ellipse
+    b, a      : major and minor axis
+    degrot    : rotation of
+                the ellipse in degrees
+    penradius : thickness of the pen
+    color     : color of the ellipse
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.thickencirclearea2file"><code>thickencirclearea2file</code></a></h3>
+<p><code>py
+def thickencirclearea2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, rgbfactors: list[float, float, float]):</code></p>
+<p>"Encircle area with a gradient and save to a file</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+
+    x, y      : center of circle
+    r         : radius of circle
+    rgbfactors: (r, g, b) values
+                are from 0.0 to 1.0
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.thickencirclearea"><code>thickencirclearea</code></a></h3>
+<p><code>py
+def thickencirclearea(bmp: array.array, x: int, y: int, r: int, rgbfactors: list[float, float, float]):</code></p>
+<p>Encircle area with a gradient</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    x, y      : center of circle
+    r         : radius of circle
+    rgbfactors: (r,g,b) r, g and b
+                values are 0 to 1
+                unsigned floats
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.thickplotpoly"><code>thickplotpoly</code></a></h3>
+<p><code>py
+def thickplotpoly(bmp: array.array, vertlist: list[list[numbers.Number, numbers.Number]], penradius: int, color: int):</code></p>
+<p>Draws a polygon of a given color and thickness</p>
+<pre><code>Args:
+    bmp      : unsigned byte array
+               with bmp format
+    vertlist : [(x, y)...]
+               list of vertices
+    penradius: radius of pen
+    color    : color of the polygon
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.thickroundline"><code>thickroundline</code></a></h3>
+<p><code>py
+def thickroundline(bmp: array.array, p1: list, p2: list, penradius: int, color: int):</code></p>
+<p>Draw a Thick Rounded Line</p>
+<pre><code>Args:
+    bmp       : unsigned byte array
+                with bmp format
+    p1, p2    : (x, y) endpoints
+                of the line
+    penradius : radius of pen
+                in pixels
+    color     : color of the line
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.thresholdadjcircregion2file"><code>thresholdadjcircregion2file</code></a></h3>
+<p><code>py
+def thresholdadjcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, lumrange: list[int, int]):</code></p>
+<p>Threshold adjustment to a circular region in a 24-bit BMP</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+    lumrange       : (byte:byte)
+                     threshold range
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.thresholdadjcircregion"><code>thresholdadjcircregion</code></a></h3>
+<p><code>py
+def thresholdadjcircregion(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int]):</code></p>
+<p>Threshold adjustment to a circular area</p>
+<pre><code>Args:
+    bmp      : unsigned byte array
+               with bmp format
+    x, y, r  : centerpoint (x, y)
+               and radius r
+    lumrange : (byte: byte)
+               threshold adjustment
+               luminosity range
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.thresholdadjto24bitimage"><code>thresholdadjto24bitimage</code></a></h3>
+<p><code>py
+def thresholdadjto24bitimage(bmp: array.array, lumrange: list[int, int]):</code></p>
+<p>Threshold adjustment to a whole BMP</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    lumrange: (byte: byte)
+              threshold adjustment
+              luminosity range
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.thresholdadjto24bitregion"><code>thresholdadjto24bitregion</code></a></h3>
+<p><code>py
+def thresholdadjto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):</code></p>
+<p>Threshold adjustment to a rectangular area</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: ints that defines
+                    the rectangular
+                    region
+    lumrange      : (byte:byte)
+                    threshold
+                    adjustment
+                    luminosity range
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.thresholdadjust2file"><code>thresholdadjust2file</code></a></h3>
+<p><code>py
+def thresholdadjust2file(ExistingBMPfile: str, NewBMPfile: str, lumrange: list[int, int]):</code></p>
+<p>Apply a threshold adjustment</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    lumrange       : (byte:byte)
+                     threshold
+                     to apply
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.colors.thresholdadjust"><code>thresholdadjust</code></a></h3>
+<p><code>py
+def thresholdadjust(rgb: list[int, int, int], lumrange: list[int, int]) -&gt; list[int, int, int]:</code></p>
+<p>Apply a threshold adjustment
+    to a rgb</p>
+<pre><code>Args:
+    rgb: color as [r: byte,
+                   g: byte,
+                   b: byte]
+    lumrange: [min: byte,
+               max: byte]
+              brightness
+              threshold
+              adjustment
+              limits
+
+Returns:
+    a brightness threshold adjusted
+    color as [r: byte,
+              g: byte,
+              b: byte]
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.trans"><code>trans</code></a></h3>
+<p><code>py
+def trans(vlist: list[list[numbers.Number]], u: list[numbers.Number]) -&gt; list[list[numbers.Number]]:</code></p>
+<p>Translates list of vectors by adding vector u
+to all vectors in the list of vectors</p>
+<pre><code>Args:
+    vlist: list of vectors
+    u    : translation vector
+
+Returns:
+    list of vectors
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.upgradeto24bitimage2file"><code>upgradeto24bitimage2file</code></a></h3>
+<p><code>py
+def upgradeto24bitimage2file(ExistingBMPfile: str, NewBMPfile: str):</code></p>
+<p>Upgrades a bitmap file to 24-bits</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.upgradeto24bitimage"><code>upgradeto24bitimage</code></a></h3>
+<p><code>py
+def upgradeto24bitimage(bmp: array.array):</code></p>
+<p>Upgrade an image to 24-bits</p>
+<pre><code>Args:
+    bmp: unsigned byte array
+         with bmp format
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.userdef2Dcooordsys2screenxy"><code>userdef2Dcooordsys2screenxy</code></a></h3>
+<p><code>py
+def userdef2Dcooordsys2screenxy(x: int, y: int, lstcooordinfo: list):</code></p>
+<p>2D coordinate trans from user to screen</p>
+<pre><code>Args:
+    x, y         : user coordinates
+    lstcooordinfo: info on how to
+                   transform the
+                   2D coordinate
+                   system
+                   [origin,
+                    steps,
+                    xylimits,
+                    xyvalstarts,
+                    xysteps]
+                    all
+                    (x: int,
+                     y: int) pairs
+
+Returns:
+    [x: int, y: int] screen coordinates
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.vertBMPbitBLTget"><code>vertBMPbitBLTget</code></a></h3>
+<p><code>py
+def vertBMPbitBLTget(bmp: array.array, x: int, y1: int, y2: int) -&gt; array.array:</code></p>
+<p>Gets vertical slice to a new array</p>
+<pre><code>Args:
+    bmp   : unsigned byte array
+            with bmp format
+    x     : unsigned int x
+    y1, y2  and y coordinates
+
+Returns:
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.vertbrightnessgrad2circregion2file"><code>vertbrightnessgrad2circregion2file</code></a></h3>
+<p><code>py
+def vertbrightnessgrad2circregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, lumrange: list[int, int]):</code></p>
+<p>Vertical brightness gradient to a circular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes to
+    x, y, r        : center (x, y)
+                     and radius r
+                     of a circular
+                     region
+    lumrange       : brightness
+                     gradient
+                     (byte: byte)
+                     adjust
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.vertbrightnessgrad2circregion"><code>vertbrightnessgrad2circregion</code></a></h3>
+<p><code>py
+def vertbrightnessgrad2circregion(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int]):</code></p>
+<p>Vertical brightness gradient adjustment to a circular area</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    x, y, r : center (x,y)
+              and radius r
+    lumrange: [byte,byte]
+              that define
+              the range of
+              luminosity
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.verticalbrightnessgrad2file"><code>verticalbrightnessgrad2file</code></a></h3>
+<p><code>py
+def verticalbrightnessgrad2file(ExistingBMPfile: str, NewBMPfile: str, lumrange: list[int, int]):</code></p>
+<p>Applies a Vertical brightness gradient</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    lumrange       : (byte:byte)
+                     defines the
+                     brightness
+                     gradient
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.verticalbrightnessgradregion2file"><code>verticalbrightnessgradregion2file</code></a></h3>
+<p><code>py
+def verticalbrightnessgradregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):</code></p>
+<p>Vertical brightness gradient to a rectangular area</p>
+<pre><code>Args:
+    ExistingBMPfile: Whole path to
+                     existing file
+    NewBMPfile     : New file to
+                     save changes in
+    x1, y1, x2, y2 : defines the
+                     rectangular
+                     region
+    lumrange       : (byte:byte)
+                     defines the
+                     brightness
+                     gradient
+
+Returns:
+    new bitmap file
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.verticalbrightnessgradto24bitimage"><code>verticalbrightnessgradto24bitimage</code></a></h3>
+<p><code>py
+def verticalbrightnessgradto24bitimage(bmp: array.array, lumrange: list[int, int]):</code></p>
+<p>Applies a vertical brightness gradient</p>
+<pre><code>Args:
+    bmp     : unsigned byte array
+              with bmp format
+    lumrange: (byte: byte) the
+              brightness gradient
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.verticalbrightnessgradto24bitregion"><code>verticalbrightnessgradto24bitregion</code></a></h3>
+<p><code>py
+def verticalbrightnessgradto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):</code></p>
+<p>Apply a vertical brightness gradient
+to a rectangular area in a 24-bit bitmap</p>
+<pre><code>Args:
+    bmp          :  unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: defines the
+                    rectangular
+                    region
+    lumrange      : (byte:byte)
+                    brightness
+                    gradient
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.primitives2D.verticalvert"><code>verticalvert</code></a></h3>
+<p><code>py
+def verticalvert(x: int, y1: int, y2: int, dy: int) -&gt; list[list[int, int]]:</code></p>
+<p>Creates a list of int vertices
+along a vertical line with int step dy</p>
+<pre><code>Args:
+    x : int constant x
+    y1: int start point
+    y2: int end point
+    dy: int y step increment
+
+Returns:
+    list of int vertices
+    [(x, y), ...]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.vertline"><code>vertline</code></a></h3>
+<p><code>py
+def vertline(bmp: array.array, x: int, y1: int, y2: int, color: int):</code></p>
+<p>Draw a Vertical Line</p>
+<pre><code>Args:
+    bmp  : unsigned byte array
+           with bmp format
+    x    : constant x value
+           of the line
+    y1   : starts at y1
+    y2   : ends at y2
+    color: color of the line
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.vertlinevert"><code>vertlinevert</code></a></h3>
+<p><code>py
+def vertlinevert(bmp: array.array, vlist: list[list[int, int]], linelen: int, yadj: int, color: int):</code></p>
+<p>Vertical line marks at vertices in vlist</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    vlist  : [(x,y),...] the
+             list of vertices
+    linelen: lenght of the
+             vertical lines
+    yadj   : sets an adjustment
+             for y coordinates
+    color  : color of the line
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.verttrans"><code>verttrans</code></a></h3>
+<p><code>py
+def verttrans(bmp: array.array, trans: str):</code></p>
+<p>Do vertical image transforms</p>
+<pre><code>Args:
+    bmp : unsigned byte array
+          with bmp format
+    tran: single letter
+          transform code
+          'T' - mirror top-half
+          'B' - mirror bottom-half
+          'F' - flip
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.verttransformincircregion"><code>verttransformincircregion</code></a></h3>
+<p><code>py
+def verttransformincircregion(bmp: array.array, x: int, y: int, r: int, trans: str):</code></p>
+<p>Applies a vertical transform to
+a circular region with a center
+at (x, y) and radius r</p>
+<pre><code>Args:
+    bmp    : unsigned byte array
+             with bmp format
+    x, y, r: center (x, y)
+             and radius r
+             of region
+    trans  :single letter
+            transform code
+            'T' mirror top
+            'B' mirror bottom
+            'F' flip
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.verttransregion"><code>verttransregion</code></a></h3>
+<p><code>py
+def verttransregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, trans: str):</code></p>
+<p>Do vertical image transforms
+    in a rectangular region</p>
+<pre><code>Args:
+    bmp            : unsigned
+                     byte array
+                     with bmp format
+    x1, y1, x2, y2 : ints that
+                     defines the
+                     rectangular
+                     region
+    trans          : single letter
+                     transform code
+            'T' - mirror top half
+            'B' - mirror bottom half
+            'F' - flip
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.vmag"><code>vmag</code></a></h3>
+<p><code>py
+def vmag(v: list[float]) -&gt; float:</code></p>
+<p>Compute the Magnitude or length of a vector v
+of arbitrary dimension n equal to len(v)</p>
+<pre><code>Args:
+    v: list of ints or floats
+
+Returns:
+    float
+</code></pre>
+<h3><a href="#Python_BMP.inttools.writeint"><code>writeint</code></a></h3>
+<p><code>py
+def writeint(offset: int, cnt: int, arr: array.array, value: int):</code></p>
+<p>Writes an integer value to an
+    unsigned byte array</p>
+<pre><code>Args:
+    offset: uint starting offset in
+            buffer or array
+            to write to
+    cnt   : uint length of int data
+            to write
+    arr   : unsigned byte array
+            to write int data in
+    value : value of uint data to
+            write in buffer or
+            array
+
+Returns:
+    byref unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.mathlib.xorvect"><code>xorvect</code></a></h3>
+<p><code>py
+def xorvect(u: list[int], v: list[int]) -&gt; list[int]:</code></p>
+<p>Applies a xor operation of between the elements of
+two lists of ints</p>
+<pre><code>Args:
+    v      : list[int]
+    bitmask: int
+
+Returns:
+    list[int]
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.XYaxis"><code>XYaxis</code></a></h3>
+<p><code>py
+def XYaxis(bmp: array.array, origin: list[int, int], steps: list[int, int], xylimits: list[int, int], xyvalstarts: list[numbers.Number, numbers.Number], xysteps: list[numbers.Number, numbers.Number], color: int, textcolor: int, showgrid: bool, gridcolor: int):</code></p>
+<p>XY axis with tick marks and numbers</p>
+<pre><code>Args:
+    bmp      : unsigned byte array
+               with bmp format
+    origin   : (x, y) on screen
+                origin point
+                of the axis
+    steps    : (x, y) steps between
+               tick marks onscreen
+    xylimits : (x, y) sets where the
+               graph ends onscreen
+    xyvalstarts: (x, y) sets the
+                  start point of
+                  x and y number
+                  lines
+    xysteps   : (x, y) sets the
+                number increment
+                along the x and y
+                numberlines
+    color    : color of the lines
+    textcolor: color of the
+               numberline text
+    showgrid : True -&gt; display
+                       gridline
+               False -&gt; no grid
+    gridcolor: color of the grid
+
+Returns:
+    byref modified
+    unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.xygrid"><code>xygrid</code></a></h3>
+<p><code>py
+def xygrid(bmp: array.array, x1: int, y1: int, x2: int, y2: int, xysteps: list[int, int], color: int):</code></p>
+<p>Draws a grid</p>
+<pre><code>Args:
+    bmp           : unsigned
+                    byte array
+                    with bmp format
+    x1, y1, x2, y2: sets limits
+                    of the grid
+    xysteps       : [x, y] sets the
+                    increments
+    color         : sets the color
+                    of the grid
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.xygridvec"><code>xygridvec</code></a></h3>
+<p><code>py
+def xygridvec(bmp: array.array, u: list[int, int], v: list[int, int], steps: list[int, int], gridcolor: int):</code></p>
+<p>Grid using (x, y) point pairs u and v</p>
+<pre><code>Args:
+    bmp  : unsigned byte array
+           with bmp format
+    u, v : (x, y) sets limits
+            of the  grid
+    steps: (x, y) -&gt; sets the
+           increments for x and y
+    color: sets the color
+           of the grid
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>
+<h3><a href="#Python_BMP.BITMAPlib.XYscatterplot"><code>XYscatterplot</code></a></h3>
+<p><code>py
+def XYscatterplot(bmp: array.array, XYdata: list, XYcoordinfo: list, showLinearRegLine: bool, reglinecolor: int):</code></p>
+<p>Create a XY scatterplot</p>
+<pre><code>Args:
+    bmp             : unsigned
+                      byte array
+                      with bmp format
+    XYData          : [[x,y,
+                      radius
+                      (max radius is 5),
+                      isfilled],...]
+    lstcooordinfo   : info on how to
+                      transform the
+                      coordinate system
+                      [origin,
+                       -&gt; origin point
+                          on screen
+                      steps,
+                       -&gt; on screen steps
+                      xylimits,
+                       -&gt; x and y
+                          clipping limit
+                      xyvalstarts,
+                       -&gt; number line
+                          start values
+                      xysteps
+                       -&gt; increments for
+                          the number lines
+                        ]
+                      * (x:int,y:int) pairs
+    howLinearRegLine: True -&gt; display linear
+                              regression line
+    reglinecolor    : color of linear
+                      regression line
+
+Returns:
+    byref modified unsigned byte array
+</code></pre>

--- a/docs/BitmapLib_Doc.md
+++ b/docs/BitmapLib_Doc.md
@@ -1,29 +1,1056 @@
 # Python BMP Public API
 
-**def addvect(u: list[numbers.Number], v: list[numbers.Number]) -> list[numbers.Number]:**
->Add vectors u and v by adding their components
+### [`_1bmof`](#Python_BMP.BITMAPlib._1bmof)
+
+```py
+def _1bmof(bmp: array.array, x: int, y: int) -> int:
+```
+
+Get the offset in a byte array
+with 1 bit color data given x and y data
+
+    Args:
+        bmp : unsigned byte array
+              with bmp format
+        x, y: unsigned int value
+              of location in
+              x-axis and y-axis
+    
+    Returns:
+        int value of offset to that data in byte array
+
+
+### [`_1bmofhd`](#Python_BMP.BITMAPlib._1bmofhd)
+
+```py
+def _1bmofhd(bmp: array.array, x: int, y: int) -> int:
+```
+
+Get the offset in a byte array
+    with 1 bit color data given
+    x and y with adjustments
+    made for a bmp header
+
+    Args:
+        bmp : unsigned byte array
+              with bmp format
+        x, y: unsigned int value
+              of location in
+              x-axis and y-axis
+    
+    Returns:
+        int value of offset to that data in byte array
+
+
+### [`_24bmof`](#Python_BMP.BITMAPlib._24bmof)
+
+```py
+def _24bmof(bmp: array.array, x: int, y: int) -> int:
+```
+
+Get the offset in a byte array with RGB data given x and y
+
+    Args:
+        bmp: unsigned byte array
+             with bmp format
+        x,y: unsigned int value
+             of location in
+             x-axis and y-axis
+    
+    Returns:
+        int value of offset to that data in byte array
+
+
+### [`_24bmofhd`](#Python_BMP.BITMAPlib._24bmofhd)
+
+```py
+def _24bmofhd(bmp: array.array, x: int, y: int) -> int:
+```
+
+Get the offset in a byte array
+with RGB data given x and y with bmp header
+
+    Args:
+        bmp:  unsigned byte array
+              with bmp format
+        x, y: unsigned int value
+              of location in
+              x-axis and y-axis
+    
+    Returns:
+        int value of offset to that data in byte array
+
+
+### [`_4bmof`](#Python_BMP.BITMAPlib._4bmof)
+
+```py
+def _4bmof(bmp: array.array, x: int, y: int) -> int:
+```
+
+Get the offset in a byte array
+with 4 bit color data given x and y data
+
+    Args:
+        bmp:  unsigned byte array
+              with bmp format
+        x, y: unsigned int value
+              of location in
+              x-axis and y-axis
+    
+    Returns:
+        int value of offset to that data in byte array
+
+
+### [`_4bmofhd`](#Python_BMP.BITMAPlib._4bmofhd)
+
+```py
+def _4bmofhd(bmp: array.array, x: int, y: int) -> int:
+```
+
+Get the offset in a byte array
+with 4 bit color data given
+x and y with adjustments
+made due to a header
+
+    Args:
+        bmp : unsigned byte array
+              with bmp format
+        x, y: unsigned int value
+              of location in
+              x-axis and y-axis
+    
+    Returns:
+        int value of offset to that data in byte array
+
+
+### [`_8bmof`](#Python_BMP.BITMAPlib._8bmof)
+
+```py
+def _8bmof(bmp: array.array, x: int, y: int) -> int:
+```
+
+Get the offset in a byte array
+with 8 bit color data given x and y data
+
+    Args:
+        bmp:  unsigned byte array
+              with bmp format
+        x, y: unsigned int value
+              of location in
+              x-axis and y-axis
+    
+    Returns:
+        int value of offset to
+        that data in byte array
+
+
+### [`_8bmofhd`](#Python_BMP.BITMAPlib._8bmofhd)
+
+```py
+def _8bmofhd(bmp: array.array, x: int, y: int) -> int:
+```
+
+Get the offset in a byte array
+with 8 bit color data given
+x and y with adjustments
+made for a bmp header
+
+    Args:
+        bmp : unsigned byte array
+              with bmp format
+        x, y: unsigned int value
+              of location in
+              x-axis and y-axis
+    
+    Returns:
+        int value of offset to
+        that data in byte array
+
+
+### [`_bmmeta`](#Python_BMP.BITMAPlib._bmmeta)
+
+```py
+def _bmmeta(x: int, y: int, bits: int) -> tuple:
+```
+
+Computes bitmap meta data
+
+    Args:
+        x, y : unsigned int
+               values of the
+               x and y dimension
+        bits : bit depth (1, 4, 8, 24)
+    
+    Returns:
+        unsigned int values for
+        (filesize, headersize,
+        xdim, ydim, bitdepth)
+
+
+### [`_BMoffset`](#Python_BMP.BITMAPlib._BMoffset)
+
+```py
+def _BMoffset(bmp: array.array, x: int, y: int) -> int:
+```
+
+Returns the offset given a bmp and (x, y) coordinates
+
+    Args:
+        bmp : unsigned byte array
+              with bmp format
+        x, y: unsigned int location
+              in x-axis and y-axis
+    
+    Returns:
+        unsigned int offset to data in buffer
+
+
+### [`_BMoffsethd`](#Python_BMP.BITMAPlib._BMoffsethd)
+
+```py
+def _BMoffsethd(bmp: array.array, x: int, y: int) -> int:
+```
+
+Returns the offset given a bmp
+and (x, y) coordinates with header considered
+
+    Args:
+        bmp : unsigned byte array
+              with bmp format
+        x, y: unsigned int location
+              in x-axis and y-axis
+    
+    Returns:
+        unsigned int offset to data in buffer
+
+
+### [`_cmpimglines`](#Python_BMP.BITMAPlib._cmpimglines)
+
+```py
+def _cmpimglines(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Callable):
+```
+
+
+
+    
+
+
+### [`_flsz`](#Python_BMP.BITMAPlib._flsz)
+
+```py
+def _flsz(bmp: array.array) -> int:
+```
+
+Get the file size of a win bmp
+    from its bmp header
+
+    Args:
+        bmp: unsigned byte array
+             with bmp format
+    
+    Returns:
+        unsigned int value of size
+        of the bmp header
+
+
+### [`_fnwithpar2vertslice`](#Python_BMP.BITMAPlib._fnwithpar2vertslice)
+
+```py
+def _fnwithpar2vertslice(bmp: array.array, x: int, y1: int, y2: int, func: Callable, funcparam):
+```
+
+Apply a user defined function to vertical slices
+
+    Args:
+        bmp       : unsigned byte array
+                    with bmp format
+        x, y1, y2 : unsigned int
+                    x and y coordinates
+        func      : user defined function
+        funcparam : parameters of
+                    the user defined
+                    function
+    
+    Returns:
+        byref modified unsigned byte array
+
+
+### [`_getbmflsz`](#Python_BMP.BITMAPlib._getbmflsz)
+
+```py
+def _getbmflsz(x: int, y: int, bits: int) -> int:
+```
+
+Computes bitmap file size
+
+    Args:
+        x, y: unsigned int value
+              of x and y dimensions
+        bits: bit depth (1, 4, 8, 24)
+    
+    Returns:
+        int value of file size
+
+
+### [`_getBMofffunc`](#Python_BMP.BITMAPlib._getBMofffunc)
+
+```py
+def _getBMofffunc(bmp: array.array):
+```
+
+Returns the correct function
+to use in computing the offset
+in a given bitmap
+
+    Args:
+        bmp: unsigned byte array
+             with bmp format
+    
+    Returns:
+        function to compute offsets
+
+
+### [`_getBMoffhdfunc`](#Python_BMP.BITMAPlib._getBMoffhdfunc)
+
+```py
+def _getBMoffhdfunc(bmp: array.array):
+```
+
+Returns the correct function
+to use in computing offsets
+with headers in a given bmp
+
+    Args:
+        bmp: unsigned byte array
+             with bmp format
+    
+    Returns:
+        function to compute offsets with headers
+
+
+### [`_getclrbits`](#Python_BMP.BITMAPlib._getclrbits)
+
+```py
+def _getclrbits(bmp: array.array) -> int:
+```
+
+Get the bit depth of BMP
+
+    Args:
+        bmp: unsigned byte array
+             with bmp format
+    
+    Returns:
+        int value of bit depth
+        (1, 4, 8, 24) bits
+
+
+### [`_hdsz`](#Python_BMP.BITMAPlib._hdsz)
+
+```py
+def _hdsz(bmp: array.array) -> int:
+```
+
+Get the header size of a BMP
+
+    Args:
+        bmp: unsigned byte array
+             with bmp format
+    
+    Returns:
+        int value of header size
+
+
+### [`_pdbytes`](#Python_BMP.BITMAPlib._pdbytes)
+
+```py
+def _pdbytes(x: int, bits: int) -> int:
+```
+
+Get the number of bytes used to pad for
+32-bit alignment given x dimension and bit depth
+
+    Args:
+        x   : unsigned int value of
+              x-dimension
+        bits: unsigned int value of
+              bit depth (1, 4, 8, 24)
+    
+    Returns:
+        int value of number of pad bytes
+
+
+### [`_setflsz`](#Python_BMP.BITMAPlib._setflsz)
+
+```py
+def _setflsz(bmp: array.array, size: int):
+```
+
+Set the file size of a BMP
+
+    Args:
+        bmp  : unsigned byte array
+               with bmp format
+        size : unsigned int value
+               of size of
+               the bmp file
+    
+    Returns:
+        byref modified unsigned byte array
+        with new file size
+
+
+### [`_sethdsz`](#Python_BMP.BITMAPlib._sethdsz)
+
+```py
+def _sethdsz(bmp: array.array, hdsize: int):
+```
+
+Set the header size of a win bmp
+
+    Args:
+        bmp   : unsigned byte array
+                with bmp format
+        hdsize: unsigned int value
+                of size of the
+                bmp header
+    
+    Returns:
+        byref modified byte array
+        with new header size
+
+
+### [`_setmeta`](#Python_BMP.BITMAPlib._setmeta)
+
+```py
+def _setmeta(bmpmeta: list) -> array.array:
+```
+
+Creates a new bitmap
+    with the properties set
+    by bmpmeta to
+    a new unsigned byte array
+
+    Args:
+        bmpmeta: [filesize, hdrsize,
+                  x, y, bits]
+    
+    Returns:
+        unsigned byte array with bmp format
+
+
+### [`_setx`](#Python_BMP.BITMAPlib._setx)
+
+```py
+def _setx(bmp: array.array, xmax: int):
+```
+
+Sets the x value stored in the windows bmp header
+
+    Args:
+        bmp: unsigned byte array
+             with bmp format
+        int: value of x dimension
+    
+    Returns:
+        byref modified unsigned byte array
+
+
+### [`_sety`](#Python_BMP.BITMAPlib._sety)
+
+```py
+def _sety(bmp: array.array, ymax: int):
+```
+
+Sets the y value stored in the windows bmp header
+
+    Args:
+        bmp: unsigned byte array
+             with bmp format
+        int: value of y dimension
+    
+    Returns:
+        byref modified unsigned byte array
+
+
+### [`_use24bitfn2reg`](#Python_BMP.BITMAPlib._use24bitfn2reg)
+
+```py
+def _use24bitfn2reg(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Callable, funcparam):
+```
+
+Apply func(funcparam) to a rectangular area
+in a 24-bit bitmap
+
+    Args:
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: defines the
+                        rectangular area
+        func          : user defined
+                        function
+        funcparam     : parameters of
+                        the function
+    
+    Returns:
+        byref modified unsigned byte array
+
+
+### [`_use24btbyrefclrfn2regnsv`](#Python_BMP.BITMAPlib._use24btbyrefclrfn2regnsv)
+
+```py
+def _use24btbyrefclrfn2regnsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable, funcparam):
+```
+
+Apply a 24-bit byref
+color modification function
+to a rectangular area and save
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        x1, y1, x2, y2:  the rectangular
+                         area
+        func           : user defined
+                         function
+        funcparam      : function
+                         parameters
+    
+    Returns:
+        new bitmap file
+
+
+### [`_use24btclrfn`](#Python_BMP.BITMAPlib._use24btclrfn)
+
+```py
+def _use24btclrfn(ExistingBMPfile: str, NewBMPfile: str, func: Callable, funcparam):
+```
+
+Apply a user provided color adjustment function
+to a 24-bit bitmap
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save the
+                         changes in
+        func           : user defined
+                         function
+        funcparam      : parameters of
+                         the function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_use24btclrfntocircregion`](#Python_BMP.BITMAPlib._use24btclrfntocircregion)
+
+```py
+def _use24btclrfntocircregion(ExistingBMPfile: str, NewBMPfile: str, func: Callable, x: int, y: int, r: int):
+```
+
+Apply a no parameter color adjustment function
+to a circular area (24-bit only)
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        x, y, r        : center (x, y)
+                         and radius r
+        func           : user defined
+                         function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_use24btclrfnwithpar2circreg`](#Python_BMP.BITMAPlib._use24btclrfnwithpar2circreg)
+
+```py
+def _use24btclrfnwithpar2circreg(ExistingBMPfile: str, NewBMPfile: str, func: Callable, x: int, y: int, r: int, funcparam):
+```
+
+Apply a user provided color adjustment function
+to a circular area (24-bit only)
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        x, y, r        : center (x,y)
+                         and radius r
+        func           : user defined
+                         function
+        funcparam      : parameters of
+                         the function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_use24btfn2circreg`](#Python_BMP.BITMAPlib._use24btfn2circreg)
+
+```py
+def _use24btfn2circreg(bmp: array.array, x: int, y: int, r: int, func: Callable, funcparam):
+```
+
+Apply function func to a
+circular region with center at
+(x, y) and a radius r that is
+within a 24-bit bitmap
+
+    Args:
+        bmp       : unsigned byte array
+                    with bmp format
+        x, y, r   : center (x, y)
+                    and radius r
+                    of the circular area
+        func      : function to apply
+        funcparam : parameters of the
+                    function
+    
+    Returns:
+        byref modified
+        unsigned byte array
+
+
+### [`_use24btfnwithparnsv`](#Python_BMP.BITMAPlib._use24btfnwithparnsv)
+
+```py
+def _use24btfnwithparnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable, funcparam):
+```
+
+Apply a 24-bit only function with parameters and save
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        func           : user defined
+                         function
+        funcparam      : parameters of
+                         the function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_usebyref24btfn2reg`](#Python_BMP.BITMAPlib._usebyref24btfn2reg)
+
+```py
+def _usebyref24btfn2reg(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Callable, funcparam):
+```
+
+Apply byref func(funcparam) to a rectangular area
+in a 24-bit bitmap
+
+    Args:
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: defines the
+                        rectangular area
+        func          : user defined
+                        function
+        funcparam     : parameters of
+                        the function
+    
+    Returns:
+        byref modified unsigned byte array
+
+
+### [`_usebyref24btfn2regnsv`](#Python_BMP.BITMAPlib._usebyref24btfn2regnsv)
+
+```py
+def _usebyref24btfn2regnsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable):
+```
+
+Apply a 24-bit byref function
+with no parameters to a
+rectangular area and save
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        x1, y1, x2, y2 : defines the
+                         rectangular
+                         region
+        func           : user defined
+                         function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_usebyreffn2regnsv`](#Python_BMP.BITMAPlib._usebyreffn2regnsv)
+
+```py
+def _usebyreffn2regnsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable):
+```
+
+Apply a byref function
+with no parameters to a
+rectangular region and save
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        x1, y1, x2, y2 : defines the
+                         rectangular
+                         region
+        func           : user defined
+                         function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_usebyreffnsv`](#Python_BMP.BITMAPlib._usebyreffnsv)
+
+```py
+def _usebyreffnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable):
+```
+
+Apply a by-ref function with no parameters and save
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        func           : user defined
+                         function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_usebyreffnwithpar2regnsv`](#Python_BMP.BITMAPlib._usebyreffnwithpar2regnsv)
+
+```py
+def _usebyreffnwithpar2regnsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable, funcparam):
+```
+
+Apply a 24-bit byref function
+to a rectangular area and save
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        x1, y1, x2, y2 : the rectangular
+                         area
+        func           : user defined
+                         function
+        funcparam      : function
+                         parameters
+    
+    Returns:
+        new bitmap file
+
+
+### [`_usebyreffnwithparnsv`](#Python_BMP.BITMAPlib._usebyreffnwithparnsv)
+
+```py
+def _usebyreffnwithparnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable, funcparam):
+```
+
+
+
+    
+
+
+### [`_usebyrefnopar24bitfn2reg`](#Python_BMP.BITMAPlib._usebyrefnopar24bitfn2reg)
+
+```py
+def _usebyrefnopar24bitfn2reg(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Callable):
+```
+
+Apply a func to a rectangular area in a 24-bit bitmap
+
+    Args:
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: the rectangular
+                        area
+        func          : user defined
+                        function
+    
+    Returns:
+        byref modified unsigned byte array
+
+
+### [`_useclradjfn`](#Python_BMP.BITMAPlib._useclradjfn)
+
+```py
+def _useclradjfn(ExistingBMPfile: str, NewBMPfile: str, func: Callable, funcparam):
+```
+
+Apply a user provided color adjustmen function
+to an existing bitmap
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        func           : user defined
+                         function
+        funcparam      : parameters of
+                         the function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_usefn2circreg`](#Python_BMP.BITMAPlib._usefn2circreg)
+
+```py
+def _usefn2circreg(ExistingBMPfile: str, NewBMPfile: str, func: Callable, x: int, y: int, r: int):
+```
+
+Apply a user provided function (no parameters)
+to a circular area
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        x, y, r        : center (x, y)
+                         and radius r
+        func           : user defined
+                         function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_usefn2regsv`](#Python_BMP.BITMAPlib._usefn2regsv)
+
+```py
+def _usefn2regsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable):
+```
+
+Apply a function withno parameters to a
+rectangular area and save
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        x1, y1, x2, y2 : defines the
+                         rectangular
+                         region
+        func           : user defined
+                         function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_usefnsv`](#Python_BMP.BITMAPlib._usefnsv)
+
+```py
+def _usefnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable):
+```
+
+Apply a function with no parameters and save
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        func           : user defined
+                         function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_usefnwithpar2circreg`](#Python_BMP.BITMAPlib._usefnwithpar2circreg)
+
+```py
+def _usefnwithpar2circreg(ExistingBMPfile: str, NewBMPfile: str, func: Callable, x: int, y: int, r: int, funcparam):
+```
+
+Apply a user provided function with parameters
+to a circular area
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        x, y, r        : center (x,y)
+                         and radius r
+        func           : user defined
+                         function
+        funcparam      : parameters of
+                         the function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_usenopar24btfn2circreg`](#Python_BMP.BITMAPlib._usenopar24btfn2circreg)
+
+```py
+def _usenopar24btfn2circreg(bmp: array.array, x: int, y: int, r: int, func: Callable):
+```
+
+Apply a no parameter function
+to a circular region with
+center at (x, y) and a radius r
+in a 24-bit bitmap
+
+    Args:
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x, y)
+                 and radius r
+                 of the circular area
+        func   : function to apply
+    
+    Returns:
+        byref modified unsigned byte array
+
+
+### [`_usenoparclradjfn`](#Python_BMP.BITMAPlib._usenoparclradjfn)
+
+```py
+def _usenoparclradjfn(ExistingBMPfile: str, NewBMPfile: str, func: Callable):
+```
+
+Apply a user provided no parameter color
+    adjustment function to an existing bitmap
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        func           : user defined
+                         function
+    
+    Returns:
+        new bitmap file
+
+
+### [`_usenoparfn2circreg`](#Python_BMP.BITMAPlib._usenoparfn2circreg)
+
+```py
+def _usenoparfn2circreg(bmp: array.array, x: int, y: int, r: int, func: Callable):
+```
+
+Apply a no parameter function
+to a circular region with a
+center at (x,y) and a radius r
+
+    Args:
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x,y)
+                 and radius r
+                 of the
+                 circular area
+        func   : function
+                 to apply
+                 to the area
+    
+    Returns:
+        byref modified unsigned byte array
+
+
+### [`_xbytes`](#Python_BMP.BITMAPlib._xbytes)
+
+```py
+def _xbytes(x: int, bits: int) -> int:
+```
+
+Get the number of bytes in
+a bmp row given x dimension and bit depth
+
+    Args:
+        x   : unsigned int value of
+              x-dimension
+        bits: unsigned int value of
+              bit depth (1, 4, 8, 24)
+    
+    Returns:
+        int value of number of bytes in a row
+
+
+### [`_xchrcnt`](#Python_BMP.BITMAPlib._xchrcnt)
+
+```py
+def _xchrcnt(bmp: array.array) -> int:
+```
+
+Get the chars or bytes in row of a BMP
+
+    Args:
+        bmp: unsigned byte array
+             with bmp format
+    
+    Returns:
+        count of bytes or
+        chars in a row (x dim)
+
+
+### [`addvect`](#Python_BMP.mathlib.addvect)
+
+```py
+def addvect(u: list[numbers.Number], v: list[numbers.Number]) -> list[numbers.Number]:
+```
+
+Add vectors u and v by adding their components
 
     Args:
         u, v: list of ints or floats
-
+    
     Returns:
         list of ints or floats
-    
 
 
-**def addvectinlist(vlist: list[list[numbers.Number]]) -> numbers.Number:**
->Gets the sum of the vectors in a list of vectors
+### [`addvectinlist`](#Python_BMP.mathlib.addvectinlist)
+
+```py
+def addvectinlist(vlist: list[list[numbers.Number]]) -> numbers.Number:
+```
+
+Gets the sum of the vectors in a list of vectors
 
     Args:
         vlist: list of vectors
-
+    
     Returns:
         list or vector
-    
 
 
-**def adjustbrightness2file(ExistingBMPfile: str, NewBMPfile: str, percentadj: float):**
->Apply a brightness adjustment to the image in a BMP
+### [`adjustbrightness2file`](#Python_BMP.BITMAPlib.adjustbrightness2file)
+
+```py
+def adjustbrightness2file(ExistingBMPfile: str, NewBMPfile: str, percentadj: float):
+```
+
+Apply a brightness adjustment to the image in a BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -34,14 +1061,18 @@
                          positive or
                          negative value
                          (signed float)
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def adjustbrightnessinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, percentadj: float):**
->Brightness adjustment to rectangular area in a 24-bit BMP
+### [`adjustbrightnessinregion2file`](#Python_BMP.BITMAPlib.adjustbrightnessinregion2file)
+
+```py
+def adjustbrightnessinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, percentadj: float):
+```
+
+Brightness adjustment to rectangular area in a 24-bit BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -56,28 +1087,36 @@
                          negative
                          adjustment
                         (signed float)
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def adjustcolordicttopal(bmp: array.array, colordict: dict):**
->Adjust a color dictionary to match
-    as closely as possible a bitmap palette
+### [`adjustcolordicttopal`](#Python_BMP.BITMAPlib.adjustcolordicttopal)
+
+```py
+def adjustcolordicttopal(bmp: array.array, colordict: dict):
+```
+
+Adjust a color dictionary to match
+as closely as possible a bitmap palette
 
     Args:
         bmp      : unsigned byte array
                    with bmp format
         colordict: dictionary of colors
-
+    
     Returns:
         byref modified dictionary of colors
-    
 
 
-**def adjustthresholdinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, lumrange: list):**
->Threshold adjust in a rectangular area in a 24-bit BMP
+### [`adjustthresholdinregion2file`](#Python_BMP.BITMAPlib.adjustthresholdinregion2file)
+
+```py
+def adjustthresholdinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, lumrange: list):
+```
+
+Threshold adjust in a rectangular area in a 24-bit BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -90,19 +1129,23 @@
         lumrange       : (byte:byte)
                          threshold to
                          apply
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def adjustxbufsize(bmp: array.array, x1: int, x2: int) -> int:**
->Returns a 32 -bit padded
-        int buffer size for a
-        buffer with the bit depth
-        stored in byte number 28
-        of the bitmap bmp and an
-        int length of x2 - x1 + 1
+### [`adjustxbufsize`](#Python_BMP.bufresize.adjustxbufsize)
+
+```py
+def adjustxbufsize(bmp: array.array, x1: int, x2: int) -> int:
+```
+
+Returns a 32 -bit padded
+    int buffer size for a
+    buffer with the bit depth
+    stored in byte number 28
+    of the bitmap bmp and an
+    int length of x2 - x1 + 1
 
     Args:
         bmp   : unsigned byte array
@@ -110,150 +1153,186 @@
         x1, x2: int params for
                 a x coord line
                 in the bitmap
-
+    
     Returns:
         int adjusted buffer size
-    
 
 
-**def andvect(u: list[int], v: list[int]) -> list[int]:**
->Bitwise and operation of between
-    the elements of two lists of ints
+### [`andvect`](#Python_BMP.mathlib.andvect)
+
+```py
+def andvect(u: list[int], v: list[int]) -> list[int]:
+```
+
+Bitwise and operation of between
+the elements of two lists of ints
 
     Args:
         v      : list[int]
         bitmask: int
-
+    
     Returns:
         list[int]
-    
 
 
-**def anglebetween2Dlines(u: list[numbers.Number, numbers.Number], v: list[numbers.Number, numbers.Number]) -> float:**
->Compute the angle between two lines of vectors
+### [`anglebetween2Dlines`](#Python_BMP.mathlib.anglebetween2Dlines)
+
+```py
+def anglebetween2Dlines(u: list[numbers.Number, numbers.Number], v: list[numbers.Number, numbers.Number]) -> float:
+```
+
+Compute the angle between two lines of vectors
 
     Args:
         u, v: list[Number, Number]
-
+    
     Returns:
         float angle in radians
-    
 
 
-**def applybrightnessadjtoBGRbuf(buf: array.array, percentadj: float) -> array.array:**
->Apply a brightness adjustment
-        to a BGR buffer
+### [`applybrightnessadjtoBGRbuf`](#Python_BMP.colors.applybrightnessadjtoBGRbuf)
+
+```py
+def applybrightnessadjtoBGRbuf(buf: array.array, percentadj: float) -> array.array:
+```
+
+Apply a brightness adjustment
+    to a BGR buffer
 
     Args:
         buf: unsigned byte array
              holding BGR data
-
+    
         percentadj: float brightness
                     adjust can be
                     positive or
                     negative
-
+    
     Returns:
         unsigned byte array
         holding brightness adjusted
         BGR data
-    
 
 
-**def applycolorfiltertoBGRbuf(buf: array.array, rgbfactors: list[float, float, float]):**
->Apply a color filter to a
-        BGR buffer
+### [`applycolorfiltertoBGRbuf`](#Python_BMP.colors.applycolorfiltertoBGRbuf)
+
+```py
+def applycolorfiltertoBGRbuf(buf: array.array, rgbfactors: list[float, float, float]):
+```
+
+Apply a color filter to a
+    BGR buffer
 
     Args:
         buf: unsigned byte array
              holding BGR data
-
+    
         rgbfactors: color filter as
                       [r: float,
                        g: float,
                        b: float]
-
+    
     Returns:
         byref unsigned byte array
         holding color BGR data
-    
 
 
-**def applygammaBGRbuf(buf: array.array, gamma: float):**
->Apply a gamma adjustment to a
-        BGR buffer
+### [`applygammaBGRbuf`](#Python_BMP.colors.applygammaBGRbuf)
+
+```py
+def applygammaBGRbuf(buf: array.array, gamma: float):
+```
+
+Apply a gamma adjustment to a
+    BGR buffer
 
     Args:
         buf: unsigned byte array
              holding BGR data
-
+    
         gamma: float gamma adjust
-
+    
     Returns:
         byref unsigned byte array
         holding gamma adjusted
         BGR data
-    
 
 
-**def applymonochromefiltertoBGRbuf(buf: array.array):**
->Apply a monochrome filter to a
-        BGR buffer
+### [`applymonochromefiltertoBGRbuf`](#Python_BMP.colors.applymonochromefiltertoBGRbuf)
+
+```py
+def applymonochromefiltertoBGRbuf(buf: array.array):
+```
+
+Apply a monochrome filter to a
+    BGR buffer
 
     Args:
         buf: unsigned byte array
              holding BGR data
-
+    
         rgbfactors: color filter as
                       [r: float,
                        g: float,
                        b: float]
-
+    
     Returns:
         byref unsigned byte array
         holding mono BGR data
-    
 
 
-**def applythresholdadjtoBGRbuf(buf: array.array, lumrange: list) -> array.array:**
->Apply a threshold adjustment
-        to a BGR buffer
+### [`applythresholdadjtoBGRbuf`](#Python_BMP.colors.applythresholdadjtoBGRbuf)
+
+```py
+def applythresholdadjtoBGRbuf(buf: array.array, lumrange: list) -> array.array:
+```
+
+Apply a threshold adjustment
+    to a BGR buffer
 
     Args:
         buf: unsigned byte array
              holding BGR data
-
+    
         lumrange: [min: int, max: int]
                   brightness threshold
-
+    
     Returns:
         unsigned byte array
         holding threshold adjusted
         BGR data
-    
 
 
-**def arcvert(x: int, y: int, r: int, startdegangle: float, enddegangle: float):**
->Returns a list[(int, int)] of 2D vertices
-    along a path defined by radius r as it
-    traces an arc with origin set at (x, y)
+### [`arcvert`](#Python_BMP.primitives2D.arcvert)
+
+```py
+def arcvert(x: int, y: int, r: int, startdegangle: float, enddegangle: float):
+```
+
+Returns a list[(int, int)] of 2D vertices
+along a path defined by radius r as it
+traces an arc with origin set at (x, y)
 
     Args:
         x, y: int centerpoint
                   coordinates
         r   : int radius
-
+    
         startangle: degree start of arc
         endangle  : degree end of arc
-
+    
     Yields:
         list of vertices of the arc
         list[[x: int, y: int]]
-    
 
 
-**def autocropimg2file(ExistingBMPfile: str, NewBMPfile: str, similaritythreshold: float):**
->Perform an auto crop to the image in a bitmap file
+### [`autocropimg2file`](#Python_BMP.BITMAPlib.autocropimg2file)
+
+```py
+def autocropimg2file(ExistingBMPfile: str, NewBMPfile: str, similaritythreshold: float):
+```
+
+Perform an auto crop to the image in a bitmap file
 
     Args:
         ExistingBMPfile    : Whole path to
@@ -262,14 +1341,18 @@
                              save changes in
         similaritythreshold: used to tune
                              autocrop
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def beziercurve(bmp: array.array, pntlist: list[list[numbers.Number, numbers.Number]], penradius: int, color: int):**
->Draws a Bezier Curve
+### [`beziercurve`](#Python_BMP.BITMAPlib.beziercurve)
+
+```py
+def beziercurve(bmp: array.array, pntlist: list[list[numbers.Number, numbers.Number]], penradius: int, color: int):
+```
+
+Draws a Bezier Curve
 
     Args:
         bmp      : unsigned byte array
@@ -279,14 +1362,18 @@
         penradius: radius of pen
         color    : color of the
                    bezier curve
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def BMPbitBLTget(bmp: array.array, offset: int, bufsize: int) -> array.array:**
->Gets [offset: offset + bufsize] to a new array
+### [`BMPbitBLTget`](#Python_BMP.BITMAPlib.BMPbitBLTget)
+
+```py
+def BMPbitBLTget(bmp: array.array, offset: int, bufsize: int) -> array.array:
+```
+
+Gets [offset: offset + bufsize] to a new array
 
     Args:
         bmp    : unsigned byte array
@@ -295,14 +1382,18 @@
                  address in buffer
         bufsize: unsigned int
                  size of buffer
-
+    
     Returns:
         unsigned byte array
-    
 
 
-**def BMPbitBLTput(bmp: array.array, offset: int, arraybuf: array.array):**
->Sets offset in array to arraybuf
+### [`BMPbitBLTput`](#Python_BMP.BITMAPlib.BMPbitBLTput)
+
+```py
+def BMPbitBLTput(bmp: array.array, offset: int, arraybuf: array.array):
+```
+
+Sets offset in array to arraybuf
 
     Args:
         bmp     : unsigned byte array
@@ -310,43 +1401,34 @@
         offset  : unsigned int
                   address in buffer
         arraybuf: unsigned byte array
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def bottomrightcoord(bmp: array.array) -> tuple:**
->Gets the maximum bottom right coordinates of a bmp
+### [`bottomrightcoord`](#Python_BMP.BITMAPlib.bottomrightcoord)
+
+```py
+def bottomrightcoord(bmp: array.array) -> tuple:
+```
+
+Gets the maximum bottom right coordinates of a bmp
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         tuple (x:int,y:int)
-    
 
 
-**def brightnessadjcircregion(bmp: array.array, x: int, y: int, r: int, percentadj: float):**
->Brightness adjustment to a circular area
+### [`brightnessadjcircregion2file`](#Python_BMP.BITMAPlib.brightnessadjcircregion2file)
 
-    Args:
-        bmp       : unsigned byte array
-                    with bmp format
-        x, y, r   : center (x, y)
-                    and radius r
-                    of the region
-        percentadj: float percent of the
-                    brightness adjustment
+```py
+def brightnessadjcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, percentadj: float):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def brightnessadjcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, percentadj: float):**
->Brightness gradient to a circular area
+Brightness gradient to a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -364,15 +1446,40 @@
                          that can be
                          positive
                          or negative
-
+    
     Returns:
         new bitmap file
+
+
+### [`brightnessadjcircregion`](#Python_BMP.BITMAPlib.brightnessadjcircregion)
+
+```py
+def brightnessadjcircregion(bmp: array.array, x: int, y: int, r: int, percentadj: float):
+```
+
+Brightness adjustment to a circular area
+
+    Args:
+        bmp       : unsigned byte array
+                    with bmp format
+        x, y, r   : center (x, y)
+                    and radius r
+                    of the region
+        percentadj: float percent of the
+                    brightness adjustment
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def brightnessadjust(rgb: list[int, int, int], percentadj: float) -> list[int, int, int]:**
->Apply a brightness adjustment
-        to a rgb
+### [`brightnessadjust`](#Python_BMP.colors.brightnessadjust)
+
+```py
+def brightnessadjust(rgb: list[int, int, int], percentadj: float) -> list[int, int, int]:
+```
+
+Apply a brightness adjustment
+    to a rgb
 
     Args:
         rgb: color as [r: byte,
@@ -383,15 +1490,19 @@
                     in percent
                     can be positive
                     or negative
-
+    
     Returns:
         a brightness adjusted color as
         [r: byte, g: byte, b: byte]
-    
 
 
-**def brightnesseadjto24bitimage(bmp: array.array, percentadj: float):**
->Brightness adjustment to a whole BMP
+### [`brightnesseadjto24bitimage`](#Python_BMP.BITMAPlib.brightnesseadjto24bitimage)
+
+```py
+def brightnesseadjto24bitimage(bmp: array.array, percentadj: float):
+```
+
+Brightness adjustment to a whole BMP
 
     Args:
         bmp       : unsigned byte array
@@ -401,14 +1512,18 @@
                     adjustment
                     can be positive
                     or negative
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def brightnesseadjto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, percentadj: float):**
->Brightness adjustment to a rectangular area
+### [`brightnesseadjto24bitregion`](#Python_BMP.BITMAPlib.brightnesseadjto24bitregion)
+
+```py
+def brightnesseadjto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, percentadj: float):
+```
+
+Brightness adjustment to a rectangular area
 
     Args:
         bmp           : unsigned
@@ -420,14 +1535,18 @@
                         brightness adjust
                         can be positive
                         or negative
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def bspline(bmp: array.array, pntlist: list, penradius: int, color: int, isclosed: bool, curveback: bool):**
->Draws a Bspline
+### [`bspline`](#Python_BMP.BITMAPlib.bspline)
+
+```py
+def bspline(bmp: array.array, pntlist: list, penradius: int, color: int, isclosed: bool, curveback: bool):
+```
+
+Draws a Bspline
 
     Args:
         bmp      : unsigned byte array
@@ -442,103 +1561,156 @@
                    extra computation
                    for curve to loop
                    back on itself
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def bsplinevert(pntlist: list[list[int, int]], isclosed: bool, curveback: bool) -> list[list[int, int]]:**
->Creates a list of vertices for a bspline curve
+### [`bsplinevert`](#Python_BMP.primitives2D.bsplinevert)
+
+```py
+def bsplinevert(pntlist: list[list[int, int]], isclosed: bool, curveback: bool) -> list[list[int, int]]:
+```
+
+Creates a list of vertices for a bspline curve
 
     Args:
         pntlist: 2D control points
                  for the bspline curve
                  as list[list[x: int,
                               y: int]]
-
+    
     Returns:
         list of vertices as
         list[list[x: int, y: int]]
-    
 
 
-**def buf2int(buf: array.array) -> int:**
->Converts an unsigned byte array
-        to an integer value
+### [`buf2int`](#Python_BMP.inttools.buf2int)
+
+```py
+def buf2int(buf: array.array) -> int:
+```
+
+Converts an unsigned byte array
+    to an integer value
 
     Args:
         buf: unsigned byte array
-
+    
     Returns:
         unsigned int value
-    
 
 
-**def centercoord(bmp: array.array) -> tuple:**
->Gets the central coordinates of a BMP
+### [`centercoord`](#Python_BMP.BITMAPlib.centercoord)
+
+```py
+def centercoord(bmp: array.array) -> tuple:
+```
+
+Gets the central coordinates of a BMP
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         tuple (x:int,y:int)
-    
 
 
-**def centerpoint(x1: int, y1: int, x2: int, y2: int):**
->Returns the centerpoint x, y in rectangular area
+### [`centerpoint`](#Python_BMP.mathlib.centerpoint)
+
+```py
+def centerpoint(x1: int, y1: int, x2: int, y2: int):
+```
+
+Returns the centerpoint x, y in rectangular area
 
     Args:
         x1, y1 : defines the
         x2, y2   rectangular area
-
+    
     Returns:
         x: int, y: int centerpoint
-    
 
 
-**def char2int(charcodestr: str) -> int:**
->Packs a string into an int
-        using ascii code
+### [`char2int`](#Python_BMP.chartools.char2int)
+
+```py
+def char2int(charcodestr: str) -> int:
+```
+
+Packs a string into an int
+    using ascii code
 
     Args:
         charcodestr: string
-
+    
     Yields:
         int value
-    
 
 
-**def checklink(func: Callable):**
->Decorator to test if the first
-        parameter in a function is
-        a valid file
+### [`checklink`](#Python_BMP.fileutils.checklink)
 
-    Args:
-        function
+```py
+def checklink(func: Callable):
+```
 
-    Returns:
-        caller function
-    
-
-
-**def checklinks(func: Callable):**
->Decorator to test if the two
-        parameters in a function
-        are valid files
+Decorator to test if the first
+    parameter in a function is
+    a valid file
 
     Args:
         function
-
+    
     Returns:
         caller function
+
+
+### [`checklinks`](#Python_BMP.fileutils.checklinks)
+
+```py
+def checklinks(func: Callable):
+```
+
+Decorator to test if the two
+    parameters in a function
+    are valid files
+
+    Args:
+        function
     
+    Returns:
+        caller function
 
 
-**def circle(bmp: array.array, x: int, y: int, r: int, color: int, isfilled: bool = None):**
->Draws a Circle
+### [`circle2file`](#Python_BMP.BITMAPlib.circle2file)
+
+```py
+def circle2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, color: int):
+```
+
+Draws a Circle
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        x, y, r        : center (x, y)
+                         and radius r
+        color          : color of circle
+    
+    Returns:
+        new bitmap file
+
+
+### [`circle`](#Python_BMP.BITMAPlib.circle)
+
+```py
+def circle(bmp: array.array, x: int, y: int, r: int, color: int, isfilled: bool = None):
+```
+
+Draws a Circle
 
     Args:
         bmp     : unsigned byte array
@@ -551,58 +1723,49 @@
                   circle is filled
                   True -> filled circle
                   False -> circle outline
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def circle2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, color: int):**
->Draws a Circle
+### [`circleinvolutevert`](#Python_BMP.primitives2D.circleinvolutevert)
 
-    Args:
-        ExistingBMPfile: Whole path to
-                         existing file
-        NewBMPfile     : New file to
-                         save changes in
-        x, y, r        : center (x, y)
-                         and radius r
-        color          : color of circle
+```py
+def circleinvolutevert(x: int, y: int, a: float, delta: float, lim: float):
+```
 
-    Returns:
-        new bitmap file
-    
-
-
-**def circleinvolutevert(x: int, y: int, a: float, delta: float, lim: float):**
->Returns (int, int) 2D vertices
-    along a path defined by the involute
-    of a circle with scaling factor a
-    and an origin set at (x, y)
+Returns (int, int) 2D vertices
+along a path defined by the involute
+of a circle with scaling factor a
+and an origin set at (x, y)
 
     The involute of a circle is the path
     traced out by a point on a straight
     line that rolls around a circle.
-
+    
     It was studied by Huygens when he was
     considering clocks without pendulums
     that might be used on ships at sea.
-
+    
     Args:
         x, y : center of the curve
         a    : scaling factor
         delta: angle increment in radians
         lim  : angle limit in radians
-
+    
     Yields:
         The vertices of the
         involute of a circle in a list
         [[x: int, y: int], ...]
-    
 
 
-**def circlevec(bmp: array.array, v: list, r: int, color: int, isfilled: bool = None):**
->Draws a circle
+### [`circlevec`](#Python_BMP.BITMAPlib.circlevec)
+
+```py
+def circlevec(bmp: array.array, v: list, r: int, color: int, isfilled: bool = None):
+```
+
+Draws a circle
 
     Args:
         bmp     : unsigned byte array
@@ -614,36 +1777,18 @@
         color   : color of the circle
         isfilled: toggles if the
                   circle is filled
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def colorfilter(rgb: list[int, int, int], rgbfactors: list[float, float, float]) -> list[int, int, int]:**
->Apply a color filter
-        rgbfactors to rgb
+### [`colorfilter2file`](#Python_BMP.BITMAPlib.colorfilter2file)
 
-    Args:
-        rgb: color as [r: byte,
-                       g: byte,
-                       b: byte]
+```py
+def colorfilter2file(ExistingBMPfile: str, NewBMPfile: str, rgbfactors: list[float, float, float]):
+```
 
-        rgbfactors: color filter as
-                      [r: float,
-                       g: float,
-                       b: float]
-
-    Returns:
-        a color filtered
-        color as [r: byte,
-                  g: byte,
-                  b: byte]
-    
-
-
-**def colorfilter2file(ExistingBMPfile: str, NewBMPfile: str, rgbfactors: list[float, float, float]):**
->Applies Color Filter rgbfactors to a BMP
+Applies Color Filter rgbfactors to a BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -653,32 +1798,44 @@
         rgbfactors     : (r,g,b) r, g, b
                          values range
                          from 0.0 to 1.0
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def colorfiltercircregion(bmp: array.array, x: int, y: int, r: int, rgbfactors: list[float, float, float]):**
->Color Filter to a circular area
+### [`colorfilter`](#Python_BMP.colors.colorfilter)
+
+```py
+def colorfilter(rgb: list[int, int, int], rgbfactors: list[float, float, float]) -> list[int, int, int]:
+```
+
+Apply a color filter
+    rgbfactors to rgb
 
     Args:
-        bmp       : unsigned byte array
-                    with bmp format
-        x, y, r   : center (x, y)
-                    and radius r
-                    of the region
-        rgbfactors: [r, g, b] range of
-                    r, g and b are from
-                    0.0 min to 1.0 max
-
-    Returns:
-        byref modified unsigned byte array
+        rgb: color as [r: byte,
+                       g: byte,
+                       b: byte]
     
+        rgbfactors: color filter as
+                      [r: float,
+                       g: float,
+                       b: float]
+    
+    Returns:
+        a color filtered
+        color as [r: byte,
+                  g: byte,
+                  b: byte]
 
 
-**def colorfiltercircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, rgbfactors: list[float, float, float]):**
->Applies a color filter to a circular area in a BMP
+### [`colorfiltercircregion2file`](#Python_BMP.BITMAPlib.colorfiltercircregion2file)
+
+```py
+def colorfiltercircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, rgbfactors: list[float, float, float]):
+```
+
+Applies a color filter to a circular area in a BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -689,14 +1846,40 @@
                          and radius r
         rgbfactors     : (r, g, b) values
                          range from 0 to 1
-
+    
     Returns:
         new bitmap file
+
+
+### [`colorfiltercircregion`](#Python_BMP.BITMAPlib.colorfiltercircregion)
+
+```py
+def colorfiltercircregion(bmp: array.array, x: int, y: int, r: int, rgbfactors: list[float, float, float]):
+```
+
+Color Filter to a circular area
+
+    Args:
+        bmp       : unsigned byte array
+                    with bmp format
+        x, y, r   : center (x, y)
+                    and radius r
+                    of the region
+        rgbfactors: [r, g, b] range of
+                    r, g and b are from
+                    0.0 min to 1.0 max
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def colorfilterinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, rgbfactors: list[float, float, float]):**
->Color Filter to a Rectangular Area in a 24-bit BMP
+### [`colorfilterinregion2file`](#Python_BMP.BITMAPlib.colorfilterinregion2file)
+
+```py
+def colorfilterinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, rgbfactors: list[float, float, float]):
+```
+
+Color Filter to a Rectangular Area in a 24-bit BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -710,16 +1893,20 @@
                          values range
                          from
                          0.0 to 1.0
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def colorfilterto24bitimage(bmp: array.array, rgbfactors: list[float, float, float]):**
->Applies a color filter
-        to a whole image in
-        an in-memory 24 bit bitmap
+### [`colorfilterto24bitimage`](#Python_BMP.BITMAPlib.colorfilterto24bitimage)
+
+```py
+def colorfilterto24bitimage(bmp: array.array, rgbfactors: list[float, float, float]):
+```
+
+Applies a color filter
+    to a whole image in
+    an in-memory 24 bit bitmap
 
     Args:
         bmp       : unsigned byte array
@@ -727,18 +1914,22 @@
         rgbfactors: color filter
                     r,g and b values
                     are from 0.0 to 1.0
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def colorfilterto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, rgbfactors: list[float, float, float]):**
->Applies a color filter to
-        a rectangular area defined
-        by (x1, y1) and (x2, y2)
-        in a 24-bit bitmap
+### [`colorfilterto24bitregion`](#Python_BMP.BITMAPlib.colorfilterto24bitregion)
+
+```py
+def colorfilterto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, rgbfactors: list[float, float, float]):
+```
+
+Applies a color filter to
+    a rectangular area defined
+    by (x1, y1) and (x2, y2)
+    in a 24-bit bitmap
 
     Args:
         bmp           : unsigned
@@ -751,52 +1942,63 @@
                         r, g and b
                         range from
                         0.0 to 1.0
-
+    
     Returns:
         byref modified
         unsigned byte array
 
-    
 
+### [`colorfiltertoBGRbuf`](#Python_BMP.colors.colorfiltertoBGRbuf)
 
-**def colorfiltertoBGRbuf(buf: array.array, rgbfactors: list[float, float, float]) -> array.array:**
->Apply a color filter to a
-        BGR buffer
+```py
+def colorfiltertoBGRbuf(buf: array.array, rgbfactors: list[float, float, float]) -> array.array:
+```
+
+Apply a color filter to a
+    BGR buffer
 
     Args:
         buf: unsigned byte array
              holding BGR data
-
+    
         rgbfactors: color filter as
                       [r: float,
                        g: float,
                        b: float]
-
+    
     Returns:
         unsigned byte array
         holding color BGR data
-    
 
 
-**def colorhistorgram(bmp: array.array) -> list:**
->Creates a color histogram
+### [`colorhistorgram`](#Python_BMP.BITMAPlib.colorhistorgram)
+
+```py
+def colorhistorgram(bmp: array.array) -> list:
+```
+
+Creates a color histogram
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         list sorted in descending order of color frequencies
-    
 
 
-**def colormix(lum: int, RGBfactors: list[float, float, float]) -> int:**
->Mix a byte luminosity value to
-        an rgb triplet that express
-        a color value in [r, g, b]
-        ratios from 0.0 to 1.0 to
-        obtain an int value for a
-        specific color
+### [`colormix`](#Python_BMP.colors.colormix)
+
+```py
+def colormix(lum: int, RGBfactors: list[float, float, float]) -> int:
+```
+
+Mix a byte luminosity value to
+    an rgb triplet that express
+    a color value in [r, g, b]
+    ratios from 0.0 to 1.0 to
+    obtain an int value for a
+    specific color
 
     Args:
         lum       : a byte value for
@@ -806,16 +2008,20 @@
                          b: float]
                     float values from
                     0.0 to 1.0
-
+    
     Returns:
         int color val
-    
 
 
-**def conevertandsurface(vcen: list[float, float, float], r: float, zlen: float, deganglestep: float) -> tuple:**
->Returns a list of sparse
-        vertices and tiled surfaces
-        for a cone
+### [`conevertandsurface`](#Python_BMP.solids3D.conevertandsurface)
+
+```py
+def conevertandsurface(vcen: list[float, float, float], r: float, zlen: float, deganglestep: float) -> tuple:
+```
+
+Returns a list of sparse
+    vertices and tiled surfaces
+    for a cone
 
     Args:
         vcen       : [x: float, center
@@ -828,70 +2034,133 @@
         deganglestep: angle step between
         vertices that controls how sparse
         the list will be
-
+    
     Returns:
         list of vertices and surfaces
         for plot3Dsolid()
         see Hello_Cone.py
-    
 
 
-**def convertbufto24bit(buf: array.array, bgrpalbuf: array.array, bits: int) -> array.array:**
->Converts 1, 4 and 8-bit buffers to a BGR buffer
+### [`convertbufto24bit`](#Python_BMP.BITMAPlib.convertbufto24bit)
+
+```py
+def convertbufto24bit(buf: array.array, bgrpalbuf: array.array, bits: int) -> array.array:
+```
+
+Converts 1, 4 and 8-bit buffers to a BGR buffer
 
     Args:
         buf      : unsigned byte array
         bgrpalbuf: BGR palette info
         bits     : color depth
                    (1, 4, 8)
-
+    
     Returns:
         unsigned byte array
-    
 
 
-**def convertselection2BMP(buf: array.array):**
->Converts custom unsigned byte array to bmp format
+### [`convertselection2BMP`](#Python_BMP.BITMAPlib.convertselection2BMP)
+
+```py
+def convertselection2BMP(buf: array.array):
+```
+
+Converts custom unsigned byte array to bmp format
 
     Args:
         buf: unsigned byte array
-
+    
     Returns:
         unsigned byte array with bmp format
-    
 
 
-**def copyBMPhdr(bmp: array.array) -> array.array:**
->Copies the bitmap header of an in-memory bmp
-    to a new unsigned byte array
+### [`copyBMPhdr`](#Python_BMP.BITMAPlib.copyBMPhdr)
+
+```py
+def copyBMPhdr(bmp: array.array) -> array.array:
+```
+
+Copies the bitmap header of an in-memory bmp
+to a new unsigned byte array
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         unsigned byte array with bmp format
-    
 
 
-**def CopyBMPxydim2newBMP(bmp: array.array, newbits: int) -> array.array:**
->Creates a new bitmap with the same dimensions as bmp
+### [`CopyBMPxydim2newBMP`](#Python_BMP.BITMAPlib.CopyBMPxydim2newBMP)
+
+```py
+def CopyBMPxydim2newBMP(bmp: array.array, newbits: int) -> array.array:
+```
+
+Creates a new bitmap with the same dimensions as bmp
 
     Args:
         bmp    : unsigned byte array
                  with bmp format
         newbits: bit depth
                  (1, 4, 8, 24)
-
+    
     Returns:
         unsigned byte array with bitmap layout
+
+
+### [`copycircregion2buf`](#Python_BMP.BITMAPlib.copycircregion2buf)
+
+```py
+def copycircregion2buf(bmp: array.array, x: int, y: int, r: int) -> list:
+```
+
+Copies a circular region to a
+buffer which is defined by
+centerpoint at (x, y) and radius r
+
+    Args:
+        bmp     : unsigned byte array
+                  with bmp format
+        x, y, r : center (x, y)
+                  and radius r
+                  of the circular area
     
+    Returns:
+        list with buffer of circular region
 
 
-**def copycircregion(bmp: array.array, x: int, y: int, r: int, newxy: list):**
->Copy a circular buffer with center at (x, y)
-    and a radius r to a new area with centerpoint at
-    newxy [x, y]
+### [`copycircregion2file`](#Python_BMP.BITMAPlib.copycircregion2file)
+
+```py
+def copycircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, newxycenterpoint: list):
+```
+
+Copy/Paste of a circular area in a BMP
+
+    Args:
+        ExistingBMPfile : Whole path
+                          to existing file
+        NewBMPfile      : New file to
+                          save changes to
+        x, y, r         : center (x,y)
+                          and radius r
+        newxycenterpoint: (x:int,y:int)
+                          where to paste
+    
+    Returns:
+        new bitmap file
+
+
+### [`copycircregion`](#Python_BMP.BITMAPlib.copycircregion)
+
+```py
+def copycircregion(bmp: array.array, x: int, y: int, r: int, newxy: list):
+```
+
+Copy a circular buffer with center at (x, y)
+and a radius r to a new area with centerpoint at
+newxy [x, y]
 
     Args:
         bmp    : unsigned byte array
@@ -904,93 +2173,74 @@
                  circular area
                  to paste
                  the buffer into
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def copycircregion2buf(bmp: array.array, x: int, y: int, r: int) -> list:**
->Copies a circular region to a
-    buffer which is defined by
-    centerpoint at (x, y) and radius r
+### [`copyrect`](#Python_BMP.BITMAPlib.copyrect)
 
-    Args:
-        bmp     : unsigned byte array
-                  with bmp format
-        x, y, r : center (x, y)
-                  and radius r
-                  of the circular area
+```py
+def copyrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int) -> array.array:
+```
 
-    Returns:
-        list with buffer of circular region
-    
-
-
-**def copycircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, newxycenterpoint: list):**
->Copy/Paste of a circular area in a BMP
-
-    Args:
-        ExistingBMPfile : Whole path
-                          to existing file
-        NewBMPfile      : New file to
-                          save changes to
-        x, y, r         : center (x,y)
-                          and radius r
-        newxycenterpoint: (x:int,y:int)
-                          where to paste
-
-    Returns:
-        new bitmap file
-    
-
-
-**def copyrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int) -> array.array:**
->Copy a rectangular region to a custom buffer
+Copy a rectangular region to a custom buffer
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         custom unsigned byte array
-    
 
 
-**def copyRGBpal(sourceBMP: array.array, destBMP: array.array):**
->Copies the RGB palette info from
-    a source unsigned byte array to
-    a destination unsigned byte array
+### [`copyRGBpal`](#Python_BMP.BITMAPlib.copyRGBpal)
+
+```py
+def copyRGBpal(sourceBMP: array.array, destBMP: array.array):
+```
+
+Copies the RGB palette info from
+a source unsigned byte array to
+a destination unsigned byte array
 
     Args:
         sourceBMP and destBMP are both
         unsigned byte arrays with bmp format
-
+    
     Returns:
         byref modified destBMP
         (unsigned byte array)
-    
 
 
-**def cosaffin(u: list[numbers.Number], v: list[numbers.Number]) -> float:**
->Compute Cosine Similarity or Cosine Affinity
+### [`cosaffin`](#Python_BMP.mathlib.cosaffin)
+
+```py
+def cosaffin(u: list[numbers.Number], v: list[numbers.Number]) -> float:
+```
+
+Compute Cosine Similarity or Cosine Affinity
 
     Args:
         u, v : list of ints or floats
-
+    
     Returns:
         float value
             proportional vectors = 1
             orthogonal vectors = 0
             opposite vectors = -1
             and values in between
-    
 
 
-**def crop(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Crops the image to a rectangular
-        region defined by (x1, y1)
-                      and (x2, y2)
+### [`crop`](#Python_BMP.BITMAPlib.crop)
+
+```py
+def crop(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Crops the image to a rectangular
+    region defined by (x1, y1)
+                  and (x2, y2)
 
     Args:
         bmp           : unsigned
@@ -998,15 +2248,19 @@
                         with bmp format
         x1, y1, x2, y2: the rectangular
                         region
-
+    
     Returns:
         unsigned byte array
         with bitmap layout
-    
 
 
-**def cropBMPandsave(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Crops and saves a rectangular area to a BMP
+### [`cropBMPandsave`](#Python_BMP.BITMAPlib.cropBMPandsave)
+
+```py
+def cropBMPandsave(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
+
+Crops and saves a rectangular area to a BMP
 
     Args:
         ExistingBMPfile: Whole path
@@ -1016,14 +2270,18 @@
                          save changes to
         x1, y1, x2, y2 : the rectagular
                          region
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def cropBMPandsaveusingrectbnd(ExistingBMPfile: str, NewBMPfile: str, rectbnd: list):**
->Crops and saves a rectangular area to a BMP
+### [`cropBMPandsaveusingrectbnd`](#Python_BMP.BITMAPlib.cropBMPandsaveusingrectbnd)
+
+```py
+def cropBMPandsaveusingrectbnd(ExistingBMPfile: str, NewBMPfile: str, rectbnd: list):
+```
+
+Crops and saves a rectangular area to a BMP
 
     Args:
         ExistingBMPfile: Whole path
@@ -1037,29 +2295,37 @@
                           (x2, y2),
                           (x3, y3),
                           (x4, y4)]
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def cubevert(x: float) -> list[list[float, float, float]]:**
->Returns a list of vertices
-        for a cube
+### [`cubevert`](#Python_BMP.solids3D.cubevert)
+
+```py
+def cubevert(x: float) -> list[list[float, float, float]]:
+```
+
+Returns a list of vertices
+    for a cube
 
     Args:
         x: length of a side
-
+    
     Returns:
         list (x: float,
               y: float,
               z: float)
-    
 
 
-**def cylindervertandsurface(vcen: list[float, float, float], r: float, zlen: float, deganglestep: float) -> tuple:**
->Returns a list of sparse vertices
-       and tiled surfaces for a cylinder
+### [`cylindervertandsurface`](#Python_BMP.solids3D.cylindervertandsurface)
+
+```py
+def cylindervertandsurface(vcen: list[float, float, float], r: float, zlen: float, deganglestep: float) -> tuple:
+```
+
+Returns a list of sparse vertices
+   and tiled surfaces for a cylinder
 
     Args:
         vcen       : [x: float, center
@@ -1071,60 +2337,76 @@
         deganglestep: angle step between
         vertices that controls how sparse
         the list will be
-
+    
     Returns:
         list of vertices and surfaces
         for plot3Dsolid()
         see Hello_Coin.py
-    
 
 
-**def decahedvertandsurface(x: float) -> list[list[float, float, float]]:**
->Returns a list of vertices
-        for a decahedron
+### [`decahedvertandsurface`](#Python_BMP.solids3D.decahedvertandsurface)
+
+```py
+def decahedvertandsurface(x: float) -> list[list[float, float, float]]:
+```
+
+Returns a list of vertices
+    for a decahedron
 
     Args:
         x: min radius of sphere
            that can hold
            the decahedron
-
+    
     Returns:
         list (x: float,
               y: float,
               z: float)
-    
 
 
-**def dict2descorderlist(d: dict) -> list:**
->Creates a sorted list in
-        decending order from
-        a dictionary with counts
+### [`dict2descorderlist`](#Python_BMP.dicttools.dict2descorderlist)
+
+```py
+def dict2descorderlist(d: dict) -> list:
+```
+
+Creates a sorted list in
+    decending order from
+    a dictionary with counts
 
     Args:
         dict: histogram or
               frequency count
-
+    
     Returns:
         list
-    
 
 
-**def distance(u: list[float], v: list[float]) -> float:**
->Compute the Distance or length of a vector v
-    of arbitrary dimension n in a n-dimensional
-    Euclidean space where u and v are both vectors
-    with n components
+### [`distance`](#Python_BMP.mathlib.distance)
+
+```py
+def distance(u: list[float], v: list[float]) -> float:
+```
+
+Compute the Distance or length of a vector v
+of arbitrary dimension n in a n-dimensional
+Euclidean space where u and v are both vectors
+with n components
 
     Args:
         u, v: list of ints or floats
-
+    
     Returns:
         float
-    
 
 
-**def drawarc(bmp: array.array, x: int, y: int, r: int, startdegangle: float, enddegangle: float, color: int, showoutline: bool, fillcolor: int, isfilled: bool):**
->Draws an Arc
+### [`drawarc`](#Python_BMP.BITMAPlib.drawarc)
+
+```py
+def drawarc(bmp: array.array, x: int, y: int, r: int, startdegangle: float, enddegangle: float, color: int, showoutline: bool, fillcolor: int, isfilled: bool):
+```
+
+Draws an Arc
 
     Args:
         bmp        : unsigned
@@ -1142,14 +2424,18 @@
                              inside the
                              arc to
                              fillcolor
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def drawvec(bmp: array.array, u: list, v: list, headsize: int, color: int, penradius: int = None):**
->Draws a vector (line segment with arrow head)
+### [`drawvec`](#Python_BMP.BITMAPlib.drawvec)
+
+```py
+def drawvec(bmp: array.array, u: list, v: list, headsize: int, color: int, penradius: int = None):
+```
+
+Draws a vector (line segment with arrow head)
 
     Args:
         bmp      : unsigned byte array
@@ -1163,14 +2449,18 @@
         color    : color of the vector
         penradius: optional parameter
                    for thick arrow
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def ellipse(bmp: array.array, x: int, y: int, b: int, a: int, color: int, isfilled: bool = None):**
->Draws an Ellipse
+### [`ellipse`](#Python_BMP.BITMAPlib.ellipse)
+
+```py
+def ellipse(bmp: array.array, x: int, y: int, b: int, a: int, color: int, isfilled: bool = None):
+```
+
+Draws an Ellipse
 
     Args:
         bmp     : unsigned byte array
@@ -1183,143 +2473,179 @@
                   False-> one pixel
                           thick
                           ellipse
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def ellipsevert(x: int, y: int, b: int, a: int) -> list[int, int]:**
->Returns (int, int) 2D vertices
-    along a path defined by major and
-    minor axes b and a as it traces
-    an ellipse with origin set at (x, y)
+### [`ellipsevert`](#Python_BMP.primitives2D.ellipsevert)
+
+```py
+def ellipsevert(x: int, y: int, b: int, a: int) -> list[int, int]:
+```
+
+Returns (int, int) 2D vertices
+along a path defined by major and
+minor axes b and a as it traces
+an ellipse with origin set at (x, y)
 
     Args:
         x, y: center of the ellipse
         b, a: major and minor axes
-
+    
     Returns:
         The list vertices of an
         ellipse
         [[x: int, y: int], ...]
-    
 
 
-**def entirecircleinboundary(func):**
->Decorator to ensure that the 2nd,
-        3rd, 4th parameters are ints
-        whose values when interpreted
-        as the centerpoint x, y
-        and radius r of a circle
-        lay within the RGB bitmap.
+### [`entirecircleinboundary`](#Python_BMP.paramchecks.entirecircleinboundary)
+
+```py
+def entirecircleinboundary(func):
+```
+
+Decorator to ensure that the 2nd,
+    3rd, 4th parameters are ints
+    whose values when interpreted
+    as the centerpoint x, y
+    and radius r of a circle
+    lay within the RGB bitmap.
 
     Args:
         function(bmp:array,x:int,y:int,r:int...)
-
+    
     Returns:
         caller function
-    
 
 
-**def entirecircleisinboundary(x: int, y: int, minx: int, maxx: int, miny: int, maxy: int, r: int):**
->Checks if an entire circle
-    is within a rectagular area
+### [`entirecircleisinboundary`](#Python_BMP.primitives2D.entirecircleisinboundary)
+
+```py
+def entirecircleisinboundary(x: int, y: int, minx: int, maxx: int, miny: int, maxy: int, r: int):
+```
+
+Checks if an entire circle
+is within a rectagular area
 
     Args:
         x, y: center of the ellipse
         xmin, ymin: min (x, y) bounds
         xmax, ymax: max (x, y) bounds
         r   : radius of the circle
-
+    
     Returns:
         boolean value
         True  -> All (x, y)
                  is in bounds
         False -> Not all (x, y)
                  is in bounds
-    
 
 
-**def entireellipseisinboundary(x: int, y: int, minx: int, maxx: int, miny: int, maxy: int, b: int, a: int):**
->Checks if an entire ellipse
-    is within a rectagular area
+### [`entireellipseisinboundary`](#Python_BMP.primitives2D.entireellipseisinboundary)
+
+```py
+def entireellipseisinboundary(x: int, y: int, minx: int, maxx: int, miny: int, maxy: int, b: int, a: int):
+```
+
+Checks if an entire ellipse
+is within a rectagular area
 
     Args:
         x, y: center of the ellipse
         xmin, ymin: min (x, y) bounds
         xmax, ymax: max (x, y) bounds
         b, a: major and minor axes
-
+    
     Returns:
         boolean value
         True  -> All (x, y)
                  is in bounds
         False -> Not all (x, y)
                  is in bounds
-    
 
 
-**def entirerectinboundary(func):**
->Decorator to ensure that the
-        2nd, 3rd, 4th and 5th
-        parameters are ints whose
-        values when interpreted as
-        x and y coordinates of a
-        rectangle lay within the
-        bitmap.
+### [`entirerectinboundary`](#Python_BMP.paramchecks.entirerectinboundary)
+
+```py
+def entirerectinboundary(func):
+```
+
+Decorator to ensure that the
+    2nd, 3rd, 4th and 5th
+    parameters are ints whose
+    values when interpreted as
+    x and y coordinates of a
+    rectangle lay within the
+    bitmap.
 
     Args:
         function
-
+    
     Returns:
         caller function
-    
 
 
-**def enumbits(byteval: int):**
->Yields the 8 bits in a byte
+### [`enumbits`](#Python_BMP.mathlib.enumbits)
+
+```py
+def enumbits(byteval: int):
+```
+
+Yields the 8 bits in a byte
 
     Args:
         byteval: int value
                  from 0 to 255
-
+    
     Yields:
         Eight bits that is either
         int 0 or int 1
-    
 
 
-**def enumletters(st: str) -> str:**
->Enumerates the characters
-        in a string
+### [`enumletters`](#Python_BMP.chartools.enumletters)
 
-    Args:
-        st: string
+```py
+def enumletters(st: str) -> str:
+```
 
-    Yields:
-        individual characters
-    
-
-
-**def enumreverseletters(st: str) -> str:**
->Enumerates the characters in a
-        string in reverse order
+Enumerates the characters
+    in a string
 
     Args:
         st: string
-
+    
     Yields:
         individual characters
+
+
+### [`enumreverseletters`](#Python_BMP.chartools.enumreverseletters)
+
+```py
+def enumreverseletters(st: str) -> str:
+```
+
+Enumerates the characters in a
+    string in reverse order
+
+    Args:
+        st: string
     
+    Yields:
+        individual characters
 
 
-**def epicycloidvert(x: int, y: int, a: float, b: float, delta: float, lim: float):**
->Returns (int, int) 2D vertices
-    along a path defined by epicycloid
-    traced by a circle of radius b which
-    rolls round a circle of radius a
-    with an origin set at (x, y)
+### [`epicycloidvert`](#Python_BMP.primitives2D.epicycloidvert)
+
+```py
+def epicycloidvert(x: int, y: int, a: float, b: float, delta: float, lim: float):
+```
+
+Returns (int, int) 2D vertices
+along a path defined by epicycloid
+traced by a circle of radius b which
+rolls round a circle of radius a
+with an origin set at (x, y)
 
     Args:
         x, y : center of epicycloid
@@ -1327,16 +2653,20 @@
         b    : radius of rolling circle
         delta: angle increment in radians
         lim  : angle limit in radians
-
+    
     Returns:
         The vertices of an
         epicycloid in a list
         [[x: int, y: int], ...]
-    
 
 
-**def erasealternatehorizontallines(bmp: array.array, int_eraseeverynline: int, int_eraseNthline: int, bytepat: int):**
->Erase every nth line
+### [`erasealternatehorizontallines`](#Python_BMP.BITMAPlib.erasealternatehorizontallines)
+
+```py
+def erasealternatehorizontallines(bmp: array.array, int_eraseeverynline: int, int_eraseNthline: int, bytepat: int):
+```
+
+Erase every nth line
 
     Args:
         bmp                : unsigned
@@ -1356,15 +2686,19 @@
                              to overwrite
                              the erased
                              lines
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def erasealternatehorizontallinesincircregion(bmp: array.array, x: int, y: int, r: int, int_eraseeverynline: int, int_eraseNthline: int, bytepat: int):**
->Erase every nth line
-        in a circular region
+### [`erasealternatehorizontallinesincircregion`](#Python_BMP.BITMAPlib.erasealternatehorizontallinesincircregion)
+
+```py
+def erasealternatehorizontallinesincircregion(bmp: array.array, x: int, y: int, r: int, int_eraseeverynline: int, int_eraseNthline: int, bytepat: int):
+```
+
+Erase every nth line
+    in a circular region
 
     Args:
         bmp                : unsigned
@@ -1389,14 +2723,18 @@
                              overwrite
                              the erased
                              lines
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def erasealternatehorizontallinesinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, int_eraseeverynline: int, int_eraseNthline: int, bytepat: int):**
->Erase every nth line in a rectangular region
+### [`erasealternatehorizontallinesinregion`](#Python_BMP.BITMAPlib.erasealternatehorizontallinesinregion)
+
+```py
+def erasealternatehorizontallinesinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, int_eraseeverynline: int, int_eraseNthline: int, bytepat: int):
+```
+
+Erase every nth line in a rectangular region
 
     Args:
         bmp                : unsigned
@@ -1418,14 +2756,18 @@
                              overwrite
                              the erased
                              lines
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def eraseeverynthhoriline2file(ExistingBMPfile: str, NewBMPfile: str, n: int):**
->Erase every nth line
+### [`eraseeverynthhoriline2file`](#Python_BMP.BITMAPlib.eraseeverynthhoriline2file)
+
+```py
+def eraseeverynthhoriline2file(ExistingBMPfile: str, NewBMPfile: str, n: int):
+```
+
+Erase every nth line
 
     Args:
         ExistingBMPfile: Whole path
@@ -1434,14 +2776,18 @@
                          save changes in
         n              : erase every
                          nth line
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def eraseeverynthhorilineinccircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, n: int):**
->Erase every nth horzontal line in a circular area
+### [`eraseeverynthhorilineinccircregion2file`](#Python_BMP.BITMAPlib.eraseeverynthhorilineinccircregion2file)
+
+```py
+def eraseeverynthhorilineinccircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, n: int):
+```
+
+Erase every nth horzontal line in a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -1453,35 +2799,18 @@
                          in which we
         n              : omit every
                          nth line
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def eraseeverynthhorilineinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, n: int):**
->Erase every nth line in a
-        rectangular region
+### [`eraseeverynthhorilineinregion2file`](#Python_BMP.BITMAPlib.eraseeverynthhorilineinregion2file)
 
-    Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: defines the
-                        rectangular
-                        region
-        n             : erase every
-                        nth line in the
-                        rectangular area
+```py
+def eraseeverynthhorilineinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, n: int):
+```
 
-    Returns:
-        byref modified
-        unsigned byte array
-    
-
-
-**def eraseeverynthhorilineinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, n: int):**
->Erase every nth line in a rectangular region
+Erase every nth line in a rectangular region
 
     Args:
         ExistingBMPfile: Whole path to
@@ -1494,27 +2823,60 @@
                          region
         n              : erase every
                          nth line
-
+    
     Returns:
         new bitmap file
+
+
+### [`eraseeverynthhorilineinregion`](#Python_BMP.BITMAPlib.eraseeverynthhorilineinregion)
+
+```py
+def eraseeverynthhorilineinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, n: int):
+```
+
+Erase every nth line in a
+    rectangular region
+
+    Args:
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: defines the
+                        rectangular
+                        region
+        n             : erase every
+                        nth line in the
+                        rectangular area
     
+    Returns:
+        byref modified
+        unsigned byte array
 
 
-**def eraseeverynthhorizontalline(bmp: array.array, n: int):**
->Erase every nth horizontal line
+### [`eraseeverynthhorizontalline`](#Python_BMP.BITMAPlib.eraseeverynthhorizontalline)
+
+```py
+def eraseeverynthhorizontalline(bmp: array.array, n: int):
+```
+
+Erase every nth horizontal line
 
     Args:
         bmp: unsigned byte array
              with bmp format
         n  : erase every nth line
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def eraseeverynthhorizontallineinccircregion(bmp: array.array, x: int, y: int, r: int, n: int):**
->Erase every nth horizontal line in a circular region
+### [`eraseeverynthhorizontallineinccircregion`](#Python_BMP.BITMAPlib.eraseeverynthhorizontallineinccircregion)
+
+```py
+def eraseeverynthhorizontallineinccircregion(bmp: array.array, x: int, y: int, r: int, n: int):
+```
+
+Erase every nth horizontal line in a circular region
 
     Args:
         bmp    : unsigned byte array
@@ -1523,32 +2885,18 @@
                  and radius r
                  of the circular area
         n      : erase every nth line
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def fern(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):**
->Draws an IFS fern fractal
+### [`fern2file`](#Python_BMP.BITMAPlib.fern2file)
 
-    Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: rectangular
-                        area to draw
-                        the fern in
-        color         : color of the
-                        fern fractal
+```py
+def fern2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, color: int):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def fern2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, color: int):**
->Fern Fractal in a bounding rectangle
+Fern Fractal in a bounding rectangle
 
     Args:
         ExistingBMPfile: Whole path to
@@ -1559,14 +2907,40 @@
                          rectangular region
         color          : color of the
                          fern fractal
-
+    
     Returns:
         new bitmap file
+
+
+### [`fern`](#Python_BMP.BITMAPlib.fern)
+
+```py
+def fern(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):
+```
+
+Draws an IFS fern fractal
+
+    Args:
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: rectangular
+                        area to draw
+                        the fern in
+        color         : color of the
+                        fern fractal
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def fillbackgroundwithgrad(bmp: array.array, lumrange: list[int, int], RGBfactors: list[float, float, float], direction: int):**
->Fills entire bitmap with a linear gradient
+### [`fillbackgroundwithgrad`](#Python_BMP.BITMAPlib.fillbackgroundwithgrad)
+
+```py
+def fillbackgroundwithgrad(bmp: array.array, lumrange: list[int, int], RGBfactors: list[float, float, float], direction: int):
+```
+
+Fills entire bitmap with a linear gradient
 
     Args:
         bmp       : unsigned byte array
@@ -1579,45 +2953,36 @@
                     floats from 0 to 1
         direction : 0 - vertical
                     1 - horizontal
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def fillboundary(bmp: array.array, bndfilldic: dict, color: int):**
->Draws lines in a boundary to fill it
+### [`fillboundary`](#Python_BMP.BITMAPlib.fillboundary)
+
+```py
+def fillboundary(bmp: array.array, bndfilldic: dict, color: int):
+```
+
+Draws lines in a boundary to fill it
 
     Args:
         bmp       : unsigned byte array
                     with bmp format
         bndfilldic: boundary dictionary
         color     : color of fill
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def filledcircle(bmp: array.array, x: int, y: int, r: int, color: int):**
->Draws a Filled Circle
+### [`filledcircle2file`](#Python_BMP.BITMAPlib.filledcircle2file)
 
-    Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x, y)
-                 and radius r
-                 of filled circle
-        color  : color of the
-                 filled circle
+```py
+def filledcircle2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, color: int):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def filledcircle2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, color: int):**
->Draws a Filled Circle
+Draws a Filled Circle
 
     Args:
         ExistingBMPfile: Whole path to
@@ -1628,14 +2993,39 @@
                          and radius r
         color          : color of the
                          circular region
-
+    
     Returns:
         new bitmap file
+
+
+### [`filledcircle`](#Python_BMP.BITMAPlib.filledcircle)
+
+```py
+def filledcircle(bmp: array.array, x: int, y: int, r: int, color: int):
+```
+
+Draws a Filled Circle
+
+    Args:
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x, y)
+                 and radius r
+                 of filled circle
+        color  : color of the
+                 filled circle
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def filledellipse(bmp: array.array, x: int, y: int, b: int, a: int, color: int):**
->Filled Ellipse
+### [`filledellipse`](#Python_BMP.BITMAPlib.filledellipse)
+
+```py
+def filledellipse(bmp: array.array, x: int, y: int, b: int, a: int, color: int):
+```
+
+Filled Ellipse
 
     Args:
         bmp  : unsigned byte array
@@ -1643,14 +3033,18 @@
         x, y : center of ellipse
         b, a : major amd minor axis
         color: color of the ellipse
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def filledgradrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int], RGBfactors: list[float, float, float], direction: int):**
->Draw a filled rectangle with a linear gradient
+### [`filledgradrect`](#Python_BMP.BITMAPlib.filledgradrect)
+
+```py
+def filledgradrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int], RGBfactors: list[float, float, float], direction: int):
+```
+
+Draw a filled rectangle with a linear gradient
 
     Args:
         bmp            : unsigned
@@ -1670,15 +3064,19 @@
                          from 0.0 to 1.0
         direction      : 0 - vertical
                          1 - horizontal
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def filledparallelogram(bmp: array.array, p1: list, p2: list, p3: list, color: int):**
->Creates a filled parallelogram defined by 3 points
+### [`filledparallelogram`](#Python_BMP.BITMAPlib.filledparallelogram)
+
+```py
+def filledparallelogram(bmp: array.array, p1: list, p2: list, p3: list, color: int):
+```
+
+Creates a filled parallelogram defined by 3 points
 
     Args:
         bmp       : unsigned byte array
@@ -1688,14 +3086,18 @@
                     a parallelogram
         color     : color of the
                     filled parallelgram
-
+    
     Returns:
         byref unsigned modified byte array
-    
 
 
-**def filledrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):**
->Draws a Filled Rectangle
+### [`filledrect`](#Python_BMP.BITMAPlib.filledrect)
+
+```py
+def filledrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):
+```
+
+Draws a Filled Rectangle
 
     Args:
         bmp           : unsigned
@@ -1706,16 +3108,20 @@
                         region
         color         : color of the
                         rectangle
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def fillpolydata(polybnd: list[list[int, int]], xlim: int, ylim: int) -> list:**
->Generates a list of x values per
-        y values for filling polygon
-        boundaries
+### [`fillpolydata`](#Python_BMP.solids3D.fillpolydata)
+
+```py
+def fillpolydata(polybnd: list[list[int, int]], xlim: int, ylim: int) -> list:
+```
+
+Generates a list of x values per
+    y values for filling polygon
+    boundaries
 
     Args:
         polybnd : list of 2D vertices
@@ -1727,34 +3133,22 @@
                   def polyboundary)
         xlim    : Screen limit x dim
         ylim    : Screen limit x dim
-
+    
     Returns:
         A dictionary with y values
         as key and list of x values
         per key (if within bounds)
         or an empty list if out of
         bounds
-    
 
 
-**def fliphoricircregion(bmp: array.array, x: int, y: int, r: int):**
->Flips horizontally a circular area
+### [`fliphoricircregion2file`](#Python_BMP.BITMAPlib.fliphoricircregion2file)
 
-    Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x, y)
-                 and radius r
-                 of circular region
+```py
+def fliphoricircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
 
-    Returns:
-        byref modified
-        unsigned byte array
-    
-
-
-**def fliphoricircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Horizontal Flip of a circular area
+Horizontal Flip of a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -1763,60 +3157,74 @@
                          save changes in
         x, y, r        : center (x,y)
                          and radius r
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def fliphorizontal(bmp: array.array):**
->Does a horizontal flip of an
-        in-memory bitmap
+### [`fliphoricircregion`](#Python_BMP.BITMAPlib.fliphoricircregion)
+
+```py
+def fliphoricircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Flips horizontally a circular area
 
     Args:
-        bmp: unsigned byte array
-             with bmp format
-
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x, y)
+                 and radius r
+                 of circular region
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def fliphorizontal2file(ExistingBMPfile: str, NewBMPfile: str):**
->Flips horizontally the image in a BMP
+### [`fliphorizontal2file`](#Python_BMP.BITMAPlib.fliphorizontal2file)
+
+```py
+def fliphorizontal2file(ExistingBMPfile: str, NewBMPfile: str):
+```
+
+Flips horizontally the image in a BMP
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def fliphorizontalregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Does a horizontal flip
-        of a rectangular area
+### [`fliphorizontal`](#Python_BMP.BITMAPlib.fliphorizontal)
+
+```py
+def fliphorizontal(bmp: array.array):
+```
+
+Does a horizontal flip of an
+    in-memory bitmap
 
     Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: defines the
-                        rectangular
-                        region
-
+        bmp: unsigned byte array
+             with bmp format
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def fliphorizontalregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Flips horizontally a rectangular area in a BMP
+### [`fliphorizontalregion2file`](#Python_BMP.BITMAPlib.fliphorizontalregion2file)
+
+```py
+def fliphorizontalregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
+
+Flips horizontally a rectangular area in a BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -1825,17 +3233,19 @@
                          save changes in
         x1, y1, x2, y2 : the rectangular
                          region
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def fliphorzontalpixelbased(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Flips horizontal
-        a rectangular region
-        using pixel addressing
-        (slightly slow)
+### [`fliphorizontalregion`](#Python_BMP.BITMAPlib.fliphorizontalregion)
+
+```py
+def fliphorizontalregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Does a horizontal flip
+    of a rectangular area
 
     Args:
         bmp           : unsigned
@@ -1844,19 +3254,46 @@
         x1, y1, x2, y2: defines the
                         rectangular
                         region
-
+    
     Returns:
         byref modified
         unsigned byte array
 
+
+### [`fliphorzontalpixelbased`](#Python_BMP.BITMAPlib.fliphorzontalpixelbased)
+
+```py
+def fliphorzontalpixelbased(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Flips horizontal
+    a rectangular region
+    using pixel addressing
+    (slightly slow)
+
+    Args:
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: defines the
+                        rectangular
+                        region
     
+    Returns:
+        byref modified
+        unsigned byte array
 
 
-**def fliphverticalalpixelbased(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Flips vertical
-        a rectangular region
-        using pixel addressing
-        (slightly slow)
+### [`fliphverticalalpixelbased`](#Python_BMP.BITMAPlib.fliphverticalalpixelbased)
+
+```py
+def fliphverticalalpixelbased(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Flips vertical
+    a rectangular region
+    using pixel addressing
+    (slightly slow)
 
     Args:
         bmp           : unsigned
@@ -1864,41 +3301,34 @@
                         with bmp format
         x1, y1, x2, y2: the rectangular
                         region
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def flipnibbleinbuf(buf: array.array) -> array.array:**
->Flips a 4-bit image buffer
+### [`flipnibbleinbuf`](#Python_BMP.bufferflip.flipnibbleinbuf)
+
+```py
+def flipnibbleinbuf(buf: array.array) -> array.array:
+```
+
+Flips a 4-bit image buffer
 
     Args:
         buf: unsigned byte array
-
+    
     Returns:
         unsigned byte array
-    
 
 
-**def flipvertcircregion(bmp: array.array, x: int, y: int, r: int):**
->Vertical Flip of a circular area
+### [`flipvertcircregion2file`](#Python_BMP.BITMAPlib.flipvertcircregion2file)
 
-    Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x, y)
-                 and radius r
-                 of a region
+```py
+def flipvertcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def flipvertcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Vertical Flip of a circular area
+Vertical Flip of a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -1907,57 +3337,72 @@
                          save changes to
         x, y, r        : center (x, y)
                          and radius r
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def flipvertical(bmp: array.array):**
->Does an vertical flip of a bmp
+### [`flipvertcircregion`](#Python_BMP.BITMAPlib.flipvertcircregion)
+
+```py
+def flipvertcircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Vertical Flip of a circular area
 
     Args:
-        bmp: unsigned byte array
-        with bmp format
-
-    Returns:
-        byref modified
-        unsigned byte array
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x, y)
+                 and radius r
+                 of a region
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def flipvertical2file(ExistingBMPfile: str, NewBMPfile: str):**
->Flips a bitmap file vertically
+### [`flipvertical2file`](#Python_BMP.BITMAPlib.flipvertical2file)
+
+```py
+def flipvertical2file(ExistingBMPfile: str, NewBMPfile: str):
+```
+
+Flips a bitmap file vertically
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def flipverticalregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Flips vertical a rectangular area
+### [`flipvertical`](#Python_BMP.BITMAPlib.flipvertical)
+
+```py
+def flipvertical(bmp: array.array):
+```
+
+Does an vertical flip of a bmp
 
     Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: defines the
-                        rectangle
-
+        bmp: unsigned byte array
+        with bmp format
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def flipverticalregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Flips vertically a rectangular area in a BMP
+### [`flipverticalregion2file`](#Python_BMP.BITMAPlib.flipverticalregion2file)
+
+```py
+def flipverticalregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
+
+Flips vertically a rectangular area in a BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -1967,57 +3412,75 @@
         x1, y1, x2, y2 : defines the
                          rectangular
                          region
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def flipXY(bmp: array.array):**
->Flips the x and y coordinates of
-        an in-memory bitmap for a
-        90 degree rotation
+### [`flipverticalregion`](#Python_BMP.BITMAPlib.flipverticalregion)
+
+```py
+def flipverticalregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Flips vertical a rectangular area
 
     Args:
-        bmp: unsigned byte array
-             with bmp format
-
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: defines the
+                        rectangle
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def flipXY2file(ExistingBMPfile: str, NewBMPfile: str):**
->Flips the x and y coordinates to rotate by 90 degrees
+### [`flipXY2file`](#Python_BMP.BITMAPlib.flipXY2file)
+
+```py
+def flipXY2file(ExistingBMPfile: str, NewBMPfile: str):
+```
+
+Flips the x and y coordinates to rotate by 90 degrees
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def flipXYcircregion(bmp: array.array, x: int, y: int, r: int):**
->Flip the X and Y coordinates of a circular area
+### [`flipXY`](#Python_BMP.BITMAPlib.flipXY)
+
+```py
+def flipXY(bmp: array.array):
+```
+
+Flips the x and y coordinates of
+    an in-memory bitmap for a
+    90 degree rotation
 
     Args:
-        bmp     : unsigned byte array
-                  with bmp format
-        x, y, r : center (x,y) and
-                  radius r of region
-
-    Returns:
-        byref modified unsigned byte array
+        bmp: unsigned byte array
+             with bmp format
     
+    Returns:
+        byref modified
+        unsigned byte array
 
 
-**def flipXYcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Flips the x and y coordinates of a circular area
+### [`flipXYcircregion2file`](#Python_BMP.BITMAPlib.flipXYcircregion2file)
+
+```py
+def flipXYcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
+
+Flips the x and y coordinates of a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -2026,130 +3489,179 @@
                          save changes to
         x, y, r        : center (x, y)
                          and radius r
-
+    
     Returns:
         new bitmap file
+
+
+### [`flipXYcircregion`](#Python_BMP.BITMAPlib.flipXYcircregion)
+
+```py
+def flipXYcircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Flip the X and Y coordinates of a circular area
+
+    Args:
+        bmp     : unsigned byte array
+                  with bmp format
+        x, y, r : center (x,y) and
+                  radius r of region
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def flowervert(cx: int, cy: int, r: int, petals: int, angrot: float):**
->Returns a list of 2D points for a flower
+### [`flowervert`](#Python_BMP.primitives2D.flowervert)
+
+```py
+def flowervert(cx: int, cy: int, r: int, petals: int, angrot: float):
+```
+
+Returns a list of 2D points for a flower
 
     Args:
         cx, cy, r : center (cx,cy)
                     and radius r
         petals    : number of petals
         angrot    : angle of rotation
-
+    
     Returns:
         list[(x: int, y: int)]
-    
 
 
-**def func24bitonly(func):**
->Decorator to restrict the
-        use of this function to only
-        24-bit or RGB bitmaps
-        (1st parameter)
+### [`func24bitonly`](#Python_BMP.paramchecks.func24bitonly)
+
+```py
+def func24bitonly(func):
+```
+
+Decorator to restrict the
+    use of this function to only
+    24-bit or RGB bitmaps
+    (1st parameter)
 
     Args:
         function(bmp:array,...)
-
+    
     Returns:
         caller function
-    
 
 
-**def func24bitonlyandentirecircleinboundary(func):**
->Decorator to restrict the
-        use of this function to only
-        24-bit bitmaps (1st parameter)
-        and ensure that the 2nd, 3rd,
-        4th parameters are ints whose
-        values when interpreted as
-        x, y and radius of a circle
-        lay within the RGB bitmap.
+### [`func24bitonlyandentirecircleinboundary`](#Python_BMP.paramchecks.func24bitonlyandentirecircleinboundary)
+
+```py
+def func24bitonlyandentirecircleinboundary(func):
+```
+
+Decorator to restrict the
+    use of this function to only
+    24-bit bitmaps (1st parameter)
+    and ensure that the 2nd, 3rd,
+    4th parameters are ints whose
+    values when interpreted as
+    x, y and radius of a circle
+    lay within the RGB bitmap.
 
     Args:
         function(bmp:array,x:int,y:int,r:int...)
-
+    
     Returns:
         caller function
-    
 
 
-**def func24bitonlyandentirerectinboundary(func):**
->Decorator to restrict the
-        use of this function to only
-        24-bit or RGB bitmaps
-        (1st parameter) and ensure that
-        the 2nd, 3rd, 4th and 5th
-        parameters are ints whose
-        values when interpreted as
-        x and y coordinates lay
-        within the RGB bitmap.
+### [`func24bitonlyandentirerectinboundary`](#Python_BMP.paramchecks.func24bitonlyandentirerectinboundary)
+
+```py
+def func24bitonlyandentirerectinboundary(func):
+```
+
+Decorator to restrict the
+    use of this function to only
+    24-bit or RGB bitmaps
+    (1st parameter) and ensure that
+    the 2nd, 3rd, 4th and 5th
+    parameters are ints whose
+    values when interpreted as
+    x and y coordinates lay
+    within the RGB bitmap.
 
     Args:
         function
-
+    
     Returns:
         caller function
-    
 
 
-**def func8and24bitonlyandentirecircleinboundary(func):**
->Decorator to restrict the
-        use of this function to only
-        24-bit or 8-bit bitmaps
-        (1st parameter) and ensure
-        that the 2nd, 3rd, 4th
-        parameters are ints whose
-        values when interpreted as
-        x, y and radius of a circle
-        lay within the RGB bitmap.
+### [`func8and24bitonlyandentirecircleinboundary`](#Python_BMP.paramchecks.func8and24bitonlyandentirecircleinboundary)
+
+```py
+def func8and24bitonlyandentirecircleinboundary(func):
+```
+
+Decorator to restrict the
+    use of this function to only
+    24-bit or 8-bit bitmaps
+    (1st parameter) and ensure
+    that the 2nd, 3rd, 4th
+    parameters are ints whose
+    values when interpreted as
+    x, y and radius of a circle
+    lay within the RGB bitmap.
 
     Args:
         function(bmp:array,x:int,y:int,r:int...)
-
+    
     Returns:
         caller function
-    
 
 
-**def func8and24bitonlyandentirerectinboundary(func):**
->Decorator to restrict the
-        use of this functiom to only
-        24 bit or 8 bit bitmaps
-        (1st parameter) and ensure
-        that the 2nd, 3rd, 4th and
-        5th parameters are ints whose
-        values when interpreted as
-        x and y coordinates of a
-        rectangle lay within
-        the RGB bitmap.
+### [`func8and24bitonlyandentirerectinboundary`](#Python_BMP.paramchecks.func8and24bitonlyandentirerectinboundary)
+
+```py
+def func8and24bitonlyandentirerectinboundary(func):
+```
+
+Decorator to restrict the
+    use of this functiom to only
+    24 bit or 8 bit bitmaps
+    (1st parameter) and ensure
+    that the 2nd, 3rd, 4th and
+    5th parameters are ints whose
+    values when interpreted as
+    x and y coordinates of a
+    rectangle lay within
+    the RGB bitmap.
 
     Args:
         function
-
+    
     Returns:
         caller function
-    
 
 
-**def functimer(func):**
->Function timer Decorator
+### [`functimer`](#Python_BMP.proctimer.functimer)
+
+```py
+def functimer(func):
+```
+
+Function timer Decorator
 
     Args:
         function
-
+    
     Returns:
         caller function
 
-    
 
+### [`gammaadj2file`](#Python_BMP.BITMAPlib.gammaadj2file)
 
-**def gammaadj2file(ExistingBMPfile: str, NewBMPfile: str, gamma: float):**
->Applies a Gamma Correction
+```py
+def gammaadj2file(ExistingBMPfile: str, NewBMPfile: str, gamma: float):
+```
+
+Applies a Gamma Correction
 
     Args:
         ExistingBMPfile: Whole path to
@@ -2158,27 +3670,35 @@
                          save changes in
         gamma          : gamma
                          correction
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def gammaadjto24bitimage(bmp: array.array, gamma: float):**
->Gamma correction to an in-memory 24-bit BMP
+### [`gammaadjto24bitimage`](#Python_BMP.BITMAPlib.gammaadjto24bitimage)
+
+```py
+def gammaadjto24bitimage(bmp: array.array, gamma: float):
+```
+
+Gamma correction to an in-memory 24-bit BMP
 
     Args:
         bmp  : unsigned byte array
                with bmp format
         gamma: gamma correction
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def gammaadjto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, gamma: float):**
->Gamma correction to a rectangular area in a 24-bit BMP
+### [`gammaadjto24bitregion`](#Python_BMP.BITMAPlib.gammaadjto24bitregion)
+
+```py
+def gammaadjto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, gamma: float):
+```
+
+Gamma correction to a rectangular area in a 24-bit BMP
 
     Args:
         bmp           : unsigned
@@ -2188,14 +3708,18 @@
                         rectangular
                         region
         gamma         : gamma correction
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def gammaadjtoregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, gamma: float):**
->Gamma Correction to a Rectangular Region
+### [`gammaadjtoregion2file`](#Python_BMP.BITMAPlib.gammaadjtoregion2file)
+
+```py
+def gammaadjtoregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, gamma: float):
+```
+
+Gamma Correction to a Rectangular Region
 
     Args:
         ExistingBMPfile: Whole path to
@@ -2207,63 +3731,58 @@
                          region
         gamma          : gamma
                          correction
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def gammaBGRbuf(buf: array.array, gamma: float) -> array.array:**
->Apply a gamma adjustment to a
-        BGR buffer
+### [`gammaBGRbuf`](#Python_BMP.colors.gammaBGRbuf)
+
+```py
+def gammaBGRbuf(buf: array.array, gamma: float) -> array.array:
+```
+
+Apply a gamma adjustment to a
+    BGR buffer
 
     Args:
         buf: unsigned byte array
              holding BGR data
-
+    
         gamma: float gamma adjust
-
+    
     Returns:
         unsigned byte array
         holding gamma adjusted
         BGR data
-    
 
 
-**def gammacorrect(rgb: list[int, int, int], gamma: float) -> list[int, int, int]:**
->Apply a gamma factor to a rgb
+### [`gammacorrect`](#Python_BMP.colors.gammacorrect)
+
+```py
+def gammacorrect(rgb: list[int, int, int], gamma: float) -> list[int, int, int]:
+```
+
+Apply a gamma factor to a rgb
 
     Args:
         rgb: color as [r: byte,
                        g: byte,
                        b: byte]
         gamma  : gamma adjustment
-
+    
     Returns:
         a gamma adjusted color as
         [r: byte, g: byte, b: byte]
-    
 
 
-**def gammacorrectcircregion(bmp: array.array, x: int, y: int, r: int, gamma: float):**
->Gamma correction to a circular area
+### [`gammacorrectcircregion2file`](#Python_BMP.BITMAPlib.gammacorrectcircregion2file)
 
-    Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x, y)
-                 and radius r
-                 of the region
-        gamma  : float value of the
-                 gamma adjustment
+```py
+def gammacorrectcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, gamma: float):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def gammacorrectcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, gamma: float):**
->Gamma Adjust to a circular area in a BMP
+Gamma Adjust to a circular area in a BMP
 
     Args:
         ExistingBMPfile: Whole path
@@ -2276,132 +3795,226 @@
                          region
         gamma          : gamma
                          adjustment
-
+    
     Returns:
         new bitmap file
+
+
+### [`gammacorrectcircregion`](#Python_BMP.BITMAPlib.gammacorrectcircregion)
+
+```py
+def gammacorrectcircregion(bmp: array.array, x: int, y: int, r: int, gamma: float):
+```
+
+Gamma correction to a circular area
+
+    Args:
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x, y)
+                 and radius r
+                 of the region
+        gamma  : float value of the
+                 gamma adjustment
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def genpiechartdata(dlist: list):**
->Preprocess data to make
-        it suitable for a pie chart
+### [`genpiechartdata`](#Python_BMP.charts.genpiechartdata)
+
+```py
+def genpiechartdata(dlist: list):
+```
+
+Preprocess data to make
+    it suitable for a pie chart
 
     Args:
         dlist: [[20, c['red']],
                 [30, c['brightyellow']],
                 ...]
-
+    
     Returns:
         list and large value (if any)
+
+
+### [`gensides`](#Python_BMP.solids3D.gensides)
+
+```py
+def gensides(pointlists: list[list, list], transvect: list[float, float, float], sides: list[list[float]]) -> tuple:
+```
+
+Generates a list of polygons
+and normals from 3D polygon
+and side data to a list of
+sides and normals with
+with the hidden surfaces
+removed that is suitable
+for rendering on a 2D surface
+and also applies a
+3D translation vector for
+positioning
+
     
 
 
-**def gensides(pointlists: list[list, list], transvect: list[float, float, float], sides: list[list[float]]) -> tuple:**
->Generates a list of polygons
-        and normals from 3D polygon
-        and side data to a list of
-        sides and normals with
-        with the hidden surfaces
-        removed that is suitable
-        for rendering on a 2D surface
-        and also applies a
-        3D translation vector for
-        positioning
-    
+### [`getallRGBpal`](#Python_BMP.BITMAPlib.getallRGBpal)
 
+```py
+def getallRGBpal(bmp: array.array) -> list[list[int, int, int]]:
+```
 
-**def getallRGBpal(bmp: array.array) -> list[list[int, int, int]]:**
->Gets the RGB palette of a bitmap
+Gets the RGB palette of a bitmap
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         [(r: byte, g: byte, b: byte), ...]
-    
 
 
-**def getBGRpalbuf(bmp: array.array):**
->Gets bitmap palette as stored in the bitmap
+### [`getBGRpalbuf`](#Python_BMP.BITMAPlib.getBGRpalbuf)
+
+```py
+def getBGRpalbuf(bmp: array.array):
+```
+
+Gets bitmap palette as stored in the bitmap
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         unsigned byte array (BGR)
-    
 
 
-**def getBMPimgbytes(bmp: array.array) -> list:**
->Gets the raw image buffer of a bmp without the header
+### [`getBMPimgbytes`](#Python_BMP.BITMAPlib.getBMPimgbytes)
+
+```py
+def getBMPimgbytes(bmp: array.array) -> list:
+```
+
+Gets the raw image buffer of a bmp without the header
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         list of unsigned bytes
+
+
+### [`getcharfont`](#Python_BMP.fonts.getcharfont)
+
+```py
+def getcharfont(charbuf: list, character: str) -> list:
+```
+
+
+
     
 
 
-**def getcharfont(charbuf: list, character: str) -> list:**
->None
+### [`getcolorname2HSLdict`](#Python_BMP.colordict.getcolorname2HSLdict)
+
+```py
+def getcolorname2HSLdict() -> dict:
+```
 
 
-**def getcolorname2HSLdict() -> dict:**
->None
+
+    
 
 
-**def getcolorname2RGBdict() -> dict:**
->None
+### [`getcolorname2RGBdict`](#Python_BMP.colordict.getcolorname2RGBdict)
+
+```py
+def getcolorname2RGBdict() -> dict:
+```
 
 
-**def getdatalisttotal(dlist: list[numbers.Number]) -> numbers.Number:**
->Returns the total of a
-        list of ints or floats
+
+    
+
+
+### [`getdatalisttotal`](#Python_BMP.charts.getdatalisttotal)
+
+```py
+def getdatalisttotal(dlist: list[numbers.Number]) -> numbers.Number:
+```
+
+Returns the total of a
+    list of ints or floats
 
     Args:
         dlist: list of ints or floats
-
+    
     Returns:
         float or int
-    
 
 
-**def getdefaultbitpal(bits: int) -> list:**
->Gets the standard bitmap palette
-        for a  specified bit depth bits
+### [`getdefaultbitpal`](#Python_BMP.colors.getdefaultbitpal)
+
+```py
+def getdefaultbitpal(bits: int) -> list:
+```
+
+Gets the standard bitmap palette
+    for a  specified bit depth bits
 
     Args:
         bits: int value (1, 4, 8, 24)
-
+    
     Returns:
         list of palette entries
-    
 
 
-**def getdefaultlumrange() -> dict:**
->Gets the default luminosity
-        ranges lookup
+### [`getdefaultlumrange`](#Python_BMP.colors.getdefaultlumrange)
+
+```py
+def getdefaultlumrange() -> dict:
+```
+
+Gets the default luminosity
+    ranges lookup
 
     Returns:
         a dict for default
         luminosity ranges
+
+
+### [`getfuncmetastr`](#Python_BMP.funcmeta.getfuncmetastr)
+
+```py
+def getfuncmetastr(f: Callable):
+```
+
+
+
     
 
 
-**def getfuncmetastr(f: Callable):**
->None
+### [`getIFSparams`](#Python_BMP.fractals.getIFSparams)
+
+```py
+def getIFSparams() -> dict:
+```
 
 
-**def getIFSparams() -> dict:**
->None
+
+    
 
 
-**def getimagedgevert(bmp: array.array, similaritythreshold: int):**
->Find edges in an image
+### [`getimagedgevert`](#Python_BMP.BITMAPlib.getimagedgevert)
+
+```py
+def getimagedgevert(bmp: array.array, similaritythreshold: int):
+```
+
+Find edges in an image
 
     Args:
         bmp                : unsigned
@@ -2412,14 +4025,18 @@
                              to the color
                              before we
                              yield it
-
+    
     Yields:
         [(x: int, y: int),...]
-    
 
 
-**def getimageregionbyRGB(bmp: array.array, rgb: list[int, int, int], similaritythreshold: int):**
->Select a region by color
+### [`getimageregionbyRGB`](#Python_BMP.BITMAPlib.getimageregionbyRGB)
+
+```py
+def getimageregionbyRGB(bmp: array.array, rgb: list[int, int, int], similaritythreshold: int):
+```
+
+Select a region by color
 
     Args:
         bmp                 :unsigned
@@ -2433,189 +4050,293 @@
                              the edge
                              detection
                              sensitivity
-
+    
     Returns:
         list of vertices
-    
 
 
-**def getmaxcolors(bmp: array.array) -> int:**
->Get the maximum number of colors supported by a BMP
+### [`getmaxcolors`](#Python_BMP.BITMAPlib.getmaxcolors)
+
+```py
+def getmaxcolors(bmp: array.array) -> int:
+```
+
+Get the maximum number of colors supported by a BMP
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         int value
-    
 
 
-**def getmaxx(bmp: array.array) -> int:**
->Gets the x value stored in the windows bmp header
+### [`getmaxx`](#Python_BMP.BITMAPlib.getmaxx)
+
+```py
+def getmaxx(bmp: array.array) -> int:
+```
+
+Gets the x value stored in the windows bmp header
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         int value of x bmp dimension
-    
 
 
-**def getmaxxy(bmp: array.array) -> tuple:**
->Gets the max x and y values stored in the bmp header
+### [`getmaxxy`](#Python_BMP.BITMAPlib.getmaxxy)
+
+```py
+def getmaxxy(bmp: array.array) -> tuple:
+```
+
+Gets the max x and y values stored in the bmp header
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         tuple (x:int,y:int)
-    
 
 
-**def getmaxxyandbits(bmp: array.array) -> tuple:**
->Returns bitmap metadata
-       (x-dimension, y-dimension, bit depth)
+### [`getmaxxyandbits`](#Python_BMP.BITMAPlib.getmaxxyandbits)
+
+```py
+def getmaxxyandbits(bmp: array.array) -> tuple:
+```
+
+Returns bitmap metadata
+   (x-dimension, y-dimension, bit depth)
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         (x-dimension, y-dimension, bit depth)
-    
 
 
-**def getmaxy(bmp: array.array) -> int:**
->Gets the y value stored in the windows bmp header
+### [`getmaxy`](#Python_BMP.BITMAPlib.getmaxy)
+
+```py
+def getmaxy(bmp: array.array) -> int:
+```
+
+Gets the y value stored in the windows bmp header
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         int value of y bmp dimension
+
+
+### [`getneighborcolorlist`](#Python_BMP.BITMAPlib.getneighborcolorlist)
+
+```py
+def getneighborcolorlist(bmp: array.array, v: list):
+```
+
+
+
     
 
 
-**def getneighborcolorlist(bmp: array.array, v: list):**
->None
+### [`getRGBfactors`](#Python_BMP.colordict.getRGBfactors)
+
+```py
+def getRGBfactors() -> dict:
+```
 
 
-**def getRGBfactors() -> dict:**
->None
+
+    
 
 
-**def getRGBpal(bmp: array.array, c: int) -> list[int, int, int]:**
->Gets the [R, G, B] values
-        of color c in a bitmap
+### [`getRGBpal`](#Python_BMP.BITMAPlib.getRGBpal)
+
+```py
+def getRGBpal(bmp: array.array, c: int) -> list[int, int, int]:
+```
+
+Gets the [R, G, B] values
+    of color c in a bitmap
 
     Args:
         bmp: unsigned byte array
              with bmp format
         c  : unsigned int color
-
+    
     Returns:
         [R: byte, G: byte, B:byte]
-    
 
 
-**def getRGBxybit(bmp: array.array, x: int, y: int) -> list[int, int, int]:**
->Gets [R:byte, G:byte, B:byte]
-    of pixel at (x, y) in a bitmap
+### [`getRGBxybit`](#Python_BMP.BITMAPlib.getRGBxybit)
+
+```py
+def getRGBxybit(bmp: array.array, x: int, y: int) -> list[int, int, int]:
+```
+
+Gets [R:byte, G:byte, B:byte]
+of pixel at (x, y) in a bitmap
 
     Args:
         bmp : unsigned byte array
               with bmp format
         x, y: unsigned int
               locations in x and y
-
+    
     Returns:
         [R: byte, G: byte, B: byte]
-    
 
 
-**def getRGBxybitvec(bmp: array.array, v: list) -> list:**
->Gets the RGB of a pixel at (x,y) in a BMP
+### [`getRGBxybitvec`](#Python_BMP.BITMAPlib.getRGBxybitvec)
+
+```py
+def getRGBxybitvec(bmp: array.array, v: list) -> list:
+```
+
+Gets the RGB of a pixel at (x,y) in a BMP
 
     Args:
         bmp: unsigned byte array
              with bmp format
         v  : pixel location
              (x:int, y:int)
-
+    
     Returns:
         [R: byte, G: byte, B: byte]
-    
 
 
-**def getshapesidedict() -> dict:**
->Returns a dictionary of side
-        or polygon definitions for
-        simple solids
+### [`getshapesidedict`](#Python_BMP.solids3D.getshapesidedict)
+
+```py
+def getshapesidedict() -> dict:
+```
+
+Returns a dictionary of side
+    or polygon definitions for
+    simple solids
 
     Returns:
         dictionary of side or polygon
         definitions for basic solids
+
+
+### [`getX11colorname2HSLdict`](#Python_BMP.X11colordict.getX11colorname2HSLdict)
+
+```py
+def getX11colorname2HSLdict() -> dict:
+```
+
+
+
     
 
 
-**def getX11colorname2HSLdict() -> dict:**
->None
+### [`getX11colorname2RGBdict`](#Python_BMP.X11colordict.getX11colorname2RGBdict)
+
+```py
+def getX11colorname2RGBdict() -> dict:
+```
 
 
-**def getX11colorname2RGBdict() -> dict:**
->None
+
+    
 
 
-**def getX11RGBfactors() -> dict:**
->None
+### [`getX11RGBfactors`](#Python_BMP.X11colordict.getX11RGBfactors)
+
+```py
+def getX11RGBfactors() -> dict:
+```
 
 
-**def getXKCDcolorname2HSLdict() -> dict:**
->None
+
+    
 
 
-**def getXKCDcolorname2RGBdict() -> dict:**
->None
+### [`getXKCDcolorname2HSLdict`](#Python_BMP.XKCDcolordict.getXKCDcolorname2HSLdict)
+
+```py
+def getXKCDcolorname2HSLdict() -> dict:
+```
 
 
-**def getXKCDRGBfactors() -> dict:**
->None
+
+    
 
 
-**def getxybit(bmp: array.array, x: int, y: int) -> int:**
->Gets color of pixel at (x, y) in a BMP
+### [`getXKCDcolorname2RGBdict`](#Python_BMP.XKCDcolordict.getXKCDcolorname2RGBdict)
+
+```py
+def getXKCDcolorname2RGBdict() -> dict:
+```
+
+
+
+    
+
+
+### [`getXKCDRGBfactors`](#Python_BMP.XKCDcolordict.getXKCDRGBfactors)
+
+```py
+def getXKCDRGBfactors() -> dict:
+```
+
+
+
+    
+
+
+### [`getxybit`](#Python_BMP.BITMAPlib.getxybit)
+
+```py
+def getxybit(bmp: array.array, x: int, y: int) -> int:
+```
+
+Gets color of pixel at (x, y) in a BMP
 
     Args:
         bmp : unsigned byte array
               with bmp format
         x, y: unsigned int
               locations in x and y
-
+    
     Returns:
         unsigned int color value
-    
 
 
-**def getxybitvec(bmp: array.array, v: list) -> int:**
->Gets color of pixel at (x, y)
+### [`getxybitvec`](#Python_BMP.BITMAPlib.getxybitvec)
+
+```py
+def getxybitvec(bmp: array.array, v: list) -> int:
+```
+
+Gets color of pixel at (x, y)
 
     Args:
         bmp: unsigned byte array
              with bmp format
         v  : (x: int, y: int)
              pixel coordinates
-
+    
     Returns:
         unsigned int color value
-    
 
 
-**def gradcircle(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):**
->Filled Circle with Gradient
+### [`gradcircle`](#Python_BMP.BITMAPlib.gradcircle)
+
+```py
+def gradcircle(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
+```
+
+Filled Circle with Gradient
 
     Args:
         bmp       : unsigned byte array
@@ -2626,14 +4347,18 @@
                     the gradient
         rgbfactors: [r, g, b] range are
                     from 0.0 to 1.0
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def gradellipse(bmp: array.array, x: int, y: int, b: int, a: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):**
->Ellipical gradient
+### [`gradellipse`](#Python_BMP.BITMAPlib.gradellipse)
+
+```py
+def gradellipse(bmp: array.array, x: int, y: int, b: int, a: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
+```
+
+Ellipical gradient
 
     Args:
         bmp       : unsigned byte array
@@ -2645,14 +4370,18 @@
                     luminosity gradient
         rgbfactors: [r, g, b] range
                     are from 0.0 to 1.0
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def gradthickcircle(bmp: array.array, x: int, y: int, r: int, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):**
->Thick Circle with a Gradient
+### [`gradthickcircle`](#Python_BMP.BITMAPlib.gradthickcircle)
+
+```py
+def gradthickcircle(bmp: array.array, x: int, y: int, r: int, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
+```
+
+Thick Circle with a Gradient
 
     Args:
         bmp       : unsigned byte array
@@ -2666,14 +4395,18 @@
                     gradient
         rgbfactors: [r,g,b] range are
                     from 0.0 to 1.0
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def gradthickellipserot(bmp: array.array, x: int, y: int, b: int, a: int, degrot: float, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):**
->Thick Ellipse with a Gradient fill
+### [`gradthickellipserot`](#Python_BMP.BITMAPlib.gradthickellipserot)
+
+```py
+def gradthickellipserot(bmp: array.array, x: int, y: int, b: int, a: int, degrot: float, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
+```
+
+Thick Ellipse with a Gradient fill
 
     Args:
         bmp       : unsigned byte array
@@ -2689,14 +4422,18 @@
                     luminosity gradient
         rgbfactors: [r, g, b] range are
                     from 0.0 min to 1.0 max
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def gradthickplotpoly(bmp: array.array, vertlist: list, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):**
->Draws a polygon of a given gradient and thickness
+### [`gradthickplotpoly`](#Python_BMP.BITMAPlib.gradthickplotpoly)
+
+```py
+def gradthickplotpoly(bmp: array.array, vertlist: list, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
+```
+
+Draws a polygon of a given gradient and thickness
 
     Args:
         bmp       : unsigned byte array
@@ -2709,14 +4446,18 @@
         RGBfactors: [r, g, b] value
                     range from
                     0.0 to 1.0
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def gradthickroundline(bmp: array.array, p1: list, p2: list, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):**
->Draw a Thick Rounded Line with a Gradient
+### [`gradthickroundline`](#Python_BMP.BITMAPlib.gradthickroundline)
+
+```py
+def gradthickroundline(bmp: array.array, p1: list, p2: list, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
+```
+
+Draw a Thick Rounded Line with a Gradient
 
     Args:
         bmp      : unsigned byte array
@@ -2735,15 +4476,19 @@
                     unsigned float
                     with a range
                     from 0.0 to 1.0
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def gradvert(bmp: array.array, vertlist: list[list[int, int]], penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):**
->List of 2d vertices as spheres of a given color
+### [`gradvert`](#Python_BMP.BITMAPlib.gradvert)
+
+```py
+def gradvert(bmp: array.array, vertlist: list[list[int, int]], penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
+```
+
+List of 2d vertices as spheres of a given color
 
     Args:
         bmp       : unsigned byte array
@@ -2758,46 +4503,37 @@
         RGBfactors: (r, g, b)
                     values range from
                     min 0.0 to 1.0 max
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def hexahedravert(x: float) -> list[list[float, float, float]]:**
->Returns a list of vertices
-        for a hexahedron
+### [`hexahedravert`](#Python_BMP.solids3D.hexahedravert)
+
+```py
+def hexahedravert(x: float) -> list[list[float, float, float]]:
+```
+
+Returns a list of vertices
+    for a hexahedron
 
     Args:
         x: length of a side
-
+    
     Returns:
         list (x: float,
               y: float,
               z: float)
-    
 
 
-**def horibrightnessgrad2circregion(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int]):**
->Horizontal brightness gradient adjustment to a circular area
+### [`horibrightnessgrad2circregion2file`](#Python_BMP.BITMAPlib.horibrightnessgrad2circregion2file)
 
-    Args:
-        bmp     : unsigned byte array
-                  with bmp format
-        x, y, r : center (x, y)
-                  and radius r
-                  of a circular area
-        lumrange: [byte, byte] the
-                  luminosity range
+```py
+def horibrightnessgrad2circregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, lumrange: list[int, int]):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def horibrightnessgrad2circregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, lumrange: list[int, int]):**
->Horizontal brightness gradient to a circular area
+Horizontal brightness gradient to a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -2811,14 +4547,39 @@
                          we apply a
         lumrange       : brightness gradient
                          (byte, byte) adjust
-
+    
     Returns:
         new bitmap file
+
+
+### [`horibrightnessgrad2circregion`](#Python_BMP.BITMAPlib.horibrightnessgrad2circregion)
+
+```py
+def horibrightnessgrad2circregion(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int]):
+```
+
+Horizontal brightness gradient adjustment to a circular area
+
+    Args:
+        bmp     : unsigned byte array
+                  with bmp format
+        x, y, r : center (x, y)
+                  and radius r
+                  of a circular area
+        lumrange: [byte, byte] the
+                  luminosity range
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def horiline(bmp: array.array, y: int, x1: int, x2: int, color: int):**
->Draw a Horizontal Line
+### [`horiline`](#Python_BMP.BITMAPlib.horiline)
+
+```py
+def horiline(bmp: array.array, y: int, x1: int, x2: int, color: int):
+```
+
+Draw a Horizontal Line
 
     Args:
         bmp   : unsigned byte array
@@ -2828,14 +4589,18 @@
         x1    : starts at x1
         x2    : ends at x2
         color : color of the line
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def horilinevert(bmp: array.array, vlist: list[list[int, int]], linelen: int, xadj: int, color: int):**
->Horizontal line marks at vertices in vlist
+### [`horilinevert`](#Python_BMP.BITMAPlib.horilinevert)
+
+```py
+def horilinevert(bmp: array.array, vlist: list[list[int, int]], linelen: int, xadj: int, color: int):
+```
+
+Horizontal line marks at vertices in vlist
 
     Args:
         bmp    : unsigned byte array
@@ -2848,14 +4613,18 @@
         xadj   : sets an adjustment
                  for x coordinates
         color  : color of the line
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def horitransformincircregion(bmp: array.array, x: int, y: int, r: int, trans: str):**
->Horizontal transform to a circular area
+### [`horitransformincircregion`](#Python_BMP.BITMAPlib.horitransformincircregion)
+
+```py
+def horitransformincircregion(bmp: array.array, x: int, y: int, r: int, trans: str):
+```
+
+Horizontal transform to a circular area
 
     Args:
         bmp  :   unsigned byte array
@@ -2867,15 +4636,19 @@
                  'L' -> mirror left
                  'R' -> mirror right
                  'F' -> flip
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def horizontalbrightnessgrad2file(ExistingBMPfile: str, NewBMPfile: str, lumrange: list[int, int]):**
->Horizontal brightness gradient to a BMP
+### [`horizontalbrightnessgrad2file`](#Python_BMP.BITMAPlib.horizontalbrightnessgrad2file)
+
+```py
+def horizontalbrightnessgrad2file(ExistingBMPfile: str, NewBMPfile: str, lumrange: list[int, int]):
+```
+
+Horizontal brightness gradient to a BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -2886,14 +4659,18 @@
                          defines the
                          brightness
                          gradient
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def horizontalbrightnessgradregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):**
->Horizontal brightness gradient to a rectangular area
+### [`horizontalbrightnessgradregion2file`](#Python_BMP.BITMAPlib.horizontalbrightnessgradregion2file)
+
+```py
+def horizontalbrightnessgradregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):
+```
+
+Horizontal brightness gradient to a rectangular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -2906,15 +4683,19 @@
         lumrange       : (byte:byte)
                          brightness
                          gradient
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def horizontalbrightnessgradto24bitimage(bmp: array.array, lumrange: list[int, int]):**
->Applies a horizontal brightness
-        gradient to a 24-bit bitmap
+### [`horizontalbrightnessgradto24bitimage`](#Python_BMP.BITMAPlib.horizontalbrightnessgradto24bitimage)
+
+```py
+def horizontalbrightnessgradto24bitimage(bmp: array.array, lumrange: list[int, int]):
+```
+
+Applies a horizontal brightness
+    gradient to a 24-bit bitmap
 
     Args:
         bmp     : unsigned byte array
@@ -2922,16 +4703,20 @@
         lumrange: [byte,byte]
                   the range of the
                   luminosity gradient
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def horizontalbrightnessgradto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):**
->Apply a horizontal brightness gradient
-    to a rectangular area in a 24-bit bitmap
+### [`horizontalbrightnessgradto24bitregion`](#Python_BMP.BITMAPlib.horizontalbrightnessgradto24bitregion)
+
+```py
+def horizontalbrightnessgradto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):
+```
+
+Apply a horizontal brightness gradient
+to a rectangular area in a 24-bit bitmap
 
     Args:
         bmp            : unsigned
@@ -2944,15 +4729,19 @@
                         defines
                         the brightness
                         gradient
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def horizontalbulkswap(bmp: array.array, x1: int, y1: int, x2: int, y2: int, swapfunc: Callable):**
->Applies function swapfunc
-        to a rectangular area
+### [`horizontalbulkswap`](#Python_BMP.BITMAPlib.horizontalbulkswap)
+
+```py
+def horizontalbulkswap(bmp: array.array, x1: int, y1: int, x2: int, y2: int, swapfunc: Callable):
+```
+
+Applies function swapfunc
+    to a rectangular area
 
     Args:
         bmp           : unsigned
@@ -2960,36 +4749,44 @@
                         with bmp format
         x1, y1, x2, y2: the rectangular
                         region
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def horizontalvert(y: int, x1: int, x2: int, dx: int) -> list[list[int, int]]:**
->Creates a list of int vertices along
-    a horizontal line with int step dx
+### [`horizontalvert`](#Python_BMP.primitives2D.horizontalvert)
+
+```py
+def horizontalvert(y: int, x1: int, x2: int, dx: int) -> list[list[int, int]]:
+```
+
+Creates a list of int vertices along
+a horizontal line with int step dx
 
     Args:
         y : int constant y
         x1: int start point
         x2: int end point
         dx: int x step increment
-
+    
     Returns:
         list of int vertices
         [(x, y), ...]
-    
 
 
-**def hypotrochoidvert(x: int, y: int, a: float, b: float, c: float, delta: float, lim: float):**
->Returns (int, int) 2D vertices
-    along a path defined by a hypotrochoid
-    traced by a point with distance c from
-    the center of circle of radius b
-    which rolls round a circle of radius a
-    with an origin set at (x, y)
+### [`hypotrochoidvert`](#Python_BMP.primitives2D.hypotrochoidvert)
+
+```py
+def hypotrochoidvert(x: int, y: int, a: float, b: float, c: float, delta: float, lim: float):
+```
+
+Returns (int, int) 2D vertices
+along a path defined by a hypotrochoid
+traced by a point with distance c from
+the center of circle of radius b
+which rolls round a circle of radius a
+with an origin set at (x, y)
 
     Args:
         x, y : center of hypotrochoid
@@ -3000,32 +4797,40 @@
                radius b
         delta: angle increment in radians
         lim  : angle limit in radians
-
+    
     Returns:
         The vertices of an
         hypotrochoid in a list
         [[x: int, y: int], ...]
-    
 
 
-**def icosahedvertandsurface(x: float) -> list[list[list[float, float, float]], tuple]:**
->Returns a list of vertices
-        and surfaces for an icosahedron
+### [`icosahedvertandsurface`](#Python_BMP.solids3D.icosahedvertandsurface)
+
+```py
+def icosahedvertandsurface(x: float) -> list[list[list[float, float, float]], tuple]:
+```
+
+Returns a list of vertices
+    and surfaces for an icosahedron
 
     Args:
         x: min radius of sphere
            that can hold
            the icosahedron
-
+    
     Returns:
         list (x: float,
               y: float,
               z: float)
-    
 
 
-**def IFS(bmp: array.array, IFStransparam: tuple, x1: int, y1: int, x2: int, y2: int, xscale: int, yscale: int, xoffset: int, yoffset: int, color: int, maxiter: int):**
->Draw an Interated Function System Fractal
+### [`IFS`](#Python_BMP.BITMAPlib.IFS)
+
+```py
+def IFS(bmp: array.array, IFStransparam: tuple, x1: int, y1: int, x2: int, y2: int, xscale: int, yscale: int, xoffset: int, yoffset: int, color: int, maxiter: int):
+```
+
+Draw an Interated Function System Fractal
 
     Args:
         bmp            : unsigned
@@ -3041,16 +4846,20 @@
         color          : color of fractal
         maxiter        : when to break
                          color compute
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def iif(boolcond: bool, trueval: <built-in function any>, falseval: <built-in function any>) -> <built-in function any>:**
->Returns trueval if
-        boolcond is true
-        else return falseval
+### [`iif`](#Python_BMP.conditionaltools.iif)
+
+```py
+def iif(boolcond: bool, trueval: <built-in function any>, falseval: <built-in function any>) -> <built-in function any>:
+```
+
+Returns trueval if
+    boolcond is true
+    else return falseval
 
     Args:
         boolcond: an expression that
@@ -3062,16 +4871,20 @@
         falseval: value to return if
                   boolcond evaluates
                   to False
-
+    
     Returns:
         a value depending on boolcond
-    
 
 
-**def imagecomp(inputfile1: str, inputfile2: str, diff_file: str, func: Callable):**
->Perform a bitwise comparison of two bitmap files
-    with the same x and y dimensions and bit depth
-    using a user defined bitwise comparator function
+### [`imagecomp`](#Python_BMP.BITMAPlib.imagecomp)
+
+```py
+def imagecomp(inputfile1: str, inputfile2: str, diff_file: str, func: Callable):
+```
+
+Perform a bitwise comparison of two bitmap files
+with the same x and y dimensions and bit depth
+using a user defined bitwise comparator function
 
     Args:
         Inputfile1: path to bmp file
@@ -3080,29 +4893,37 @@
                     comparison in
         func      : User provided
                     bitwise function
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def imagediff(inputfile1: str, inputfile2: str, diff_file: str):**
->Compares 2 files and saves diff to a bitmap file
+### [`imagediff`](#Python_BMP.BITMAPlib.imagediff)
+
+```py
+def imagediff(inputfile1: str, inputfile2: str, diff_file: str):
+```
+
+Compares 2 files and saves diff to a bitmap file
 
     Args:
         inputfile1: Whole paths
         inputfile2 to existing files
-
+    
         diff_file: New file
                    to store diff
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def imgregionbyRGB2file(ExistingBMPfile: str, NewBMPfile: str, edgeradius: int, edgecolor: int, rgb: list[int, int, int], similaritythreshold: float, showedgeonly: bool):**
->Gets an image region by rgb in a bitmap file
+### [`imgregionbyRGB2file`](#Python_BMP.BITMAPlib.imgregionbyRGB2file)
+
+```py
+def imgregionbyRGB2file(ExistingBMPfile: str, NewBMPfile: str, edgeradius: int, edgecolor: int, rgb: list[int, int, int], similaritythreshold: float, showedgeonly: bool):
+```
+
+Gets an image region by rgb in a bitmap file
 
     Args:
         ExistingBMPfile: Whole path to
@@ -3123,108 +4944,140 @@
                              selection
         showedgeonly: True-> only edges
                  False-> edge and image
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def int2BGRarr(i: int) -> array.array:**
->Returns a bgr array from
-        int i color input
+### [`int2BGRarr`](#Python_BMP.colors.int2BGRarr)
+
+```py
+def int2BGRarr(i: int) -> array.array:
+```
+
+Returns a bgr array from
+    int i color input
 
     Args:
         i: color value
-
+    
     Returns:
         unsigned byte BGR array
-    
 
 
-**def int2buf(cnt: int, value: int) -> array.array:**
->Converts an integer value to an
-        unsigned byte array
+### [`int2buf`](#Python_BMP.inttools.int2buf)
+
+```py
+def int2buf(cnt: int, value: int) -> array.array:
+```
+
+Converts an integer value to an
+    unsigned byte array
 
     Args:
         cnt   : uint length of int data
         value : value of uint data
-
+    
     Returns:
         unsigned byte array
-    
 
 
-**def int2RGB(i: int):**
->Break down int color i to its
-        byte valued r, g and b
-        components
+### [`int2RGB`](#Python_BMP.colors.int2RGB)
+
+```py
+def int2RGB(i: int):
+```
+
+Break down int color i to its
+    byte valued r, g and b
+    components
 
     Args:
         i: int color value
-
+    
     Returns:
         r: byte, g: byte, b: byte
+
+
+### [`int2RGBarr`](#Python_BMP.colors.int2RGBarr)
+
+```py
+def int2RGBarr(i: int) -> array.array:
+```
+
+Returns a rgb array from
+    int i color input
+
     
-
-
-**def int2RGBarr(i: int) -> array.array:**
->Returns a rgb array from
-        int i color input
-
-
     Args:
         i: color value
-
+    
     Returns:
         unsigned byte RGB array
-    
 
 
-**def int2RGBlist(i: int) -> list[int, int, int]:**
->Break down int color i to its
-        byte valued r, g and b
-        components in a list
+### [`int2RGBlist`](#Python_BMP.colors.int2RGBlist)
+
+```py
+def int2RGBlist(i: int) -> list[int, int, int]:
+```
+
+Break down int color i to its
+    byte valued r, g and b
+    components in a list
 
     Args:
         i: int color value
-
+    
     Returns:
         [r: byte, g: byte, b: byte]
-    
 
 
-**def intcircleparam(func):**
->Decorator to test if the
-        2nd, 3rd, 4th parameters
-        in a function that renders
-        circle are ints
+### [`intcircleparam24bitonly`](#Python_BMP.paramchecks.intcircleparam24bitonly)
 
-    Args:
-        function(bmp:array,x,y,r....)
+```py
+def intcircleparam24bitonly(func):
+```
 
-    Returns:
-        caller function
-    
-
-
-**def intcircleparam24bitonly(func):**
->Decorator to test if 2nd, 3rd,
-        4th parameters in a function
-        that renders circle are ints
-        and restrict the use of this
-        function to only 24-bit or
-        RGB bitmaps (1st parameter)
+Decorator to test if 2nd, 3rd,
+    4th parameters in a function
+    that renders circle are ints
+    and restrict the use of this
+    function to only 24-bit or
+    RGB bitmaps (1st parameter)
 
     Args:
         function(bmp:array,x,y,r....)
-
+    
     Returns:
         caller function
+
+
+### [`intcircleparam`](#Python_BMP.paramchecks.intcircleparam)
+
+```py
+def intcircleparam(func):
+```
+
+Decorator to test if the
+    2nd, 3rd, 4th parameters
+    in a function that renders
+    circle are ints
+
+    Args:
+        function(bmp:array,x,y,r....)
     
+    Returns:
+        caller function
 
 
-**def intlinevec(bmp: array.array, u: list, v: list, color: int):**
->Draw a line in a bitmap
+### [`intlinevec`](#Python_BMP.BITMAPlib.intlinevec)
+
+```py
+def intlinevec(bmp: array.array, u: list, v: list, color: int):
+```
+
+Draw a line in a bitmap
 
     Args:
         bmp   : unsigned byte array
@@ -3232,14 +5085,18 @@
         u, v  : (x: int, y: int) points
                 that defines the line
         color : color of the line
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def intplotvecxypoint(bmp: array.array, v: list[int, int], c: int):**
->Sets the color of a pixel at (x, y)
+### [`intplotvecxypoint`](#Python_BMP.BITMAPlib.intplotvecxypoint)
+
+```py
+def intplotvecxypoint(bmp: array.array, v: list[int, int], c: int):
+```
+
+Sets the color of a pixel at (x, y)
 
     Args:
         bmp: unsigned byte array
@@ -3248,16 +5105,20 @@
              pixel coordinates
         c  : unsigned int
              color value
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def intscalarmulvect(vec: list[numbers.Number], scalarval: numbers.Number) -> list[int]:**
->Scales a vector by multiplying a scalar value (float)
-    to all components of the vector or a list of numbers
-    then rounds off values in the list to a whole number
+### [`intscalarmulvect`](#Python_BMP.mathlib.intscalarmulvect)
+
+```py
+def intscalarmulvect(vec: list[numbers.Number], scalarval: numbers.Number) -> list[int]:
+```
+
+Scales a vector by multiplying a scalar value (float)
+to all components of the vector or a list of numbers
+then rounds off values in the list to a whole number
 
     Args:
         v        : the vector or
@@ -3265,55 +5126,52 @@
                    ints or floats
         scalarval: scalar value
                    (float or int)
-
+    
     Returns:
         list of ints
-    
 
 
-**def invertbits2file(ExistingBMPfile: str, NewBMPfile: str):**
->Inverts the bits in a bmp file
+### [`invertbits2file`](#Python_BMP.BITMAPlib.invertbits2file)
+
+```py
+def invertbits2file(ExistingBMPfile: str, NewBMPfile: str):
+```
+
+Inverts the bits in a bmp file
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def invertbitsinbuffer(buf: array.array) -> array.array:**
->Flips all the bits in an
-        unsigned byte array
+### [`invertbitsinbuffer`](#Python_BMP.colors.invertbitsinbuffer)
+
+```py
+def invertbitsinbuffer(buf: array.array) -> array.array:
+```
+
+Flips all the bits in an
+    unsigned byte array
 
     Args:
         buf: unsigned byte array
-
+    
     Returns:
         bit flipped unsigned byte array
-    
 
 
-**def invertbitsincircregion(bmp: array.array, x: int, y: int, r: int):**
->Inverts the bits in a circular area
+### [`invertbitsincircregion2file`](#Python_BMP.BITMAPlib.invertbitsincircregion2file)
 
-    Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x,y)
-                 and radius r
-                 of the region
+```py
+def invertbitsincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def invertbitsincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Inverts bits in a circular area
+Inverts bits in a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -3322,43 +5180,53 @@
                          save changes in
         x, y, r        : center (x, y)
                          and radius r
-
+    
     Returns:
         new bitmap file
+
+
+### [`invertbitsincircregion`](#Python_BMP.BITMAPlib.invertbitsincircregion)
+
+```py
+def invertbitsincircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Inverts the bits in a circular area
+
+    Args:
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x,y)
+                 and radius r
+                 of the region
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def invertimagebits(bmp: array.array):**
->Inverts the bits in a bitmap
+### [`invertimagebits`](#Python_BMP.BITMAPlib.invertimagebits)
+
+```py
+def invertimagebits(bmp: array.array):
+```
+
+Inverts the bits in a bitmap
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def invertregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Inverts the bits in a
-        rectangular region defined
-        by (x1,y1) and (x2,y2)
+### [`invertregion2file`](#Python_BMP.BITMAPlib.invertregion2file)
 
-    Args:
-        bmp          :  unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: the rectangle
+```py
+def invertregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
 
-    Returns:
-        byref modified
-        unsigned byte array
-    
-
-
-**def invertregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Inverts the bits in a rectangular area in a BMP
+Inverts the bits in a rectangular area in a BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -3367,27 +5235,56 @@
                          save changes in
         x1, y1, x2, y2 : the rectangular
                          region
-
+    
     Returns:
         new bitmap file
+
+
+### [`invertregion`](#Python_BMP.BITMAPlib.invertregion)
+
+```py
+def invertregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Inverts the bits in a
+    rectangular region defined
+    by (x1,y1) and (x2,y2)
+
+    Args:
+        bmp          :  unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: the rectangle
     
+    Returns:
+        byref modified
+        unsigned byte array
 
 
-**def isdefaultpal(bmp: array.array) -> bool:**
->Checks if bitmap has a default RGB color palette
+### [`isdefaultpal`](#Python_BMP.BITMAPlib.isdefaultpal)
+
+```py
+def isdefaultpal(bmp: array.array) -> bool:
+```
+
+Checks if bitmap has a default RGB color palette
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         True if default
         False if not default
-    
 
 
-**def isinBMPrectbnd(bmp: array.array, x: int, y: int) -> bool:**
->Checks if (x,y) coordinates are within the BMP
+### [`isinBMPrectbnd`](#Python_BMP.BITMAPlib.isinBMPrectbnd)
+
+```py
+def isinBMPrectbnd(bmp: array.array, x: int, y: int) -> bool:
+```
+
+Checks if (x,y) coordinates are within the BMP
 
     Args:
         bmp : unsigned byte array
@@ -3395,15 +5292,19 @@
         x, y: unsigned int value
               of location
               in x-axis and y-axis
-
+    
     Returns:
         True if within bounds
         False if out of bounds
-    
 
 
-**def isinrange(value: numbers.Number, highlimit: numbers.Number, lowlimit: numbers.Number) -> bool:**
->Checks is value is within high and low limits
+### [`isinrange`](#Python_BMP.mathlib.isinrange)
+
+```py
+def isinrange(value: numbers.Number, highlimit: numbers.Number, lowlimit: numbers.Number) -> bool:
+```
+
+Checks is value is within high and low limits
 
     Args:
         value    : numeric variable
@@ -3412,163 +5313,203 @@
                    the variable
         lowlimit : lower limit of
                    the variable
-
+    
     Returns:
         True if within bounds
-    
 
 
-**def isinrectbnd(x: int, y: int, xmin: int, ymin: int, xmax: int, ymax: int) -> bool:**
->Checks if the x and y values
-    lie within the rectangular area
-    defined by xmin, ymin and xmax, ymax
+### [`isinrectbnd`](#Python_BMP.primitives2D.isinrectbnd)
+
+```py
+def isinrectbnd(x: int, y: int, xmin: int, ymin: int, xmax: int, ymax: int) -> bool:
+```
+
+Checks if the x and y values
+lie within the rectangular area
+defined by xmin, ymin and xmax, ymax
 
     Args:
         x, y: (x,y) coordinates to test
         xmin, ymin: min (x, y) bounds
         xmax, ymax: max (x, y) bounds
-
+    
     Returns:
         boolean value
         True  -> (x, y) is in bounds
         False -> (x, y) is out of bounds
-    
 
 
-**def isvalidcolorbit(bits: int) -> bool:**
->Checks if bits is in the valid
-        color bits list (1, 4, 8, 24)
+### [`isvalidcolorbit`](#Python_BMP.colors.isvalidcolorbit)
+
+```py
+def isvalidcolorbit(bits: int) -> bool:
+```
+
+Checks if bits is in the valid
+    color bits list (1, 4, 8, 24)
 
     Args:
         bits: int value
-
+    
     Returns:
         True if bits in (1, 4, 8, 24)
         False if other values not in
               the list above
-    
 
 
-**def iterbeziercurve(pntlist: list[list[int, int]]) -> list[int, int]:**
->Yields a list of vertices for a bezier curve
-    based on 2D control points in pntlist
+### [`iterbeziercurve`](#Python_BMP.primitives2D.iterbeziercurve)
+
+```py
+def iterbeziercurve(pntlist: list[list[int, int]]) -> list[int, int]:
+```
+
+Yields a list of vertices for a bezier curve
+based on 2D control points in pntlist
 
     Args:
         pntlist: 2D control points
                  for the bezier curve
                  as list[list[x: int,
                               y: int]]
-
+    
     Yields:
         vertices as list[x: int, y: int]
-    
 
 
-**def iterbspline(pntlist: list[list[int, int]], isclosed: bool, curveback: bool) -> list[int, int]:**
->Yields a list of vertices for a bspline curve
-    based on 2D control points in pntlist
+### [`iterbspline`](#Python_BMP.primitives2D.iterbspline)
+
+```py
+def iterbspline(pntlist: list[list[int, int]], isclosed: bool, curveback: bool) -> list[int, int]:
+```
+
+Yields a list of vertices for a bspline curve
+based on 2D control points in pntlist
 
     Args:
         pntlist: 2D control points
                  for the bspline curve
                  as list[list[x: int,
                               y: int]]
-
+    
     Yields:
         vertices as list[x: int, y: int]
-    
 
 
-**def itercircle(x: int, y: int, r: int) -> list[int, int]:**
->Yields (int, int) 2D vertices along
-    a path defined by radius r as it traces
-    a circle with origin set at (x, y)
+### [`itercircle`](#Python_BMP.primitives2D.itercircle)
+
+```py
+def itercircle(x: int, y: int, r: int) -> list[int, int]:
+```
+
+Yields (int, int) 2D vertices along
+a path defined by radius r as it traces
+a circle with origin set at (x, y)
 
     Args:
         x, y: int centerpoint
                   coordinates
         r   : int radius
-
+    
     Yields:
         [x: int, y: int]
-    
 
 
-**def itercircleinvolute(x: int, y: int, a: float, delta: float, lim: float):**
->Yields (int, int) 2D vertices
-    along a path defined by the involute
-    of a circle with scaling factor a
-    and an origin set at (x, y)
+### [`itercircleinvolute`](#Python_BMP.primitives2D.itercircleinvolute)
+
+```py
+def itercircleinvolute(x: int, y: int, a: float, delta: float, lim: float):
+```
+
+Yields (int, int) 2D vertices
+along a path defined by the involute
+of a circle with scaling factor a
+and an origin set at (x, y)
 
     The involute of a circle is the path
     traced out by a point on a straight
     line that rolls around a circle.
-
+    
     It was studied by Huygens when he was
     considering clocks without pendulums
     that might be used on ships at sea.
-
+    
     Args:
         x, y : center of the curve
         a    : scaling factor
         delta: angle increment in radians
         lim  : angle limit in radians
-
+    
     Yields:
         The vertices of the
         involute of a circle
         [[x: int, y: int], ...]
-    
 
 
-**def itercirclepart(r: int) -> list[int, int]:**
->Yields (int, int) 2D vertices along
-    a path defined by radius r as it traces
-    one fourth of a circle with origin set
-    at (0, 0)
+### [`itercirclepart`](#Python_BMP.primitives2D.itercirclepart)
 
-    Args:
-        r: int radius
+```py
+def itercirclepart(r: int) -> list[int, int]:
+```
 
-    Yields:
-        [x: int, y: int]
-    
-
-
-**def itercirclepartlineedge(r: int) -> list[int, int]:**
->Yields (int, int) 2D vertices along
-    a path defined by radius r as it traces
-    one fourth of a circle with origin set
-    at (0, 0) tuned for generating
-    filled circles with horizontal lines
-     and other tasks involving circular areas
+Yields (int, int) 2D vertices along
+a path defined by radius r as it traces
+one fourth of a circle with origin set
+at (0, 0)
 
     Args:
         r: int radius
-
+    
     Yields:
         [x: int, y: int]
-    
 
 
-**def itercirclepartvertlineedge(r: int) -> list[int, int]:**
->Yields (int, int) 2D vertices along
-    a path defined by radius r as it traces
-    one fourth of a circle with origin set
-    at (0, 0) tuned for generating
-    filled circles with vertical lines
-    and other tasks involving circular areas
+### [`itercirclepartlineedge`](#Python_BMP.primitives2D.itercirclepartlineedge)
+
+```py
+def itercirclepartlineedge(r: int) -> list[int, int]:
+```
+
+Yields (int, int) 2D vertices along
+a path defined by radius r as it traces
+one fourth of a circle with origin set
+at (0, 0) tuned for generating
+filled circles with horizontal lines
+ and other tasks involving circular areas
 
     Args:
         r: int radius
-
+    
     Yields:
         [x: int, y: int]
+
+
+### [`itercirclepartvertlineedge`](#Python_BMP.primitives2D.itercirclepartvertlineedge)
+
+```py
+def itercirclepartvertlineedge(r: int) -> list[int, int]:
+```
+
+Yields (int, int) 2D vertices along
+a path defined by radius r as it traces
+one fourth of a circle with origin set
+at (0, 0) tuned for generating
+filled circles with vertical lines
+and other tasks involving circular areas
+
+    Args:
+        r: int radius
     
+    Yields:
+        [x: int, y: int]
 
 
-**def itercopyrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int) -> array.array:**
->Scan a rectangular area and yield scan lines
+### [`itercopyrect`](#Python_BMP.BITMAPlib.itercopyrect)
+
+```py
+def itercopyrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int) -> array.array:
+```
+
+Scan a rectangular area and yield scan lines
 
     Args:
         bmp            : unsigned
@@ -3576,15 +5517,19 @@
                          with bmp format
         x1, y1, x2, y2 : defines the
                          rectangle
-
+    
     Yields:
         unsigned byte array
         scanlines of the area
-    
 
 
-**def iterdrawvec(u: list, v: list, headsize: int):**
->Yields a vector (line segment with arrow head)
+### [`iterdrawvec`](#Python_BMP.primitives2D.iterdrawvec)
+
+```py
+def iterdrawvec(u: list, v: list, headsize: int):
+```
+
+Yields a vector (line segment with arrow head)
 
     Args:
         u       : (x: float, y: float)
@@ -3593,61 +5538,77 @@
                   point 2 has arrow
         headsize: size of the arrow
                   0 for default size
-
+    
     Yields:
         ((x1: int, y1: int), (x2: int, y2: int))
-    
 
 
-**def iterellipse(x: int, y: int, b: int, a: int):**
->Yields (int, int) 2D vertices along
-    a path defined by major and minor axes
-    b and a as it traces an ellipse with
-    origin set at (x, y)
+### [`iterellipse`](#Python_BMP.primitives2D.iterellipse)
 
-    Args:
-        b, a: major and minor axes
+```py
+def iterellipse(x: int, y: int, b: int, a: int):
+```
 
-    Yields:
-        [x: int, y: int]
-    
-
-
-**def iterellipsepart(b: int, a: int):**
->Yields (int, int) 2D vertices along
-    a path defined by major and minor axes
-    b and a as it traces one fourth of an
-    ellipse with origin set at (0, 0)
+Yields (int, int) 2D vertices along
+a path defined by major and minor axes
+b and a as it traces an ellipse with
+origin set at (x, y)
 
     Args:
         b, a: major and minor axes
-
+    
     Yields:
         [x: int, y: int]
+
+
+### [`iterellipsepart`](#Python_BMP.primitives2D.iterellipsepart)
+
+```py
+def iterellipsepart(b: int, a: int):
+```
+
+Yields (int, int) 2D vertices along
+a path defined by major and minor axes
+b and a as it traces one fourth of an
+ellipse with origin set at (0, 0)
+
+    Args:
+        b, a: major and minor axes
     
+    Yields:
+        [x: int, y: int]
 
 
-**def iterellipserot(x: int, y: int, b: int, a: int, degrot: float):**
->Yields (int, int) 2D vertices along
-    a path defined by major and minor axes
-    b and a as it traces an ellipse with origin
-    set at (x, y) rotated by degrot degrees
+### [`iterellipserot`](#Python_BMP.primitives2D.iterellipserot)
+
+```py
+def iterellipserot(x: int, y: int, b: int, a: int, degrot: float):
+```
+
+Yields (int, int) 2D vertices along
+a path defined by major and minor axes
+b and a as it traces an ellipse with origin
+set at (x, y) rotated by degrot degrees
 
     Args:
         b, a: major and minor axes
         degrot: rotation in degrees
-
+    
     Yields:
         [x: int, y: int]
-    
 
 
-**def iterepicycloid(x: int, y: int, a: float, b: float, delta: float, lim: float):**
->Yields (int, int) 2D vertices
-    along a path defined by epicycloid
-    traced by a circleof radius b which
-    rolls round a circle of radius a
-    with an origin set at (x, y)
+### [`iterepicycloid`](#Python_BMP.primitives2D.iterepicycloid)
+
+```py
+def iterepicycloid(x: int, y: int, a: float, b: float, delta: float, lim: float):
+```
+
+Yields (int, int) 2D vertices
+along a path defined by epicycloid
+traced by a circleof radius b which
+rolls round a circle of radius a
+with an origin set at (x, y)
 
     Args:
         x, y : center of epicycloid
@@ -3655,31 +5616,39 @@
         b    : radius of rolling circle
         delta: angle increment in radians
         lim  : angle limit in radians
-
+    
     Yields:
         The vertices of an
         epicycloid
         [[x: int, y: int], ...]
-    
 
 
-**def iterflower(cx: int, cy: int, r: int, petals: int, angrot: float):**
->Yields 2D points for a flower
+### [`iterflower`](#Python_BMP.primitives2D.iterflower)
+
+```py
+def iterflower(cx: int, cy: int, r: int, petals: int, angrot: float):
+```
+
+Yields 2D points for a flower
 
     Args:
         cx, cy, r : center (cx,cy)
                     and radius r
         petals    : number of petals
         angrot    : angle of rotation
-
+    
     Yields:
         (x: int, y: int)
-    
 
 
-**def itergetcolorfromrectregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Yields color info of
-        a rectangular area
+### [`itergetcolorfromrectregion`](#Python_BMP.BITMAPlib.itergetcolorfromrectregion)
+
+```py
+def itergetcolorfromrectregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Yields color info of
+    a rectangular area
 
     Args:
         bmp           : unsigned
@@ -3687,15 +5656,19 @@
                         with bmp format
         x1, y1, x2, y2: defines the
                         rectangle
-
+    
     Yields:
         ((x: int, y: int), color: int)
         for all points in area
-    
 
 
-**def itergetneighbors(v: list[int, int], mx: int, my: int, includecenter: bool) -> list[int, int]:**
->Yields the neighboring pixels of point v
+### [`itergetneighbors`](#Python_BMP.primitives2D.itergetneighbors)
+
+```py
+def itergetneighbors(v: list[int, int], mx: int, my: int, includecenter: bool) -> list[int, int]:
+```
+
+Yields the neighboring pixels of point v
 
     Args:
         v : (x: int, y: int) point
@@ -3703,19 +5676,23 @@
         my: maximum y
         includecenter: do we yield
                        point v too
-
+    
     Yields:
         [x: int, y: int]
-    
 
 
-**def iterhypotrochoid(x: int, y: int, a: float, b: float, c: float, delta: float, lim: float):**
->Yields (int, int) 2D vertices
-    along a path defined by a hypotrochoid
-    traced by a point from with distance c
-    from the center of circle of radius b
-    which rolls round a circle of radius a
-    with an origin set at (x, y)
+### [`iterhypotrochoid`](#Python_BMP.primitives2D.iterhypotrochoid)
+
+```py
+def iterhypotrochoid(x: int, y: int, a: float, b: float, c: float, delta: float, lim: float):
+```
+
+Yields (int, int) 2D vertices
+along a path defined by a hypotrochoid
+traced by a point from with distance c
+from the center of circle of radius b
+which rolls round a circle of radius a
+with an origin set at (x, y)
 
     Args:
         x, y : center of epicycloid
@@ -3726,16 +5703,20 @@
                radius b
         delta: angle increment in radians
         lim  : angle limit in radians
-
+    
     Yields:
         The vertices of an
         epicycloid
         [[x: int, y: int], ...]
-    
 
 
-**def iterIFS(IFStransparam: tuple, x1: int, y1: int, x2: int, y2: int, xscale: int, yscale: int, xoffset: int, yoffset: int, maxiter: int):**
->Yield 2D points for an Interated Function System Fractal
+### [`iterIFS`](#Python_BMP.fractals.iterIFS)
+
+```py
+def iterIFS(IFStransparam: tuple, x1: int, y1: int, x2: int, y2: int, xscale: int, yscale: int, xoffset: int, yoffset: int, maxiter: int):
+```
+
+Yield 2D points for an Interated Function System Fractal
 
     Args:
         IFStransparam   : see line 19
@@ -3747,14 +5728,18 @@
                           the fractal
         maxiter         : when to break
                           color compute
-
+    
     Yields:
         (x: int, y: int)
-    
 
 
-**def iterimagecolor(bmp: array.array, waitmsg: str, rowprocind: str, finishmsg: str):**
->Yields color information for entire bitmap
+### [`iterimagecolor`](#Python_BMP.BITMAPlib.iterimagecolor)
+
+```py
+def iterimagecolor(bmp: array.array, waitmsg: str, rowprocind: str, finishmsg: str):
+```
+
+Yields color information for entire bitmap
 
     Args:
         bmp       : unsigned byte array
@@ -3769,14 +5754,18 @@
         finishmsg : what to display
                     in the terminal
                     when process ends
-
+    
     Yields:
         ((x: int, y: int), color: int)
-    
 
 
-**def iterimagedgevert(bmp: array.array, similaritythreshold: float):**
->Find edges in an image
+### [`iterimagedgevert`](#Python_BMP.BITMAPlib.iterimagedgevert)
+
+```py
+def iterimagedgevert(bmp: array.array, similaritythreshold: float):
+```
+
+Find edges in an image
 
     Args:
         bmp                : unsigned
@@ -3787,14 +5776,18 @@
                              to the color
                              before we
                              yield it
-
+    
     Yields:
         (x: int, y: int)
-    
 
 
-**def iterimageregionvertbyRGB(bmp: array.array, rgb: list[int, int, int], similaritythreshold: int):**
->RGB Color selection by color similarity
+### [`iterimageregionvertbyRGB`](#Python_BMP.BITMAPlib.iterimageregionvertbyRGB)
+
+```py
+def iterimageregionvertbyRGB(bmp: array.array, rgb: list[int, int, int], similaritythreshold: int):
+```
+
+RGB Color selection by color similarity
 
     Args:
         bmp                : unsigned
@@ -3808,14 +5801,18 @@
                              to the color
                              before we
                              yield it
-
+    
     Yields:
         ((x: int, y: int), (r: byte, g: byte, b: byte))
-    
 
 
-**def iterimageRGB(bmp: array.array, waitmsg: str, rowprocind: str, finishmsg: str):**
->Yields (r, g, b) information for the entire bitmap
+### [`iterimageRGB`](#Python_BMP.BITMAPlib.iterimageRGB)
+
+```py
+def iterimageRGB(bmp: array.array, waitmsg: str, rowprocind: str, finishmsg: str):
+```
+
+Yields (r, g, b) information for the entire bitmap
 
     Args:
         bmp       : unsigned byte array
@@ -3828,34 +5825,42 @@
         finishmsg : what to display
                     in terminal at
                     process end
-
+    
     Yields:
         ((x: int, y: int), (r: byte, g: byte, b: byte))
-    
 
 
-**def iterline(p1: list[int, int], p2: list[int, int]) -> list[int, int]:**
->Yields (int, int) 2D vertices
-    along a line segment defined
-    by endpoints p1 and p2
+### [`iterline`](#Python_BMP.primitives2D.iterline)
+
+```py
+def iterline(p1: list[int, int], p2: list[int, int]) -> list[int, int]:
+```
+
+Yields (int, int) 2D vertices
+along a line segment defined
+by endpoints p1 and p2
 
     Args:
         p1, p2: line endpoints
                 both [x:int, y:int]
-
+    
     Yields:
         [x:int, y:int]
-    
 
 
-**def iterlissajouscurve(x: int, y: int, a: float, b: float, c: float, d: float, e: float, delta: float, lim: float):**
->Yields (int, int) 2D vertices
-    along a path defined by lissajous
-    curve axis scaling factors a and b
-    and frequency scaling factors
-    parameters c and d and
-    radian phase shift angle e
-    with an origin set at (x, y)
+### [`iterlissajouscurve`](#Python_BMP.primitives2D.iterlissajouscurve)
+
+```py
+def iterlissajouscurve(x: int, y: int, a: float, b: float, c: float, d: float, e: float, delta: float, lim: float):
+```
+
+Yields (int, int) 2D vertices
+along a path defined by lissajous
+curve axis scaling factors a and b
+and frequency scaling factors
+parameters c and d and
+radian phase shift angle e
+with an origin set at (x, y)
 
     Args:
         x, y : center of the curve
@@ -3864,15 +5869,19 @@
         e    : phase shift in radians
         delta: angle increment in radians
         lim  : angle limit in radians
-
+    
     Yields:
         Vertices of a lissajous curve
         [x: int, y: int]
-    
 
 
-**def itermandelbrot(x1: int, y1: int, x2: int, y2: int, mandelparam: list[float, float, float, float], maxiter: int):**
->Yields a Mandelbrot set
+### [`itermandelbrot`](#Python_BMP.fractals.itermandelbrot)
+
+```py
+def itermandelbrot(x1: int, y1: int, x2: int, y2: int, mandelparam: list[float, float, float, float], maxiter: int):
+```
+
+Yields a Mandelbrot set
 
     Args:
         bmp           : unsigned
@@ -3886,22 +5895,33 @@
                         0.0 to 1.0
         maxiter       : when to break
                         color compute
-
+    
     Yields:
         (x:int, y: int, c: int)
+
+
+### [`iterparallelogram`](#Python_BMP.primitives2D.iterparallelogram)
+
+```py
+def iterparallelogram(p1: list[int, int], p2: list[int, int], p3: list[int, int]) -> list[int, int]:
+```
+
+
+
     
 
 
-**def iterparallelogram(p1: list[int, int], p2: list[int, int], p3: list[int, int]) -> list[int, int]:**
->None
+### [`iterspirograph`](#Python_BMP.primitives2D.iterspirograph)
 
+```py
+def iterspirograph(x: int, y: int, r: int, l: float, k: float, delta: float, lim: float):
+```
 
-**def iterspirograph(x: int, y: int, r: int, l: float, k: float, delta: float, lim: float):**
->Yields (int, int) 2D vertices
-    along a path defined by spirograph
-    scaling factor r and dimensionless
-    parameters l and k with an origin
-    set at (x, y)
+Yields (int, int) 2D vertices
+along a path defined by spirograph
+scaling factor r and dimensionless
+parameters l and k with an origin
+set at (x, y)
 
     Args:
         x, y : center of the spirograph
@@ -3909,16 +5929,20 @@
         l, k : spirograph shape parameters
         delta: angle increment in radians
         lim  : angle limit in radians
-
+    
     Yields:
         The vertices of an
         spirograph
         [[x: int, y: int], ...]
-    
 
 
-**def line(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):**
->Draw a Line in a bitmap
+### [`line`](#Python_BMP.BITMAPlib.line)
+
+```py
+def line(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):
+```
+
+Draw a Line in a bitmap
 
     Args:
         bmp   : unsigned byte array
@@ -3926,15 +5950,19 @@
         x1, y1: endpoint 1
         x2, y2: endpoint 2
         color : color of the line
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def linevec(bmp: array.array, u: list, v: list, color: int):**
->Draw a line in a bitmap
+### [`linevec`](#Python_BMP.BITMAPlib.linevec)
+
+```py
+def linevec(bmp: array.array, u: list, v: list, color: int):
+```
+
+Draw a line in a bitmap
 
     Args:
         bmp  : unsigned byte array
@@ -3943,19 +5971,23 @@
                the endpoints
                of the line
         color: the color of the line
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def lissajouscurvevert(x: int, y: int, a: float, b: float, c: float, d: float, e: float, delta: float, lim: float):**
->Returns (int, int) 2D vertices
-    along a path defined by a lissajous curve
-    axis scaling factors a and b and
-    frequency scaling factors parameters
-    c and d and radian phase shift angle e
-    with an origin set at (x, y)
+### [`lissajouscurvevert`](#Python_BMP.primitives2D.lissajouscurvevert)
+
+```py
+def lissajouscurvevert(x: int, y: int, a: float, b: float, c: float, d: float, e: float, delta: float, lim: float):
+```
+
+Returns (int, int) 2D vertices
+along a path defined by a lissajous curve
+axis scaling factors a and b and
+frequency scaling factors parameters
+c and d and radian phase shift angle e
+with an origin set at (x, y)
 
     Args:
         x, y : center of the curve
@@ -3964,15 +5996,19 @@
         e    : phase shift in radians
         delta: angle increment in radians
         lim  : angle limit in radians
-
+    
     Returns:
         Vertices of a lissajous curve
         in a list [[x: int, y: int], ...]
-    
 
 
-**def listinBMPrecbnd(bmp: array.array, xylist: list) -> bool:**
->Checks if a list of (x, y) coordinates are within the BMP
+### [`listinBMPrecbnd`](#Python_BMP.BITMAPlib.listinBMPrecbnd)
+
+```py
+def listinBMPrecbnd(bmp: array.array, xylist: list) -> bool:
+```
+
+Checks if a list of (x, y) coordinates are within the BMP
 
     Args:
         bmp   : unsigned byte array
@@ -3980,93 +6016,97 @@
         xylist: list of (x, y)
                 coordinates
                 to be checked
-
+    
     Returns:
         True if within bounds
         False if out of bounds
-    
 
 
-**def listinrecbnd(xylist: list[list[numbers.Number, numbers.Number]], xmin: int, ymin: int, xmax: int, ymax: int) -> bool:**
->Checks if all the values in a
-    list of x and y value pairs
-    lie within the rectangular area
-    defined by xmin, ymin and xmax, ymax
+### [`listinrecbnd`](#Python_BMP.primitives2D.listinrecbnd)
+
+```py
+def listinrecbnd(xylist: list[list[numbers.Number, numbers.Number]], xmin: int, ymin: int, xmax: int, ymax: int) -> bool:
+```
+
+Checks if all the values in a
+list of x and y value pairs
+lie within the rectangular area
+defined by xmin, ymin and xmax, ymax
 
     Args:
         x, y: list[list(x,y)] list of
               x, y pairs to test
         xmin, ymin: min (x, y) bounds
         xmax, ymax: max (x, y) bounds
-
-
+    
+    
     Returns:
         boolean value
         True  -> All (x, y)
                  is in bounds
         False -> Not all (x, y)
                  is in bounds
-    
 
 
-**def loadBMP(filename: str) -> array.array:**
->Load bitmap to a byte array
-       (uncompressed bitmap only)
+### [`loadBMP`](#Python_BMP.BITMAPlib.loadBMP)
+
+```py
+def loadBMP(filename: str) -> array.array:
+```
+
+Load bitmap to a byte array
+   (uncompressed bitmap only)
 
     Args:
         filename: full path to
                   the file to be loaded
-
+    
     Returns:
         byte array with bmp file contents
-    
 
 
-**def LSMslope(XYdata: list) -> float:**
->Slope of a line obtained by Least Squares Method
+### [`LSMslope`](#Python_BMP.mathlib.LSMslope)
+
+```py
+def LSMslope(XYdata: list) -> float:
+```
+
+Slope of a line obtained by Least Squares Method
 
     Args:
         XYdata: list of vectors
         first two values in the
         list must be [[x, y, ..,], ...]
-
+    
     Returns:
         float slope of line
-    
 
 
-**def LSMYint(XYdata: list) -> float:**
->Returns the y-intercept of a line obtained
-    by Least Squares Method
+### [`LSMYint`](#Python_BMP.mathlib.LSMYint)
+
+```py
+def LSMYint(XYdata: list) -> float:
+```
+
+Returns the y-intercept of a line obtained
+by Least Squares Method
 
     Args:
         XYdata: list of vectors
         first two values in the
         list must be [[x, y, ..,], ...]
-
+    
     Returns:
         float y-intercept of line
-    
 
 
-**def magnifyNtimescircregion(bmp: array.array, x: int, y: int, r: int, n: int):**
->Magnify a circular region in a bitmap file by int n
+### [`magnifyNtimescircregion2file`](#Python_BMP.BITMAPlib.magnifyNtimescircregion2file)
 
-    Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x,y)
-                 and radius r
-        n      : int magnification
-                 factor
+```py
+def magnifyNtimescircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, intmagfactor: int):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def magnifyNtimescircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, intmagfactor: int):**
->Magnify a circular region by an integer factor n times
+Magnify a circular region by an integer factor n times
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4077,15 +6117,39 @@
                          and radius r
         intmagfactor   : int magnification
                          factor
-
+    
     Returns:
         new bitmap file
+
+
+### [`magnifyNtimescircregion`](#Python_BMP.BITMAPlib.magnifyNtimescircregion)
+
+```py
+def magnifyNtimescircregion(bmp: array.array, x: int, y: int, r: int, n: int):
+```
+
+Magnify a circular region in a bitmap file by int n
+
+    Args:
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x,y)
+                 and radius r
+        n      : int magnification
+                 factor
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def makeBGRbuf(bbuf: array.array, gbuf: array.array, rbuf: array.array) -> array.array:**
->Assemble a BGR buffer from
-        blue, green and red buffers
+### [`makeBGRbuf`](#Python_BMP.colors.makeBGRbuf)
+
+```py
+def makeBGRbuf(bbuf: array.array, gbuf: array.array, rbuf: array.array) -> array.array:
+```
+
+Assemble a BGR buffer from
+    blue, green and red buffers
 
     Args:
         bbuf: unsigned byte array
@@ -4094,15 +6158,19 @@
               for green data
         rbuf: unsigned byte array
               for red data
-
+    
     Returns:
         unsigned byte array
         holding BGR data
-    
 
 
-**def makenewpalfromcolorhist(chist: list, colors: int, similaritythreshold: float) -> list:**
->Creates a new palatte based on a color histogram
+### [`makenewpalfromcolorhist`](#Python_BMP.BITMAPlib.makenewpalfromcolorhist)
+
+```py
+def makenewpalfromcolorhist(chist: list, colors: int, similaritythreshold: float) -> list:
+```
+
+Creates a new palatte based on a color histogram
 
     Args:
         chist              : list sorted in
@@ -4114,14 +6182,18 @@
         similaritythreshold: controls how
                              close palette
                              entries can be
-
+    
     Returns:
         unsigned byte array with bmp format
-    
 
 
-**def mandelbrot(bmp: array.array, x1: int, y1: int, x2: int, y2: int, mandelparam: list[float, float, float, float], RGBfactors: list[float, float, float], maxiter: int):**
->Draw a Mandelbrot set
+### [`mandelbrot`](#Python_BMP.BITMAPlib.mandelbrot)
+
+```py
+def mandelbrot(bmp: array.array, x1: int, y1: int, x2: int, y2: int, mandelparam: list[float, float, float, float], RGBfactors: list[float, float, float], maxiter: int):
+```
+
+Draw a Mandelbrot set
 
     Args:
         bmp           : unsigned
@@ -4135,23 +6207,34 @@
                         0.0 to 1.0
         maxiter       : when to break
                         color compute
-
+    
     Returns:
         byref modified unsigned byte array
+
+
+### [`mandelparamdict`](#Python_BMP.fractals.mandelparamdict)
+
+```py
+def mandelparamdict() -> dict:
+```
+
+
+
     
 
 
-**def mandelparamdict() -> dict:**
->None
+### [`matchRGBtopal`](#Python_BMP.colors.matchRGBtopal)
 
+```py
+def matchRGBtopal(RGB: list, pal: list) -> int:
+```
 
-**def matchRGBtopal(RGB: list, pal: list) -> int:**
->Color matching from a 24-bit
-        palette to any 1, 4 or 8-bit
-        palette using Euclidean
-        distance minimization
-        in an rgb colorspace for
-        the closest color match
+Color matching from a 24-bit
+    palette to any 1, 4 or 8-bit
+    palette using Euclidean
+    distance minimization
+    in an rgb colorspace for
+    the closest color match
 
     Args:
         RGB: color byte values
@@ -4159,39 +6242,34 @@
               g: byte,
               b: byte]
         pal: the bmp palette to match
-
+    
     Returns:
         int color val (4-bit)
-    
 
 
-**def mirror(pt: float, delta: float):**
->Mirrors a value in a numberline
+### [`mirror`](#Python_BMP.mathlib.mirror)
+
+```py
+def mirror(pt: float, delta: float):
+```
+
+Mirrors a value in a numberline
 
     Args:
         pt   : real value in numberline
         delta: value to mirror
-
+    
     Returns:
         pt - delta, pt + delta
-    
 
 
-**def mirrorbottom(bmp: array.array):**
->Mirrors the bottom-half of a bmp
+### [`mirrorbottom2file`](#Python_BMP.BITMAPlib.mirrorbottom2file)
 
-    Args:
-        bmp: unsigned byte array
-             with bmp format
+```py
+def mirrorbottom2file(ExistingBMPfile: str, NewBMPfile: str):
+```
 
-    Returns:
-        byref modified
-        unsigned byte array
-    
-
-
-**def mirrorbottom2file(ExistingBMPfile: str, NewBMPfile: str):**
->Mirrors the bottom half of a BMP
+Mirrors the bottom half of a BMP
 
     Args:
         ExistingBMPfile: Whole path
@@ -4199,14 +6277,55 @@
                          file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
+
+
+### [`mirrorbottom`](#Python_BMP.BITMAPlib.mirrorbottom)
+
+```py
+def mirrorbottom(bmp: array.array):
+```
+
+Mirrors the bottom-half of a bmp
+
+    Args:
+        bmp: unsigned byte array
+             with bmp format
     
+    Returns:
+        byref modified
+        unsigned byte array
 
 
-**def mirrorbottomincircregion(bmp: array.array, x: int, y: int, r: int):**
->Mirror the bottom-half of a circular area
+### [`mirrorbottomincircregion2file`](#Python_BMP.BITMAPlib.mirrorbottomincircregion2file)
+
+```py
+def mirrorbottomincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
+
+Mirror the bottom-half of a circular area
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes to
+        x, y, r        : center (x, y)
+                         and radius r
+    
+    Returns:
+        new bitmap file
+
+
+### [`mirrorbottomincircregion`](#Python_BMP.BITMAPlib.mirrorbottomincircregion)
+
+```py
+def mirrorbottomincircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Mirror the bottom-half of a circular area
 
     Args:
         bmp    : unsigned byte array
@@ -4214,47 +6333,18 @@
         x, y, r: center (x, y)
                  and radius r
                  of region
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def mirrorbottomincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Mirror the bottom-half of a circular area
+### [`mirrorbottominregion2file`](#Python_BMP.BITMAPlib.mirrorbottominregion2file)
 
-    Args:
-        ExistingBMPfile: Whole path to
-                         existing file
-        NewBMPfile     : New file to
-                         save changes to
-        x, y, r        : center (x, y)
-                         and radius r
+```py
+def mirrorbottominregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
 
-    Returns:
-        new bitmap file
-    
-
-
-**def mirrorbottominregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Mirror the bottom-half
-        of a rectangular region
-
-    Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: defines the
-                        rectangle
-
-    Returns:
-        byref modified
-        unsigned byte array
-    
-
-
-**def mirrorbottominregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the bottom-half region in a rectangular area in a bmp
+Mirrors the bottom-half region in a rectangular area in a bmp
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4263,56 +6353,75 @@
                          save changes in
         x1, y1, x2, y2 : the rectangular
                          region
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrorbottomleft(bmp: array.array):**
->Mirrors the bottom-left part
-        of an in-memory bitmap
+### [`mirrorbottominregion`](#Python_BMP.BITMAPlib.mirrorbottominregion)
+
+```py
+def mirrorbottominregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirror the bottom-half
+    of a rectangular region
 
     Args:
-        bmp: unsigned byte array
-             with bmp format
-
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: defines the
+                        rectangle
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def mirrorbottomleft2file(ExistingBMPfile: str, NewBMPfile: str):**
->Mirrors the bottom-left of a BMP
+### [`mirrorbottomleft2file`](#Python_BMP.BITMAPlib.mirrorbottomleft2file)
+
+```py
+def mirrorbottomleft2file(ExistingBMPfile: str, NewBMPfile: str):
+```
+
+Mirrors the bottom-left of a BMP
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrorbottomleftincircregion(bmp: array.array, x: int, y: int, r: int):**
->Mirror the bottom-left of a circular area
+### [`mirrorbottomleft`](#Python_BMP.BITMAPlib.mirrorbottomleft)
+
+```py
+def mirrorbottomleft(bmp: array.array):
+```
+
+Mirrors the bottom-left part
+    of an in-memory bitmap
 
     Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x,y) and
-                 radius r of region
-
-    Returns:
-        byref modified unsigned byte array
+        bmp: unsigned byte array
+             with bmp format
     
+    Returns:
+        byref modified
+        unsigned byte array
 
 
-**def mirrorbottomleftincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Mirror the bottom-left of a circular area
+### [`mirrorbottomleftincircregion2file`](#Python_BMP.BITMAPlib.mirrorbottomleftincircregion2file)
+
+```py
+def mirrorbottomleftincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
+
+Mirror the bottom-left of a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4321,32 +6430,36 @@
                          save changes in
         x, y, r        : center (x, y)
                          and radius r
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrorbottomleftinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the bottom-left of a
-        rectangular region defined
-        by (x1, y1) and (x2, y2)
+### [`mirrorbottomleftincircregion`](#Python_BMP.BITMAPlib.mirrorbottomleftincircregion)
+
+```py
+def mirrorbottomleftincircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Mirror the bottom-left of a circular area
 
     Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: defines the
-                        rectangle
-
-    Returns:
-        byref modified
-        unsigned byte array
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x,y) and
+                 radius r of region
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def mirrorbottomleftinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the bottom-left region in a rectangular area in a bmp
+### [`mirrorbottomleftinregion2file`](#Python_BMP.BITMAPlib.mirrorbottomleftinregion2file)
+
+```py
+def mirrorbottomleftinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the bottom-left region in a rectangular area in a bmp
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4355,56 +6468,76 @@
                          save changes in
         x1, y1, x2, y2 : the rectangular
                          region
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrorbottomright(bmp: array.array):**
->Mirrors the bottom right part
-        of an in-memory bitmap
+### [`mirrorbottomleftinregion`](#Python_BMP.BITMAPlib.mirrorbottomleftinregion)
+
+```py
+def mirrorbottomleftinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the bottom-left of a
+    rectangular region defined
+    by (x1, y1) and (x2, y2)
 
     Args:
-        bmp: unsigned byte array
-             with bmp format
-
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: defines the
+                        rectangle
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def mirrorbottomright2file(ExistingBMPfile: str, NewBMPfile: str):**
->Mirrors the bottom-right of a BMP
+### [`mirrorbottomright2file`](#Python_BMP.BITMAPlib.mirrorbottomright2file)
+
+```py
+def mirrorbottomright2file(ExistingBMPfile: str, NewBMPfile: str):
+```
+
+Mirrors the bottom-right of a BMP
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrorbottomrightincircregion(bmp: array.array, x: int, y: int, r: int):**
->Mirror the bottom-right of a circular area
+### [`mirrorbottomright`](#Python_BMP.BITMAPlib.mirrorbottomright)
+
+```py
+def mirrorbottomright(bmp: array.array):
+```
+
+Mirrors the bottom right part
+    of an in-memory bitmap
 
     Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x,y) and
-                 radius r of region
-
-    Returns:
-        byref modified unsigned byte array
+        bmp: unsigned byte array
+             with bmp format
     
+    Returns:
+        byref modified
+        unsigned byte array
 
 
-**def mirrorbottomrightincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Mirror the bottom-right of a circular area
+### [`mirrorbottomrightincircregion2file`](#Python_BMP.BITMAPlib.mirrorbottomrightincircregion2file)
+
+```py
+def mirrorbottomrightincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
+
+Mirror the bottom-right of a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4413,32 +6546,36 @@
                          save changes to
         x, y, r        : center (x, y)
                          and radius r
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrorbottomrightinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the bottom-right of a
-        rectangular region defined by
-        (x1, y1) and (x2, y2)
+### [`mirrorbottomrightincircregion`](#Python_BMP.BITMAPlib.mirrorbottomrightincircregion)
+
+```py
+def mirrorbottomrightincircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Mirror the bottom-right of a circular area
 
     Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: the rectangular
-                        region
-
-    Returns:
-        byref modified
-        unsigned byte array
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x,y) and
+                 radius r of region
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def mirrorbottomrightinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the bottom-right region in a rectangular area in a BMP
+### [`mirrorbottomrightinregion2file`](#Python_BMP.BITMAPlib.mirrorbottomrightinregion2file)
+
+```py
+def mirrorbottomrightinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the bottom-right region in a rectangular area in a BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4447,56 +6584,76 @@
                          save changes in
         x1, y1, x2, y2  :the rectangular
                          region
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrorleft(bmp: array.array):**
->Mirrors the left-half of an
-        in-memory bitmap
+### [`mirrorbottomrightinregion`](#Python_BMP.BITMAPlib.mirrorbottomrightinregion)
+
+```py
+def mirrorbottomrightinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the bottom-right of a
+    rectangular region defined by
+    (x1, y1) and (x2, y2)
 
     Args:
-        bmp: unsigned byte array
-             with bmp format
-
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: the rectangular
+                        region
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def mirrorleft2file(ExistingBMPfile: str, NewBMPfile: str):**
->Mirrors the left-half of a BMP
+### [`mirrorleft2file`](#Python_BMP.BITMAPlib.mirrorleft2file)
+
+```py
+def mirrorleft2file(ExistingBMPfile: str, NewBMPfile: str):
+```
+
+Mirrors the left-half of a BMP
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrorleftincircregion(bmp: array.array, x: int, y: int, r: int):**
->Mirrors the top-left of a circular area
+### [`mirrorleft`](#Python_BMP.BITMAPlib.mirrorleft)
+
+```py
+def mirrorleft(bmp: array.array):
+```
+
+Mirrors the left-half of an
+    in-memory bitmap
 
     Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x, y) and
-                 radius r of region
-
-    Returns:
-        byref modified unsigned byte array
+        bmp: unsigned byte array
+             with bmp format
     
+    Returns:
+        byref modified
+        unsigned byte array
 
 
-**def mirrorleftincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Mirror the left-half of a circular area
+### [`mirrorleftincircregion2file`](#Python_BMP.BITMAPlib.mirrorleftincircregion2file)
+
+```py
+def mirrorleftincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
+
+Mirror the left-half of a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4505,31 +6662,36 @@
                          save changes to
         x, y, r        : center (x, y)
                          and radius r
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrorleftinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the left-half
-        of a rectangular area
+### [`mirrorleftincircregion`](#Python_BMP.BITMAPlib.mirrorleftincircregion)
+
+```py
+def mirrorleftincircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Mirrors the top-left of a circular area
 
     Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: defines the
-                        rectangle
-
-    Returns:
-        byref modified
-        unsigned byte array
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x, y) and
+                 radius r of region
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def mirrorleftinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the left-half region in a rectangular area in a bmp
+### [`mirrorleftinregion2file`](#Python_BMP.BITMAPlib.mirrorleftinregion2file)
+
+```py
+def mirrorleftinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the left-half region in a rectangular area in a bmp
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4539,57 +6701,75 @@
         x1, y1, x2, y2 : defines the
                          rectangular
                          region
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrorright(bmp: array.array):**
->Mirrors the right-half of an
-        in-memory bitmap
+### [`mirrorleftinregion`](#Python_BMP.BITMAPlib.mirrorleftinregion)
+
+```py
+def mirrorleftinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the left-half
+    of a rectangular area
 
     Args:
-        bmp: unsigned byte array
-             with bmp format
-
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: defines the
+                        rectangle
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def mirrorright2file(ExistingBMPfile: str, NewBMPfile: str):**
->Mirrors the right half of a BMP
+### [`mirrorright2file`](#Python_BMP.BITMAPlib.mirrorright2file)
+
+```py
+def mirrorright2file(ExistingBMPfile: str, NewBMPfile: str):
+```
+
+Mirrors the right half of a BMP
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrorrightincircregion(bmp: array.array, x: int, y: int, r: int):**
->Mirrors the right-half of a circular area
+### [`mirrorright`](#Python_BMP.BITMAPlib.mirrorright)
+
+```py
+def mirrorright(bmp: array.array):
+```
+
+Mirrors the right-half of an
+    in-memory bitmap
 
     Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x, y)
-                 and radius r
-                 of a region
-
-    Returns:
-        byref modified unsigned byte array
+        bmp: unsigned byte array
+             with bmp format
     
+    Returns:
+        byref modified
+        unsigned byte array
 
 
-**def mirrorrightincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Mirror the right-half of a circular area
+### [`mirrorrightincircregion2file`](#Python_BMP.BITMAPlib.mirrorrightincircregion2file)
+
+```py
+def mirrorrightincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
+
+Mirror the right-half of a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4598,31 +6778,37 @@
                          save changes to
         x, y, r        : center (x, y)
                          and radius r
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrorrightinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the right-half of
-        a rectangular area in a bitmap
+### [`mirrorrightincircregion`](#Python_BMP.BITMAPlib.mirrorrightincircregion)
+
+```py
+def mirrorrightincircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Mirrors the right-half of a circular area
 
     Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: defines the
-                        rectangle
-
-    Returns:
-        byref modified
-        unsigned byte array
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x, y)
+                 and radius r
+                 of a region
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def mirrorrightinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the right-half region in a rectangular area in a bmp
+### [`mirrorrightinregion2file`](#Python_BMP.BITMAPlib.mirrorrightinregion2file)
+
+```py
+def mirrorrightinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the right-half region in a rectangular area in a bmp
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4631,55 +6817,74 @@
                          save changes in
         x1, y1, x2, y2 : the rectangular
                          region
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrortop(bmp: array.array):**
->Mirrors the top-half of a bitmap
+### [`mirrorrightinregion`](#Python_BMP.BITMAPlib.mirrorrightinregion)
+
+```py
+def mirrorrightinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the right-half of
+    a rectangular area in a bitmap
 
     Args:
-        bmp: unsigned byte array
-             with bmp format
-
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: defines the
+                        rectangle
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def mirrortop2file(ExistingBMPfile: str, NewBMPfile: str):**
->Mirrors the top-half of a bitmap
+### [`mirrortop2file`](#Python_BMP.BITMAPlib.mirrortop2file)
+
+```py
+def mirrortop2file(ExistingBMPfile: str, NewBMPfile: str):
+```
+
+Mirrors the top-half of a bitmap
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrortopincircregion(bmp: array.array, x: int, y: int, r: int):**
->Mirror the top-half of a circular area
+### [`mirrortop`](#Python_BMP.BITMAPlib.mirrortop)
+
+```py
+def mirrortop(bmp: array.array):
+```
+
+Mirrors the top-half of a bitmap
 
     Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x, y)
-                 and radius r of area
-
-    Returns:
-        byref modified unsigned byte array
+        bmp: unsigned byte array
+             with bmp format
     
+    Returns:
+        byref modified
+        unsigned byte array
 
 
-**def mirrortopincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Mirror the top-half of a circular area
+### [`mirrortopincircregion2file`](#Python_BMP.BITMAPlib.mirrortopincircregion2file)
+
+```py
+def mirrortopincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
+
+Mirror the top-half of a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4688,15 +6893,57 @@
                          save changes to
         x, y, r        : center (x, y)
                          and radius r
-
+    
     Returns:
         new bitmap file
+
+
+### [`mirrortopincircregion`](#Python_BMP.BITMAPlib.mirrortopincircregion)
+
+```py
+def mirrortopincircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Mirror the top-half of a circular area
+
+    Args:
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x, y)
+                 and radius r of area
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def mirrortopinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Mirror the top-half of
-        a rectangular region
+### [`mirrortopinregion2file`](#Python_BMP.BITMAPlib.mirrortopinregion2file)
+
+```py
+def mirrortopinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the top-half region in a rectangular area in a bmp
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        x1, y1, x2, y2 : the rectangular
+                         region
+    
+    Returns:
+        new bitmap file
+
+
+### [`mirrortopinregion`](#Python_BMP.BITMAPlib.mirrortopinregion)
+
+```py
+def mirrortopinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirror the top-half of
+    a rectangular region
 
     Args:
         bmp           : unsigned
@@ -4705,75 +6952,55 @@
         x1, y1, x2, y2: defines the
                         rectangular
                         region
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def mirrortopinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the top-half region in a rectangular area in a bmp
+### [`mirrortopleft2file`](#Python_BMP.BITMAPlib.mirrortopleft2file)
+
+```py
+def mirrortopleft2file(ExistingBMPfile: str, NewBMPfile: str):
+```
+
+Mirrors the top-left of a bitmap
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-        x1, y1, x2, y2 : the rectangular
-                         region
-
+    
     Returns:
         new bitmap file
 
-    
 
+### [`mirrortopleft`](#Python_BMP.BITMAPlib.mirrortopleft)
 
-**def mirrortopleft(bmp):**
->Mirrors the top-left part
-        of an in-memory bitmap
+```py
+def mirrortopleft(bmp):
+```
+
+Mirrors the top-left part
+    of an in-memory bitmap
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def mirrortopleft2file(ExistingBMPfile: str, NewBMPfile: str):**
->Mirrors the top-left of a bitmap
+### [`mirrortopleftincircregion2file`](#Python_BMP.BITMAPlib.mirrortopleftincircregion2file)
 
-    Args:
-        ExistingBMPfile: Whole path to
-                         existing file
-        NewBMPfile     : New file to
-                         save changes in
+```py
+def mirrortopleftincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
 
-    Returns:
-        new bitmap file
-    
-
-
-**def mirrortopleftincircregion(bmp: array.array, x: int, y: int, r: int):**
->Mirror the top-left of a circular area
-
-    Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x, y)
-                 and radius r
-                 of region
-
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def mirrortopleftincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Mirror the top-left of a circular area
+Mirror the top-left of a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4782,32 +7009,37 @@
                          save changes to
         x, y, r        : center (x, y)
                          and radius r
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrortopleftinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the top-left of a
-        rectangular region defined by
-        (x1, y1) and (x2, y2)
+### [`mirrortopleftincircregion`](#Python_BMP.BITMAPlib.mirrortopleftincircregion)
+
+```py
+def mirrortopleftincircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Mirror the top-left of a circular area
 
     Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: defines the
-                        rectangle
-
-    Returns:
-        byref modified
-        unsigned byte array
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x, y)
+                 and radius r
+                 of region
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def mirrortopleftinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the top-left region in a rectangular area in a BMP
+### [`mirrortopleftinregion2file`](#Python_BMP.BITMAPlib.mirrortopleftinregion2file)
+
+```py
+def mirrortopleftinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the top-left region in a rectangular area in a BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4816,29 +7048,41 @@
                          save changes in
         x1, y1, x2, y2 : the rectangular
                          region
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrortopright(bmp: array.array):**
->Mirrors the top-right part
-        of an in-memory bitmap
+### [`mirrortopleftinregion`](#Python_BMP.BITMAPlib.mirrortopleftinregion)
+
+```py
+def mirrortopleftinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the top-left of a
+    rectangular region defined by
+    (x1, y1) and (x2, y2)
 
     Args:
-        bmp: unsigned byte array
-             with bmp format
-
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: defines the
+                        rectangle
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def mirrortopright2file(ExistingBMPfile: str, NewBMPfile: str):**
->Mirrors the top-right of a
-        bitmap file
+### [`mirrortopright2file`](#Python_BMP.BITMAPlib.mirrortopright2file)
+
+```py
+def mirrortopright2file(ExistingBMPfile: str, NewBMPfile: str):
+```
+
+Mirrors the top-right of a
+    bitmap file
 
     Args:
         ExistingBMPfile: Whole path
@@ -4846,28 +7090,36 @@
                          file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrortoprightincircregion(bmp: array.array, x: int, y: int, r: int):**
->Mirror the top-right of a circular area
+### [`mirrortopright`](#Python_BMP.BITMAPlib.mirrortopright)
+
+```py
+def mirrortopright(bmp: array.array):
+```
+
+Mirrors the top-right part
+    of an in-memory bitmap
 
     Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x, y) and
-                 radius r of region
-
-    Returns:
-        byref modified unsigned byte array
+        bmp: unsigned byte array
+             with bmp format
     
+    Returns:
+        byref modified
+        unsigned byte array
 
 
-**def mirrortoprightincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Mirror the top-right of a circular area
+### [`mirrortoprightincircregion2file`](#Python_BMP.BITMAPlib.mirrortoprightincircregion2file)
+
+```py
+def mirrortoprightincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
+
+Mirror the top-right of a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4876,32 +7128,36 @@
                          save changes in
         x, y, r        : center (x, y)
                          and radius r
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def mirrortoprightinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the top-right of a
-        rectangular region defined by
-        (x1, y1) and (x2, y2)
+### [`mirrortoprightincircregion`](#Python_BMP.BITMAPlib.mirrortoprightincircregion)
+
+```py
+def mirrortoprightincircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Mirror the top-right of a circular area
 
     Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: defines the
-                        rectangle
-
-    Returns:
-        byref modified
-        unsigned byte array
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x, y) and
+                 radius r of region
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def mirrortoprightinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Mirrors the top-right region in a rectangular area in a BMP
+### [`mirrortoprightinregion2file`](#Python_BMP.BITMAPlib.mirrortoprightinregion2file)
+
+```py
+def mirrortoprightinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the top-right region in a rectangular area in a BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -4910,42 +7166,76 @@
                          save changes in
         x1, y1, x2, y2 : the rectangular
                          region
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def monochrome(rgb: list[int, int, int]) -> list[int, int, int]:**
->Returns a monochrome color
-        based on a 24-bit RGB value
+### [`mirrortoprightinregion`](#Python_BMP.BITMAPlib.mirrortoprightinregion)
+
+```py
+def mirrortoprightinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Mirrors the top-right of a
+    rectangular region defined by
+    (x1, y1) and (x2, y2)
 
     Args:
-        rgb: color values
-            [r: byte, g: byte, b: byte]
-
-    Returns:
-        a gray color (r = g = b)
-        [r: byte, g: byte, b: byte]
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: defines the
+                        rectangle
     
+    Returns:
+        byref modified
+        unsigned byte array
 
 
-**def monochrome2file(ExistingBMPfile: str, NewBMPfile: str):**
->Applies a monochrome filter to a BMP
+### [`monochrome2file`](#Python_BMP.BITMAPlib.monochrome2file)
+
+```py
+def monochrome2file(ExistingBMPfile: str, NewBMPfile: str):
+```
+
+Applies a monochrome filter to a BMP
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
+
+
+### [`monochrome`](#Python_BMP.colors.monochrome)
+
+```py
+def monochrome(rgb: list[int, int, int]) -> list[int, int, int]:
+```
+
+Returns a monochrome color
+    based on a 24-bit RGB value
+
+    Args:
+        rgb: color values
+            [r: byte, g: byte, b: byte]
     
+    Returns:
+        a gray color (r = g = b)
+        [r: byte, g: byte, b: byte]
 
 
-**def monochromecircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Monochrome filter to a circular region
+### [`monochromecircregion2file`](#Python_BMP.BITMAPlib.monochromecircregion2file)
+
+```py
+def monochromecircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
+
+Monochrome filter to a circular region
 
     Args:
         ExistingBMPfile: Whole path
@@ -4955,35 +7245,43 @@
                          save changes in
         x, y, r        : center (x, y)
                          and radius r
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def monochromefiltertoBGRbuf(buf: array.array) -> array.array:**
->Apply a monochrome filter to a
-        BGR buffer
+### [`monochromefiltertoBGRbuf`](#Python_BMP.colors.monochromefiltertoBGRbuf)
+
+```py
+def monochromefiltertoBGRbuf(buf: array.array) -> array.array:
+```
+
+Apply a monochrome filter to a
+    BGR buffer
 
     Args:
         buf: unsigned byte array
              holding BGR data
-
+    
         rgbfactors: color filter as
                       [r: float,
                        g: float,
                        b: float]
-
+    
     Returns:
         unsigned byte array
         holding mono BGR data
-    
 
 
-**def monochromepal(bits: int, rgbfactors: list[float, float, float]) -> list[list[int, int, int]]:**
->Returns a monochrome palette
-        based on bit depth bits and
-        rgbfactors
+### [`monochromepal`](#Python_BMP.colors.monochromepal)
+
+```py
+def monochromepal(bits: int, rgbfactors: list[float, float, float]) -> list[list[int, int, int]]:
+```
+
+Returns a monochrome palette
+    based on bit depth bits and
+    rgbfactors
 
     Args:
         bits      : bit depth
@@ -4993,15 +7291,19 @@
                     [r: float,
                      g: float,
                      b: float]
-
+    
     Returns:
       a palette as
       list[list[r: int, g: int, b int]]
-    
 
 
-**def monocircle(bmp: array.array, x: int, y: int, r: int):**
->Monochrome filter to a circular area
+### [`monocircle`](#Python_BMP.BITMAPlib.monocircle)
+
+```py
+def monocircle(bmp: array.array, x: int, y: int, r: int):
+```
+
+Monochrome filter to a circular area
 
     Args:
         bmp    : unsigned byte array
@@ -5009,14 +7311,18 @@
         x, y, r: center (x, y)
                  and radius r
                  of the region
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def monofilterinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Monochrome filter to rectangular area in a 24-bit BMP
+### [`monofilterinregion2file`](#Python_BMP.BITMAPlib.monofilterinregion2file)
+
+```py
+def monofilterinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
+
+Monochrome filter to rectangular area in a 24-bit BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -5026,119 +7332,139 @@
         x1, y1, x2, y2 : defines the
                          rectangular
                          region
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def monofilterto24bitimage(bmp: array.array):**
->Applies a mono filter
-        to a 24 bit in-memory bitmap
+### [`monofilterto24bitimage`](#Python_BMP.BITMAPlib.monofilterto24bitimage)
+
+```py
+def monofilterto24bitimage(bmp: array.array):
+```
+
+Applies a mono filter
+    to a 24 bit in-memory bitmap
 
     Args:
         bmp: unsigned byte array
              with bmp format
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def monofilterto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Applies a monochrome filter
-        to a rectangular area
-        defined by (x1, y1) and
-        (x2, y2) in a 24 bit bitmap
+### [`monofilterto24bitregion`](#Python_BMP.BITMAPlib.monofilterto24bitregion)
+
+```py
+def monofilterto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Applies a monochrome filter
+    to a rectangular area
+    defined by (x1, y1) and
+    (x2, y2) in a 24 bit bitmap
 
     Args:
         bmp           : unsigned
                         byte array
                         with bmp format
         x1, y1, x2, y2: the rectangle
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def newBMP(x: int, y: int, colorbits: int) -> array.array:**
->Creates a new in-memory bitmap
+### [`newBMP`](#Python_BMP.BITMAPlib.newBMP)
+
+```py
+def newBMP(x: int, y: int, colorbits: int) -> array.array:
+```
+
+Creates a new in-memory bitmap
 
     Args:
         x, y     : unsigned int values
                    of x and y dims
         colorbits: bit depth
                    (1, 4, 8, 24) bits
-
+    
     Returns:
         unsigned byte array with bitmap layout
+
+
+### [`numbervert`](#Python_BMP.BITMAPlib.numbervert)
+
+```py
+def numbervert(bmp: array.array, vlist: list[list[int, int]], xadj: int, yadj: int, scale: int, valstart: numbers.Number, valstep: numbers.Number, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, suppresszero: bool, suppresslastnum: bool, rightjustify: bool):
+```
+
+
+
     
 
 
-**def numbervert(bmp: array.array, vlist: list[list[int, int]], xadj: int, yadj: int, scale: int, valstart: numbers.Number, valstep: numbers.Number, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, suppresszero: bool, suppresslastnum: bool, rightjustify: bool):**
->None
+### [`octahedravert`](#Python_BMP.solids3D.octahedravert)
 
+```py
+def octahedravert(x: float) -> list[list[float, float, float]]:
+```
 
-**def octahedravert(x: float) -> list[list[float, float, float]]:**
->Returns a list of vertices
-        for an octrahedron
+Returns a list of vertices
+    for an octrahedron
 
     Args:
         x: length of a side
-
+    
     Returns:
         list (x: float,
               y: float,
               z: float)
-    
 
 
-**def outline(bmp: array.array):**
->Applies an Outline Filter
+### [`outline2file`](#Python_BMP.BITMAPlib.outline2file)
 
-    Args:
-        bmp: unsigned byte array
-             with bmp format
+```py
+def outline2file(ExistingBMPfile: str, NewBMPfile: str):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def outline2file(ExistingBMPfile: str, NewBMPfile: str):**
->Applies an outline filter
+Applies an outline filter
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def outlinecircregion(bmp: array.array, x: int, y: int, r: int):**
->Outlines a circular area
+### [`outline`](#Python_BMP.BITMAPlib.outline)
+
+```py
+def outline(bmp: array.array):
+```
+
+Applies an Outline Filter
 
     Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x, y)
-                 and radius r
-                 of the region
-
+        bmp: unsigned byte array
+             with bmp format
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def outlinecircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):**
->Outlines area in a circular region
+### [`outlinecircregion2file`](#Python_BMP.BITMAPlib.outlinecircregion2file)
+
+```py
+def outlinecircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
+```
+
+Outlines area in a circular region
 
     Args:
         ExistingBMPfile: Whole path to
@@ -5147,30 +7473,37 @@
                          save changes in
         x, y, r        : center (x, y)
                          and radius r
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def outlineregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):**
->Outines a rectangular region in a BMP
+### [`outlinecircregion`](#Python_BMP.BITMAPlib.outlinecircregion)
+
+```py
+def outlinecircregion(bmp: array.array, x: int, y: int, r: int):
+```
+
+Outlines a circular area
 
     Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: defines
-                        the rectangular
-                        region
-
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x, y)
+                 and radius r
+                 of the region
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def outlineregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):**
->Outline filter to rectangular area
+### [`outlineregion2file`](#Python_BMP.BITMAPlib.outlineregion2file)
+
+```py
+def outlineregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
+```
+
+Outline filter to rectangular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -5180,15 +7513,39 @@
         x1, y1, x2, y2 : defines the
                          rectangular
                          region
-
+    
     Returns:
         new bitmap file
+
+
+### [`outlineregion`](#Python_BMP.BITMAPlib.outlineregion)
+
+```py
+def outlineregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
+```
+
+Outines a rectangular region in a BMP
+
+    Args:
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: defines
+                        the rectangular
+                        region
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def pastecirularbuf(bmp: array.array, x: int, y: int, circbuf: list):**
->Paste a circular buffer with a
-    given radius to a centerpoint at (x, y)
+### [`pastecirularbuf`](#Python_BMP.BITMAPlib.pastecirularbuf)
+
+```py
+def pastecirularbuf(bmp: array.array, x: int, y: int, circbuf: list):
+```
+
+Paste a circular buffer with a
+given radius to a centerpoint at (x, y)
 
     Args:
         bmp    : unsigned byte array
@@ -5197,14 +7554,18 @@
                  region
         circbuf: list generated by
                  copycircregion2buf
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def pasterect(bmp: array.array, buf: array.array, x1: int, y1: int):**
->Paste a rectangular area from a buffer to a bmp
+### [`pasterect`](#Python_BMP.BITMAPlib.pasterect)
+
+```py
+def pasterect(bmp: array.array, buf: array.array, x1: int, y1: int):
+```
+
+Paste a rectangular area from a buffer to a bmp
 
     Args:
         bmp   : unsigned byte array
@@ -5213,16 +7574,20 @@
                 image buffer
         x1, y1: point to paste
                 the buffer
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def perspective(vlist: list[list[numbers.Number, numbers.Number, numbers.Number]], rotvec: list[list[float, float], list[float, float], list[float, float]], dispvec: list[numbers.Number, numbers.Number, numbers.Number], d: float) -> tuple:**
->Projects 3D points to 2D and
-        apply rotation and translation
-        vectors
+### [`perspective`](#Python_BMP.solids3D.perspective)
+
+```py
+def perspective(vlist: list[list[numbers.Number, numbers.Number, numbers.Number]], rotvec: list[list[float, float], list[float, float], list[float, float]], dispvec: list[numbers.Number, numbers.Number, numbers.Number], d: float) -> tuple:
+```
+
+Projects 3D points to 2D and
+    apply rotation and translation
+    vectors
 
     Args:
         vlist  : list of 3D vertices
@@ -5230,14 +7595,18 @@
         dispvec: 3D translation vector
         d      : Distance of observer
                  from the screen
-
+    
     Returns:
         tuple (list, list)
-    
 
 
-**def piechart(bmp: array.array, x: int, y: int, r: int, dataandcolorlist: list):**
->Draw a piechart
+### [`piechart`](#Python_BMP.BITMAPlib.piechart)
+
+```py
+def piechart(bmp: array.array, x: int, y: int, r: int, dataandcolorlist: list):
+```
+
+Draw a piechart
 
     Args:
         bmp             : unsigned
@@ -5247,45 +7616,36 @@
                           and radius r
         dataandcolorlist: stuff to plot
                           + color
-
+    
     Returns:
         byref modified unsigned byte array
 
-    
 
+### [`pixelizenxn`](#Python_BMP.BITMAPlib.pixelizenxn)
 
-**def pixelizenxn(bmp: array.array, n: int) -> array.array:**
->Pixelize a whole image with n by n areas
-    in which colors are averaged
+```py
+def pixelizenxn(bmp: array.array, n: int) -> array.array:
+```
+
+Pixelize a whole image with n by n areas
+in which colors are averaged
 
     Args:
         bmp: unsigned byte array
              with bmp format
         n  : size of pixel blur
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def pixelizenxncircregion(bmp: array.array, x: int, y: int, r: int, n: int):**
->Pixelize a circular region in a BMP by n
+### [`pixelizenxncircregion2file`](#Python_BMP.BITMAPlib.pixelizenxncircregion2file)
 
-    Args:
-        bmp    : unsigned byte array
-                 with bmp format
-        x, y, r: center (x, y)
-                 and radius r
-        n      : integer pixellation
-                 dimension n by n
+```py
+def pixelizenxncircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, intpixsize: int):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def pixelizenxncircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, intpixsize: int):**
->Apply a Pixel Blur in a circular area
+Apply a Pixel Blur in a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -5296,28 +7656,56 @@
                          and radius r
         intpixsize     : n by n
                          pixel blur size
-
+    
     Returns:
         new bitmap file
+
+
+### [`pixelizenxncircregion`](#Python_BMP.BITMAPlib.pixelizenxncircregion)
+
+```py
+def pixelizenxncircregion(bmp: array.array, x: int, y: int, r: int, n: int):
+```
+
+Pixelize a circular region in a BMP by n
+
+    Args:
+        bmp    : unsigned byte array
+                 with bmp format
+        x, y, r: center (x, y)
+                 and radius r
+        n      : integer pixellation
+                 dimension n by n
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def pixelizenxntofile(ExistingBMPfile: str, NewBMPfile: str, n: int):**
->Pixellate a bitmap file with n by n pixel areas
+### [`pixelizenxntofile`](#Python_BMP.BITMAPlib.pixelizenxntofile)
+
+```py
+def pixelizenxntofile(ExistingBMPfile: str, NewBMPfile: str, n: int):
+```
+
+Pixellate a bitmap file with n by n pixel areas
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def plot3d(bmp: array.array, sides: list[list, list], issolid: bool, RGBfactors: list[float, float], showoutline: bool, outlinecolor: int):**
->The 3D rendering function
+### [`plot3d`](#Python_BMP.BITMAPlib.plot3d)
+
+```py
+def plot3d(bmp: array.array, sides: list[list, list], issolid: bool, RGBfactors: list[float, float], showoutline: bool, outlinecolor: int):
+```
+
+The 3D rendering function
 
     Args:
         bmp         : unsigned
@@ -5333,14 +7721,18 @@
                       polygon outline
         outlinecolor: color of the
                       polygon outline
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plot3Dsolid(bmp: array.array, vertandsides: list[list, list], issolid: bool, RGBfactors: list[float, float, float], showoutline: bool, outlinecolor: int, rotvect: list[float, float, float], transvect3D: list[float, float, float], d: int, transvect: list[int, int]):**
->3D solid rendering function
+### [`plot3Dsolid`](#Python_BMP.BITMAPlib.plot3Dsolid)
+
+```py
+def plot3Dsolid(bmp: array.array, vertandsides: list[list, list], issolid: bool, RGBfactors: list[float, float, float], showoutline: bool, outlinecolor: int, rotvect: list[float, float, float], transvect3D: list[float, float, float], d: int, transvect: list[int, int]):
+```
+
+3D solid rendering function
 
     Args:
         bmp         : unsigned
@@ -5366,14 +7758,18 @@
         transvect   : 2D translation
                       vector for
                       screen position
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plot8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit pattern
+### [`plot8bitpattern`](#Python_BMP.BITMAPlib.plot8bitpattern)
+
+```py
+def plot8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit pattern
 
     Args:
         bmp       : unsigned byte array
@@ -5387,14 +7783,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plot8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit pattern as circles
+### [`plot8bitpatternasdots`](#Python_BMP.BITMAPlib.plot8bitpatternasdots)
+
+```py
+def plot8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit pattern as circles
 
     Args:
         bmp       : unsigned byte array
@@ -5409,15 +7809,19 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plot8bitpatternastext(bitpattern: list[int], onechar: str, zerochar: str):**
->Outputs the bits of a list
-        of bytes to console
+### [`plot8bitpatternastext`](#Python_BMP.textgraphics.plot8bitpatternastext)
+
+```py
+def plot8bitpatternastext(bitpattern: list[int], onechar: str, zerochar: str):
+```
+
+Outputs the bits of a list
+    of bytes to console
 
     Args:
         bitpattern: list of bytes
@@ -5425,35 +7829,18 @@
                     if bit is 1
         zeropchar : char to display
                     if bit is 0
-
+    
     Returns:
         console output
-    
 
 
-**def plot8bitpatternsideway(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit pattern sideways
+### [`plot8bitpatternsideway`](#Python_BMP.BITMAPlib.plot8bitpatternsideway)
 
-    Args:
-        bmp       : unsigned byte array
-                    with bmp format
-        x, y      : sets where to
-                    draw the pattern
-        bitpattern: list of bytes that
-                    makes the pattern
-        scale     : control how big
-                    the pattern is
-        pixspace  : space between
-                    each bit in pixels
-        color     : color of the pattern
+```py
+def plot8bitpatternsideway(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def plot8bitpatternsidewaywithdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit pattern sideways with dots
+Draws a 8-bit pattern sideways
 
     Args:
         bmp       : unsigned byte array
@@ -5467,14 +7854,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plot8bitpatternsidewaywithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):**
->Draws a 8-bit pattern sideways with a function
+### [`plot8bitpatternsidewaywithdots`](#Python_BMP.BITMAPlib.plot8bitpatternsidewaywithdots)
+
+```py
+def plot8bitpatternsidewaywithdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit pattern sideways with dots
 
     Args:
         bmp       : unsigned byte array
@@ -5488,14 +7879,43 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
+
+
+### [`plot8bitpatternsidewaywithfn`](#Python_BMP.BITMAPlib.plot8bitpatternsidewaywithfn)
+
+```py
+def plot8bitpatternsidewaywithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
+```
+
+Draws a 8-bit pattern sideways with a function
+
+    Args:
+        bmp       : unsigned byte array
+                    with bmp format
+        x, y      : sets where to
+                    draw the pattern
+        bitpattern: list of bytes that
+                    makes the pattern
+        scale     : control how big
+                    the pattern is
+        pixspace  : space between
+                    each bit in pixels
+        color     : color of the pattern
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def plot8bitpatternupsidedown(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit pattern upsidedown
+### [`plot8bitpatternupsidedown`](#Python_BMP.BITMAPlib.plot8bitpatternupsidedown)
+
+```py
+def plot8bitpatternupsidedown(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit pattern upsidedown
 
     Args:
         bmp       : unsigned byte array
@@ -5510,14 +7930,18 @@
                     each bit in pixels
         color     : color of the
                     pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plot8bitpatternupsidedownasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit pattern upsidedown with dots
+### [`plot8bitpatternupsidedownasdots`](#Python_BMP.BITMAPlib.plot8bitpatternupsidedownasdots)
+
+```py
+def plot8bitpatternupsidedownasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit pattern upsidedown with dots
 
     Args:
         bmp       : unsigned byte array
@@ -5531,14 +7955,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plot8bitpatternupsidedownwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):**
->Draws a 8-bit pattern upsidedown with a function
+### [`plot8bitpatternupsidedownwithfn`](#Python_BMP.BITMAPlib.plot8bitpatternupsidedownwithfn)
+
+```py
+def plot8bitpatternupsidedownwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
+```
+
+Draws a 8-bit pattern upsidedown with a function
 
     Args:
         bmp       : unsigned byte array
@@ -5553,14 +7981,18 @@
                     each bit in pixels
         color     : color of the pattern
         fn        : function
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plot8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):**
->8-bit pattern with a function
+### [`plot8bitpatternwithfn`](#Python_BMP.BITMAPlib.plot8bitpatternwithfn)
+
+```py
+def plot8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
+```
+
+8-bit pattern with a function
 
     Args:
         bmp       : unsigned byte array
@@ -5575,47 +8007,58 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotbitsastext(bits: int):**
->Outputs the bits of byte to
-        console
+### [`plotbitsastext`](#Python_BMP.textgraphics.plotbitsastext)
+
+```py
+def plotbitsastext(bits: int):
+```
+
+Outputs the bits of byte to
+    console
 
     Args:
         bits: byte value
-
+    
     Returns:
         space for 0
         *     for 1
-    
 
 
-**def plotbmpastext(bmp: array.array):**
->Plot a bitmap as text
-    (cannot output 24-bit bmp)
+### [`plotbmpastext`](#Python_BMP.BITMAPlib.plotbmpastext)
+
+```py
+def plotbmpastext(bmp: array.array):
+```
+
+Plot a bitmap as text
+(cannot output 24-bit bmp)
 
     Args:
         bmp : unsigned byte array
               with bmp format
-
+    
     Returns:
         console text output
         for debug and ascii art
 
-    
 
+### [`plotcircinsqr`](#Python_BMP.BITMAPlib.plotcircinsqr)
 
-**def plotcircinsqr(bmp, x, y, d, color):**
->Draws a circle in an
-        invisible square with side
-        equal to the circle's diameter
-        and positioned by (x, y)
-        at  the upper left
-        of the bounding square
+```py
+def plotcircinsqr(bmp, x, y, d, color):
+```
+
+Draws a circle in an
+    invisible square with side
+    equal to the circle's diameter
+    and positioned by (x, y)
+    at  the upper left
+    of the bounding square
 
     Args:
         bmp       : unsigned byte array
@@ -5626,11 +8069,15 @@
                     circle
      Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotfilledflower(bmp: array.array, cx: int, cy: int, r: int, petals: float, angrot: float, lumrange: list[int, int], RGBfactors: list[float, float, float]):**
->Draw a filled flower
+### [`plotfilledflower`](#Python_BMP.BITMAPlib.plotfilledflower)
+
+```py
+def plotfilledflower(bmp: array.array, cx: int, cy: int, r: int, petals: float, angrot: float, lumrange: list[int, int], RGBfactors: list[float, float, float]):
+```
+
+Draw a filled flower
 
     Args:
         bmp       : unsigned byte array
@@ -5645,15 +8092,18 @@
                     of r, g and b
                     range from
                     0.0 to 1.0
-
+    
     Returns:
         byref modified unsigned byte array
 
-    
 
+### [`plotflower`](#Python_BMP.BITMAPlib.plotflower)
 
-**def plotflower(bmp: array.array, cx: int, cy: int, r: int, petals: float, angrot: float, lumrange: list[int, int], RGBfactors: list[float, float, float]):**
->Draw a flower
+```py
+def plotflower(bmp: array.array, cx: int, cy: int, r: int, petals: float, angrot: float, lumrange: list[int, int], RGBfactors: list[float, float, float]):
+```
+
+Draw a flower
 
     Args:
         bmp       : unsigned byte array
@@ -5668,14 +8118,18 @@
         rgbfactors: [r, g, b] values
                     all range from
                     0.0 to 1.0
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotimgedges(bmp: array.array, similaritythreshold: int, edgeradius: int, edgecolor: int):**
->Draw edges
+### [`plotimgedges`](#Python_BMP.BITMAPlib.plotimgedges)
+
+```py
+def plotimgedges(bmp: array.array, similaritythreshold: int, edgeradius: int, edgecolor: int):
+```
+
+Draw edges
 
     Args:
         bmp                : unsigned
@@ -5692,14 +8146,18 @@
                              used to
                              draw the
                              edges
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalic8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit italic pattern
+### [`plotitalic8bitpattern`](#Python_BMP.BITMAPlib.plotitalic8bitpattern)
+
+```py
+def plotitalic8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit italic pattern
 
     Args:
         bmp       : unsigned byte array
@@ -5714,14 +8172,18 @@
         pixspace  : space between
                     each bit
         color     : color of pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalic8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit italic pattern as dots
+### [`plotitalic8bitpatternasdots`](#Python_BMP.BITMAPlib.plotitalic8bitpatternasdots)
+
+```py
+def plotitalic8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit italic pattern as dots
 
     Args:
         bmp       : unsigned byte array
@@ -5735,14 +8197,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalic8bitpatternsideway(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws an italic 8-bit pattern sideways
+### [`plotitalic8bitpatternsideway`](#Python_BMP.BITMAPlib.plotitalic8bitpatternsideway)
+
+```py
+def plotitalic8bitpatternsideway(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws an italic 8-bit pattern sideways
 
     Args:
         bmp       : unsigned byte array
@@ -5756,14 +8222,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalic8bitpatternsidewayasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws an italic 8-bit pattern sideways as dots
+### [`plotitalic8bitpatternsidewayasdots`](#Python_BMP.BITMAPlib.plotitalic8bitpatternsidewayasdots)
+
+```py
+def plotitalic8bitpatternsidewayasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws an italic 8-bit pattern sideways as dots
 
     Args:
         bmp       : unsigned byte array
@@ -5777,14 +8247,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalic8bitpatternsidewaywithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):**
->Draws an Italic 8-bit pattern sideways with a function
+### [`plotitalic8bitpatternsidewaywithfn`](#Python_BMP.BITMAPlib.plotitalic8bitpatternsidewaywithfn)
+
+```py
+def plotitalic8bitpatternsidewaywithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
+```
+
+Draws an Italic 8-bit pattern sideways with a function
 
     Args:
         bmp       : unsigned byte array
@@ -5798,14 +8272,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalic8bitpatternupdsidedownasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit italic pattern upsidedown as dots
+### [`plotitalic8bitpatternupdsidedownasdots`](#Python_BMP.BITMAPlib.plotitalic8bitpatternupdsidedownasdots)
+
+```py
+def plotitalic8bitpatternupdsidedownasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit italic pattern upsidedown as dots
 
     Args:
         bmp       : unsigned byte array
@@ -5819,14 +8297,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalic8bitpatternupsidedownwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):**
->Italic 8-bit pattern upsidedown with a function
+### [`plotitalic8bitpatternupsidedownwithfn`](#Python_BMP.BITMAPlib.plotitalic8bitpatternupsidedownwithfn)
+
+```py
+def plotitalic8bitpatternupsidedownwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
+```
+
+Italic 8-bit pattern upsidedown with a function
 
     Args:
         bmp       : unsigned byte array
@@ -5841,14 +8323,18 @@
                     each bit in pixels
         color     : color of the pattern
         fn        : function
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalic8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):**
->Italic 8-bit pattern with a function
+### [`plotitalic8bitpatternwithfn`](#Python_BMP.BITMAPlib.plotitalic8bitpatternwithfn)
+
+```py
+def plotitalic8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
+```
+
+Italic 8-bit pattern with a function
 
     Args:
         bmp       : unsigned byte array
@@ -5863,14 +8349,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalicstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a string as Italic
+### [`plotitalicstring`](#Python_BMP.BITMAPlib.plotitalicstring)
+
+```py
+def plotitalicstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a string as Italic
 
     Args:
         bmp             : unsigned
@@ -5890,14 +8380,18 @@
                           the font
         fontbuf         : the font
                           (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalicstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a string as Italic dots
+### [`plotitalicstringasdots`](#Python_BMP.BITMAPlib.plotitalicstringasdots)
+
+```py
+def plotitalicstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a string as Italic dots
 
     Args:
         bmp             : unsigned
@@ -5917,14 +8411,18 @@
                           the font
         fontbuf         : the font
                           (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalicstringsideway(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws an Italic String Sideways
+### [`plotitalicstringsideway`](#Python_BMP.BITMAPlib.plotitalicstringsideway)
+
+```py
+def plotitalicstringsideway(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws an Italic String Sideways
 
     Args:
         bmp             : unsigned
@@ -5946,14 +8444,18 @@
                           list of ints
         fontbuf         : the font
                           (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalicstringsidewayasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws an italic string sideways as dots
+### [`plotitalicstringsidewayasdots`](#Python_BMP.BITMAPlib.plotitalicstringsidewayasdots)
+
+```py
+def plotitalicstringsidewayasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws an italic string sideways as dots
 
     Args:
         bmp             : unsigned
@@ -5972,14 +8474,18 @@
                           the font
         fontbuf         : the font
                          (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalicstringvertical(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws an italic string vertically with dots
+### [`plotitalicstringvertical`](#Python_BMP.BITMAPlib.plotitalicstringvertical)
+
+```py
+def plotitalicstringvertical(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws an italic string vertically with dots
 
     Args:
         bmp             : unsigned
@@ -5998,14 +8504,18 @@
                           the font
         fontbuf         : the font
                          (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotitalicstringverticalasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws an italic string vertically with dots
+### [`plotitalicstringverticalasdots`](#Python_BMP.BITMAPlib.plotitalicstringverticalasdots)
+
+```py
+def plotitalicstringverticalasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws an italic string vertically with dots
 
     Args:
         bmp             : unsigned
@@ -6024,14 +8534,18 @@
                           the font
         fontbuf         : the font
                          (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotlines(bmp: array.array, vertlist: list, color: int):**
->Draws connected lines defined by a list of vertices
+### [`plotlines`](#Python_BMP.BITMAPlib.plotlines)
+
+```py
+def plotlines(bmp: array.array, vertlist: list, color: int):
+```
+
+Draws connected lines defined by a list of vertices
 
     Args:
         bmp     : unsigned byte array
@@ -6039,14 +8553,18 @@
         vertlist: [(x:uint,y:uint),...]
                   list of vertices
         color   : color of the lines
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotpoly(bmp: array.array, vertlist: list, color: int):**
->Draws a polygon defined by a list of vertices
+### [`plotpoly`](#Python_BMP.BITMAPlib.plotpoly)
+
+```py
+def plotpoly(bmp: array.array, vertlist: list, color: int):
+```
+
+Draws a polygon defined by a list of vertices
 
     Args:
         bmp     : unsigned byte array
@@ -6054,14 +8572,18 @@
         vertlist: [(x:uint,y:uint),...]
                   list of vertices
         color   : color of the lines
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotpolyfill(bmp: array.array, vertlist: list[list[numbers.Number, numbers.Number]], color: int):**
->Draws a filled polygon with a given color
+### [`plotpolyfill`](#Python_BMP.BITMAPlib.plotpolyfill)
+
+```py
+def plotpolyfill(bmp: array.array, vertlist: list[list[numbers.Number, numbers.Number]], color: int):
+```
+
+Draws a filled polygon with a given color
 
     Args:
         bmp     : unsigned byte array
@@ -6070,14 +8592,18 @@
                   list of vertices
         color   : color of the
                   filled polygon
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotpolyfillist(bmp: array.array, sides: list[list[list[list]], list[list[float, float, float]]], RGBfactors: list[float, float]):**
->3D polygon rendering function
+### [`plotpolyfillist`](#Python_BMP.BITMAPlib.plotpolyfillist)
+
+```py
+def plotpolyfillist(bmp: array.array, sides: list[list[list[list]], list[list[float, float, float]]], RGBfactors: list[float, float]):
+```
+
+3D polygon rendering function
 
     Args:
         bmp       : unsigned byte array
@@ -6088,14 +8614,18 @@
                     r, g, b are
                     float values
                     from 0.0 to 1.0
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotpolylist(bmp: array.array, polylist: list, color: int):**
->Draws a list of polygons of a given color
+### [`plotpolylist`](#Python_BMP.BITMAPlib.plotpolylist)
+
+```py
+def plotpolylist(bmp: array.array, polylist: list, color: int):
+```
+
+Draws a list of polygons of a given color
 
     Args:
         bmp      : unsigned byte array
@@ -6104,14 +8634,18 @@
                     ...],...]
                    list of polygons
         color    : color of the lines
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotreverseditalic8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit reversed italic pattern
+### [`plotreverseditalic8bitpattern`](#Python_BMP.BITMAPlib.plotreverseditalic8bitpattern)
+
+```py
+def plotreverseditalic8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit reversed italic pattern
 
     Args:
         bmp       : unsigned byte array
@@ -6125,14 +8659,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotreverseditalic8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit reversed italic pattern as dots
+### [`plotreverseditalic8bitpatternasdots`](#Python_BMP.BITMAPlib.plotreverseditalic8bitpatternasdots)
+
+```py
+def plotreverseditalic8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit reversed italic pattern as dots
 
     Args:
         bmp       : unsigned byte array
@@ -6146,14 +8684,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotreverseditalicstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a reversed string as Italic
+### [`plotreverseditalicstring`](#Python_BMP.BITMAPlib.plotreverseditalicstring)
+
+```py
+def plotreverseditalicstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a reversed string as Italic
 
     Args:
         bmp             : unsigned
@@ -6171,14 +8713,18 @@
         color           : color of font
         fontbuf         : the font
                           (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotreverseditalicstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a Reversed String as Italic dots
+### [`plotreverseditalicstringasdots`](#Python_BMP.BITMAPlib.plotreverseditalicstringasdots)
+
+```py
+def plotreverseditalicstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a Reversed String as Italic dots
 
     Args:
         bmp             : unsigned
@@ -6198,14 +8744,18 @@
                           the font
         fontbuf         : the font
                           (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotreversestring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a string reversed
+### [`plotreversestring`](#Python_BMP.BITMAPlib.plotreversestring)
+
+```py
+def plotreversestring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a string reversed
 
     Args:
         bmp             : unsigned
@@ -6224,14 +8774,18 @@
                           the font
         fontbuf         : the font
                          (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotreversestringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a string reversed with dots
+### [`plotreversestringasdots`](#Python_BMP.BITMAPlib.plotreversestringasdots)
+
+```py
+def plotreversestringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a string reversed with dots
 
     Args:
         bmp             : unsigned
@@ -6250,14 +8804,18 @@
                           the font
         fontbuf         : the font
                          (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotRGBxybit(bmp: array.array, x: int, y: int, rgb: list):**
->Sets pixel at (x, y) in a bitmap to color [R, G, B]
+### [`plotRGBxybit`](#Python_BMP.BITMAPlib.plotRGBxybit)
+
+```py
+def plotRGBxybit(bmp: array.array, x: int, y: int, rgb: list):
+```
+
+Sets pixel at (x, y) in a bitmap to color [R, G, B]
 
     Args:
         bmp: unsigned byte array
@@ -6266,14 +8824,18 @@
              in x and y
         rgb: color defined by
              [R: byte, G: byte, B: byte]
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotRGBxybitvec(bmp: array.array, v: list, rgb: list):**
->Sets [R, G, B] of pixel at (x, y)
+### [`plotRGBxybitvec`](#Python_BMP.BITMAPlib.plotRGBxybitvec)
+
+```py
+def plotRGBxybitvec(bmp: array.array, v: list, rgb: list):
+```
+
+Sets [R, G, B] of pixel at (x, y)
 
     Args:
         bmp: unsigned byte array
@@ -6282,14 +8844,18 @@
         rgb: [R: byte,
               G: byte,
               B: byte]
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotrotated8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit pattern with the bits rotated
+### [`plotrotated8bitpattern`](#Python_BMP.BITMAPlib.plotrotated8bitpattern)
+
+```py
+def plotrotated8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit pattern with the bits rotated
 
     Args:
         bmp       : unsigned byte array
@@ -6304,14 +8870,18 @@
                     each bit in pixels
         color     : color of the
                     pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotrotated8bitpatternwithdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit pattern with the bits rotated
+### [`plotrotated8bitpatternwithdots`](#Python_BMP.BITMAPlib.plotrotated8bitpatternwithdots)
+
+```py
+def plotrotated8bitpatternwithdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit pattern with the bits rotated
 
     Args:
         bmp       : unsigned byte array
@@ -6326,15 +8896,19 @@
                     each bit in pixels
         color     : color of the
                     pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotrotated8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):**
->Draws a 8-bit pattern with
-    the bits rotated with a function
+### [`plotrotated8bitpatternwithfn`](#Python_BMP.BITMAPlib.plotrotated8bitpatternwithfn)
+
+```py
+def plotrotated8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
+```
+
+Draws a 8-bit pattern with
+the bits rotated with a function
 
     Args:
         bmp       : unsigned byte array
@@ -6348,15 +8922,19 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotrotateditalic8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):**
->Bit rotated Italic 8-bit pattern
-    with a function
+### [`plotrotateditalic8bitpatternwithfn`](#Python_BMP.BITMAPlib.plotrotateditalic8bitpatternwithfn)
+
+```py
+def plotrotateditalic8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
+```
+
+Bit rotated Italic 8-bit pattern
+with a function
 
     Args:
         bmp       : unsigned byte array
@@ -6371,14 +8949,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a string
+### [`plotstring`](#Python_BMP.BITMAPlib.plotstring)
+
+```py
+def plotstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a string
 
     Args:
         bmp             : unsigned
@@ -6401,14 +8983,18 @@
                           list of ints)
         fontbuf         : the font
                           (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a string as Dots
+### [`plotstringasdots`](#Python_BMP.BITMAPlib.plotstringasdots)
+
+```py
+def plotstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a string as Dots
 
     Args:
         bmp             : unsigned
@@ -6426,14 +9012,18 @@
         color           : color of the font
         fontbuf         : the font
                           (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotstringfunc(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, orderfunc: Callable, fontrenderfunc: Callable):**
->Draws a string
+### [`plotstringfunc`](#Python_BMP.BITMAPlib.plotstringfunc)
+
+```py
+def plotstringfunc(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, orderfunc: Callable, fontrenderfunc: Callable):
+```
+
+Draws a string
 
     Args:
         bmp             : unsigned
@@ -6458,14 +9048,18 @@
                           input string
         fontrenderfunc  : function that
                           renders the font
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotstringsideway(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a string sideways
+### [`plotstringsideway`](#Python_BMP.BITMAPlib.plotstringsideway)
+
+```py
+def plotstringsideway(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a string sideways
 
     Args:
         bmp             : unsigned
@@ -6484,14 +9078,18 @@
                           the font
         fontbuf         : the font
                          (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotstringsidewayasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a string sideways as dots
+### [`plotstringsidewayasdots`](#Python_BMP.BITMAPlib.plotstringsidewayasdots)
+
+```py
+def plotstringsidewayasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a string sideways as dots
 
     Args:
         bmp             : unsigned
@@ -6510,14 +9108,18 @@
                           the font
         fontbuf         : the font
                          (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotstringsidewayfn(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, fn: Callable):**
->Draws a string sideways with a function
+### [`plotstringsidewayfn`](#Python_BMP.BITMAPlib.plotstringsidewayfn)
+
+```py
+def plotstringsidewayfn(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, fn: Callable):
+```
+
+Draws a string sideways with a function
 
     Args:
         bmp             : unsigned
@@ -6536,14 +9138,18 @@
                           the font
         fontbuf         : the font
                          (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotstringupsidedown(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a string upsidedown
+### [`plotstringupsidedown`](#Python_BMP.BITMAPlib.plotstringupsidedown)
+
+```py
+def plotstringupsidedown(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a string upsidedown
 
     Args:
         bmp             : unsigned
@@ -6562,14 +9168,18 @@
                           the font
         fontbuf         : the font
                           (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotstringupsidedownasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a string upsidedown as dots
+### [`plotstringupsidedownasdots`](#Python_BMP.BITMAPlib.plotstringupsidedownasdots)
+
+```py
+def plotstringupsidedownasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a string upsidedown as dots
 
     Args:
         bmp             : unsigned
@@ -6587,14 +9197,18 @@
         color           : color of the font
         fontbuf         : the font
                           (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotstringvertical(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a string vertically
+### [`plotstringvertical`](#Python_BMP.BITMAPlib.plotstringvertical)
+
+```py
+def plotstringvertical(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a string vertically
 
     Args:
         bmp             : unsigned
@@ -6613,14 +9227,18 @@
                           the font
         fontbuf         : the font
                          (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotstringverticalasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draws a string vertically with dots
+### [`plotstringverticalasdots`](#Python_BMP.BITMAPlib.plotstringverticalasdots)
+
+```py
+def plotstringverticalasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draws a string vertically with dots
 
     Args:
         bmp             : unsigned
@@ -6639,14 +9257,18 @@
                           the font
         fontbuf         : the font
                          (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotstringverticalwithfn(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, fn: Callable):**
->Draws a string vertically using a function
+### [`plotstringverticalwithfn`](#Python_BMP.BITMAPlib.plotstringverticalwithfn)
+
+```py
+def plotstringverticalwithfn(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, fn: Callable):
+```
+
+Draws a string vertically using a function
 
     Args:
         bmp             : unsigned
@@ -6665,14 +9287,18 @@
                           the font
         fontbuf         : the font
                          (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotupsidedownitalic8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit italic pattern upsidedown
+### [`plotupsidedownitalic8bitpattern`](#Python_BMP.BITMAPlib.plotupsidedownitalic8bitpattern)
+
+```py
+def plotupsidedownitalic8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit italic pattern upsidedown
 
     Args:
         bmp       : unsigned byte array
@@ -6686,14 +9312,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotupsidedownitalic8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):**
->Draws a 8-bit italic pattern upsidedown as dots
+### [`plotupsidedownitalic8bitpatternasdots`](#Python_BMP.BITMAPlib.plotupsidedownitalic8bitpatternasdots)
+
+```py
+def plotupsidedownitalic8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
+```
+
+Draws a 8-bit italic pattern upsidedown as dots
 
     Args:
         bmp       : unsigned byte array
@@ -6707,14 +9337,18 @@
         pixspace  : space between
                     each bit in pixels
         color     : color of the pattern
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotupsidedownitalicstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draw an italic string upsidedown
+### [`plotupsidedownitalicstring`](#Python_BMP.BITMAPlib.plotupsidedownitalicstring)
+
+```py
+def plotupsidedownitalicstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draw an italic string upsidedown
 
     Args:
         bmp             : unsigned
@@ -6734,14 +9368,18 @@
                           the font
         fontbuf         : the font
                           (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotupsidedownitalicstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):**
->Draw an italic string upsidedown as dots
+### [`plotupsidedownitalicstringasdots`](#Python_BMP.BITMAPlib.plotupsidedownitalicstringasdots)
+
+```py
+def plotupsidedownitalicstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
+```
+
+Draw an italic string upsidedown as dots
 
     Args:
         bmp             : unsigned
@@ -6761,15 +9399,19 @@
                           the font
         fontbuf         : the font
                           (see fonts.py)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotvecxypoint(bmp: array.array, v: list, c: int):**
->Sets the color of a pixel
-        at (x, y)
+### [`plotvecxypoint`](#Python_BMP.BITMAPlib.plotvecxypoint)
+
+```py
+def plotvecxypoint(bmp: array.array, v: list, c: int):
+```
+
+Sets the color of a pixel
+    at (x, y)
 
     Args:
         bmp: unsigned byte array
@@ -6779,15 +9421,19 @@
              (x:int, y:int)
         c  : unsigned int
              color value
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def plotxybit(bmp: array.array, x: int, y: int, c: int):**
->Sets pixel at (x, y) in a bitmap to color c
+### [`plotxybit`](#Python_BMP.BITMAPlib.plotxybit)
+
+```py
+def plotxybit(bmp: array.array, x: int, y: int, c: int):
+```
+
+Sets pixel at (x, y) in a bitmap to color c
 
     Args:
         bmp : unsigned byte array
@@ -6795,17 +9441,21 @@
         x, y: unsigned int
               locations in x and y
         c   : unsigned int color
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def plotxypointlist(bmp: array.array, vlist: list, penradius: int, color: int):**
->Draws a circle or a point
-    depending on the penradius
-    with a given color for
-    all points in a point list
+### [`plotxypointlist`](#Python_BMP.BITMAPlib.plotxypointlist)
+
+```py
+def plotxypointlist(bmp: array.array, vlist: list, penradius: int, color: int):
+```
+
+Draws a circle or a point
+depending on the penradius
+with a given color for
+all points in a point list
 
     Args:
         bmp      : unsigned byte array
@@ -6815,74 +9465,94 @@
         penradius: radius of the pen
                    (in pixels)
         color    : color of the pen
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def polar2rectcoord2D(vpolarcoord: list[float, float]) -> list[float, float]:**
->Converts from polar coordinates with
-    origin at (0, 0) to 2D rectangular coordinates
+### [`polar2rectcoord2D`](#Python_BMP.mathlib.polar2rectcoord2D)
+
+```py
+def polar2rectcoord2D(vpolarcoord: list[float, float]) -> list[float, float]:
+```
+
+Converts from polar coordinates with
+origin at (0, 0) to 2D rectangular coordinates
 
     Args:
         vcylindcoord:(r: float,
                   theta: float)
-
+    
     Returns:
         [x: float,
          y: float]
-    
 
 
-**def polyboundary(vertlist: list[list[int, int]]) -> list[list[int, int]]:**
->Generates a polygon boundary
-        from a list of 2D vertices
+### [`polyboundary`](#Python_BMP.solids3D.polyboundary)
+
+```py
+def polyboundary(vertlist: list[list[int, int]]) -> list[list[int, int]]:
+```
+
+Generates a polygon boundary
+    from a list of 2D vertices
 
     Args:
         polybnd : list of 2D vertices
                   list[list[x: int,
                             y: int]]
-
+    
     Returns:
         list[list[x: int, y: int]]
         A list of vertices that traces
         the boundaries of the polygon
-    
 
 
-**def probplotRGBto1bit(rgb: list[int, int, int], brightness: int) -> int:**
->Use a non deterministic plot
-        to convert 24-bit colors to
-        1-bit
+### [`probplotRGBto1bit`](#Python_BMP.colors.probplotRGBto1bit)
+
+```py
+def probplotRGBto1bit(rgb: list[int, int, int], brightness: int) -> int:
+```
+
+Use a non deterministic plot
+    to convert 24-bit colors to
+    1-bit
 
     Args:
         rgb: color byte values
              [r: byte,
               g: byte,
               b: byte]
-
+    
     Returns:
         0 or 1
-    
 
 
-**def range2baseanddelta(lst_range: list[int, int]):**
->Gets the base and range values in a list of numbers
+### [`range2baseanddelta`](#Python_BMP.mathlib.range2baseanddelta)
+
+```py
+def range2baseanddelta(lst_range: list[int, int]):
+```
+
+Gets the base and range values in a list of numbers
 
     Args:
         lst_range: list[min: int,
                         max: int]
-
+    
     Returns:
         minimum value and delta of min and max value
         in lst_range
-    
 
 
-**def readint(offset: int, cnt: int, arr: int) -> int:**
->Reads an integer value in an
-        unsigned byte array
+### [`readint`](#Python_BMP.inttools.readint)
+
+```py
+def readint(offset: int, cnt: int, arr: int) -> int:
+```
+
+Reads an integer value in an
+    unsigned byte array
 
     Args:
         offset: uint starting offset in
@@ -6892,31 +9562,18 @@
                 to read
         arr   : unsigned byte array
                 to read int data from
-
+    
     Returns:
         unsigned int value
-    
 
 
-**def rectangle(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):**
->Draws a Rectangle
+### [`rectangle2file`](#Python_BMP.BITMAPlib.rectangle2file)
 
-    Args:
-        bmp           : unsigned
-                        byte array
-                        with bmp format
-        x1, y1, x2, y2: the rectangular
-                        region
-        color         : color of the
-                        rectangle
+```py
+def rectangle2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, color: int):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def rectangle2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, color: int):**
->Draws a Rectangle
+Draws a Rectangle
 
     Args:
         ExistingBMPfile: Whole path to
@@ -6926,39 +9583,72 @@
         x1, y1, x2, y2 : defines the
                          rectangular region
         color          : color of rectangle
-
+    
     Returns:
         new bitmap file
+
+
+### [`rectangle`](#Python_BMP.BITMAPlib.rectangle)
+
+```py
+def rectangle(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):
+```
+
+Draws a Rectangle
+
+    Args:
+        bmp           : unsigned
+                        byte array
+                        with bmp format
+        x1, y1, x2, y2: the rectangular
+                        region
+        color         : color of the
+                        rectangle
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def rectboundarycoords(vlist: list) -> list:**
->Returns the rectangular bounds of a list of 2D vertices
+### [`rectboundarycoords`](#Python_BMP.primitives2D.rectboundarycoords)
+
+```py
+def rectboundarycoords(vlist: list) -> list:
+```
+
+Returns the rectangular bounds of a list of 2D vertices
 
     Args:
         vlist: list[(x: int, y :int)]
-
+    
     Yields:
         ((min(x), min(y)),
          (max(x), max(y)))
-    
 
 
-**def recvert(x1: int, y1: int, x2: int, y2: int) -> list[list[int, int], list[int, int], list[int, int], list[int, int]]:**
->Creates a list of vertices for a rectangle
+### [`recvert`](#Python_BMP.primitives2D.recvert)
+
+```py
+def recvert(x1: int, y1: int, x2: int, y2: int) -> list[list[int, int], list[int, int], list[int, int], list[int, int]]:
+```
+
+Creates a list of vertices for a rectangle
 
     Args:
         x1, y1, x1, y2: int values
-
+    
     Returns:
         list of vertices
         [(x1, y1), (x2, y1),
          (x2, y2), (x1, y2)]
-    
 
 
-**def reduce24bitimagebits(Existing24BMPfile: str, NewBMPfile: str, newbits: int, similaritythreshold: float, usemonopal: bool, RGBfactors: list[float, float, float] = None):**
->Reduce bits used to encode color in a 24-bit BMP
+### [`reduce24bitimagebits`](#Python_BMP.BITMAPlib.reduce24bitimagebits)
+
+```py
+def reduce24bitimagebits(Existing24BMPfile: str, NewBMPfile: str, newbits: int, similaritythreshold: float, usemonopal: bool, RGBfactors: list[float, float, float] = None):
+```
+
+Reduce bits used to encode color in a 24-bit BMP
 
     Args:
         ExistingBMPfile    : Whole path
@@ -6983,11 +9673,14 @@
     Returns:
         new bitmap file
 
-    
 
+### [`regpolygonvert`](#Python_BMP.primitives2D.regpolygonvert)
 
-**def regpolygonvert(cx: int, cy: int, r: int, sides: int, angle: float) -> list[list[int, int]]:**
->Creates a list of int vertices for a regular polygon
+```py
+def regpolygonvert(cx: int, cy: int, r: int, sides: int, angle: float) -> list[list[int, int]]:
+```
+
+Creates a list of int vertices for a regular polygon
 
     Args:
         cx, cy: int center of a circle
@@ -6999,16 +9692,20 @@
         angle:  angle of rotation
                 of the polygon in
                 degrees
-
+    
     Returns:
         list of int vertices
         [(x, y), ...]
-    
 
 
-**def resizebufNtimesbigger(buf: array.array, n: int, bits: int) -> array.array:**
->Resize a buffer n times bigger
-        given a particular bit depth n
+### [`resizebufNtimesbigger`](#Python_BMP.bufresize.resizebufNtimesbigger)
+
+```py
+def resizebufNtimesbigger(buf: array.array, n: int, bits: int) -> array.array:
+```
+
+Resize a buffer n times bigger
+    given a particular bit depth n
 
     Args:
         buf : array to resize
@@ -7016,15 +9713,37 @@
         bits: bit depth of
               color info
               (1, 4, 8, 24) bits
-
+    
     Returns:
         list
+
+
+### [`resizeNtimesbigger2file`](#Python_BMP.BITMAPlib.resizeNtimesbigger2file)
+
+```py
+def resizeNtimesbigger2file(ExistingBMPfile: str, NewBMPfile: str, n: int):
+```
+
+Resize a bitmap file n times bigger
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
     
+    Returns:
+        new bitmap file
 
 
-**def resizeNtimesbigger(bmp: array.array, n: int):**
->Resize an in-memory bmp
-        n times bigger
+### [`resizeNtimesbigger`](#Python_BMP.BITMAPlib.resizeNtimesbigger)
+
+```py
+def resizeNtimesbigger(bmp: array.array, n: int):
+```
+
+Resize an in-memory bmp
+    n times bigger
 
     Args:
         buf : array to resize
@@ -7032,129 +9751,147 @@
         bits: bit depth of
               the color info
               (1, 4, 8, 24)
-
+    
     Returns:
         unsigned byte array
-    
 
 
-**def resizeNtimesbigger2file(ExistingBMPfile: str, NewBMPfile: str, n: int):**
->Resize a bitmap file n times bigger
+### [`resizeNtimessmaller2file`](#Python_BMP.BITMAPlib.resizeNtimessmaller2file)
+
+```py
+def resizeNtimessmaller2file(ExistingBMPfile: str, NewBMPfile: str, n: int):
+```
+
+Resize a bitmap file n times smaller
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def resizeNtimessmaller(bmp: array.array, n: int) -> array.array:**
->Resize a whole image int n times smaller
+### [`resizeNtimessmaller`](#Python_BMP.BITMAPlib.resizeNtimessmaller)
+
+```py
+def resizeNtimessmaller(bmp: array.array, n: int) -> array.array:
+```
+
+Resize a whole image int n times smaller
 
     Args:
         bmp: unsigned byte array
              with bmp format
         n  : int resize factor
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def resizeNtimessmaller2file(ExistingBMPfile: str, NewBMPfile: str, n: int):**
->Resize a bitmap file n times smaller
+### [`resizesmaller24bitbuf`](#Python_BMP.bufresize.resizesmaller24bitbuf)
 
-    Args:
-        ExistingBMPfile: Whole path to
-                         existing file
-        NewBMPfile     : New file to
-                         save changes in
+```py
+def resizesmaller24bitbuf(buf: array.array) -> array.array:
+```
 
-    Returns:
-        new bitmap file
-    
-
-
-**def resizesmaller24bitbuf(buf: array.array) -> array.array:**
->Resize a 24-bit buffer
-        n times smaller
+Resize a 24-bit buffer
+    n times smaller
 
     Args:
         buf: unsigned byte array
         n  : buffer multiplier
-
+    
     Returns:
         unsigned byte array
-    
 
 
-**def RGB2BGRarr(r: int, g: int, b: int) -> array.array:**
->Returns a bgr array from
-        individual r, g and b color
-        component inputs
+### [`RGB2BGRarr`](#Python_BMP.colors.RGB2BGRarr)
+
+```py
+def RGB2BGRarr(r: int, g: int, b: int) -> array.array:
+```
+
+Returns a bgr array from
+    individual r, g and b color
+    component inputs
 
     Args:
         r, g, b: byte color values
-
+    
     Returns:
         unsigned byte BGR array
-    
 
 
-**def RGB2BGRbuf(buf: array.array):**
->Convert an RGB buffer
-             to a BGR buffer
+### [`RGB2BGRbuf`](#Python_BMP.colors.RGB2BGRbuf)
+
+```py
+def RGB2BGRbuf(buf: array.array):
+```
+
+Convert an RGB buffer
+         to a BGR buffer
 
     Args:
         buf: unsigned byte array
              holding RGB data
-
+    
     Returns:
         byref unsigned byte array
         holding BGR data
-    
 
 
-**def RGB2HSL(r: int, g: int, b: int) -> list[int, int, int]:**
->Converts an RGB value to HSL
+### [`RGB2HSL`](#Python_BMP.colors.RGB2HSL)
+
+```py
+def RGB2HSL(r: int, g: int, b: int) -> list[int, int, int]:
+```
+
+Converts an RGB value to HSL
 
     Args:
         r: unsigned byte red value
         g: unsigned byte green value
         b: unsigned byte blue value
-
+    
     Returns:
         [hue: int,  ->  in degrees
          sat: int,  ->  percentage
          lum: int]  ->  percentage
-    
 
 
-**def RGB2int(r: int, g: int, b: int) -> int:**
->Pack byte r, g and b color value
-        components to an int
-        representation for a
-        specific color
+### [`RGB2int`](#Python_BMP.colors.RGB2int)
+
+```py
+def RGB2int(r: int, g: int, b: int) -> int:
+```
+
+Pack byte r, g and b color value
+    components to an int
+    representation for a
+    specific color
 
     Args:
         r, g, b: color byte values
-
+    
     Returns:
         int color val
-    
 
 
-**def RGBfactors2RGB(RGBfactors: list[float, float, float], bytelum: int) -> list[int, int, int]:**
->Mix a byte luminosity value to
-        an rgb triplet that express
-        a color value in [r, g, b]
-        ratios from 0.0 to 1.0 to
-        obtain byte r, g, b values
-        stored in a list [r, g, b]
+### [`RGBfactors2RGB`](#Python_BMP.colors.RGBfactors2RGB)
+
+```py
+def RGBfactors2RGB(RGBfactors: list[float, float, float], bytelum: int) -> list[int, int, int]:
+```
+
+Mix a byte luminosity value to
+    an rgb triplet that express
+    a color value in [r, g, b]
+    ratios from 0.0 to 1.0 to
+    obtain byte r, g, b values
+    stored in a list [r, g, b]
 
     Args:
         lum       : a byte value for
@@ -7164,94 +9901,118 @@
                          b: float]
                     float values from
                     0.0 to 1.0
-
+    
     Returns:
         [r: byte, g: byte, b: byte]
-    
 
 
-**def RGBfactorstoBaseandRange(lumrange: list[int, int], rgbfactors: list[float, float, float]):**
->Get base color luminosity and
-        luminosity range from color
-        expressed as r, g, b  float
-        values and min and max byte
-        luminosity values
+### [`RGBfactorstoBaseandRange`](#Python_BMP.colors.RGBfactorstoBaseandRange)
+
+```py
+def RGBfactorstoBaseandRange(lumrange: list[int, int], rgbfactors: list[float, float, float]):
+```
+
+Get base color luminosity and
+    luminosity range from color
+    expressed as r, g, b  float
+    values and min and max byte
+    luminosity values
 
     Args:
         lumrange: [minval: byte
                    maxval: byte]
-
+    
         rgbfactors: color  as
                     [r: float,
                      g: float,
                      b: float]
-
+    
     Returns:
         base luminosity as
         [r: byte, g: byte, b: byte]
-
+    
         luminosity range as
         [r: byte, g: byte, b: byte]
-    
 
 
-**def RGBpalbrightnessadjust(bmp: array.array, percentadj: float) -> list:**
->Copies the RGB palette info from
-    a source unsigned byte array to
-    a destination unsigned byte array
+### [`RGBpalbrightnessadjust`](#Python_BMP.BITMAPlib.RGBpalbrightnessadjust)
+
+```py
+def RGBpalbrightnessadjust(bmp: array.array, percentadj: float) -> list:
+```
+
+Copies the RGB palette info from
+a source unsigned byte array to
+a destination unsigned byte array
 
     Args:
         bmp       : unsigned byte array
                     with bmp format
         percentadj: signed float
                     brightness adj in %
-
+    
     Returns:
         list of modified RGB values
-    
 
 
-**def rotatebits(bits: int) -> int:**
->Rotates the bits in a byte
+### [`rotatebits`](#Python_BMP.mathlib.rotatebits)
+
+```py
+def rotatebits(bits: int) -> int:
+```
+
+Rotates the bits in a byte
 
     Args:
         bits: the int 8 bits to rotate
-
+    
     Returns:
         int value of rotated 8 bits
-    
 
 
-**def rotatebitsinbuf(buf: array.array) -> array.array:**
->Does a bit rotate to the bytes
-        in an unsigned byte array
+### [`rotatebitsinbuf`](#Python_BMP.bufferflip.rotatebitsinbuf)
+
+```py
+def rotatebitsinbuf(buf: array.array) -> array.array:
+```
+
+Does a bit rotate to the bytes
+    in an unsigned byte array
 
     Args:
         buf: unsigned byte array
-
+    
     Returns:
         unsigned byte array
-    
 
 
-**def rotvec3D(roll: float, pitch: float, yaw: float) -> tuple:**
->Returns a 3D rotation vector
+### [`rotvec3D`](#Python_BMP.solids3D.rotvec3D)
+
+```py
+def rotvec3D(roll: float, pitch: float, yaw: float) -> tuple:
+```
+
+Returns a 3D rotation vector
 
     Args:
         All input arguements are in
         degrees (roll, pitch, yaw)
-
+    
     Returns:
         tuple ((float, float),
                (float, float),
                (float, float))
-    
 
 
-**def roundpen(bmp: array.array, point: list, penradius: int, color: int):**
->Draws a circle or a point
-    depending on the penradius
-    with a given color
+### [`roundpen`](#Python_BMP.BITMAPlib.roundpen)
+
+```py
+def roundpen(bmp: array.array, point: list, penradius: int, color: int):
+```
+
+Draws a circle or a point
+depending on the penradius
+with a given color
 
     Args:
         bmp      : unsigned byte array
@@ -7261,26 +10022,34 @@
         penradius: radius of the
                    pen in pixels
         color    : color of the pen
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def roundvect(v: list[numbers.Number]) -> list[int]:**
->Rounds off the components of a vector
-       (list of floats -> list of ints)
+### [`roundvect`](#Python_BMP.mathlib.roundvect)
+
+```py
+def roundvect(v: list[numbers.Number]) -> list[int]:
+```
+
+Rounds off the components of a vector
+   (list of floats -> list of ints)
 
     Args:
         v: list of floats
-
+    
     Returns:
         list of ints
-    
 
 
-**def saveBMP(filename: str, bmp: array.array):**
->Saves bitmap to file
+### [`saveBMP`](#Python_BMP.BITMAPlib.saveBMP)
+
+```py
+def saveBMP(filename: str, bmp: array.array):
+```
+
+Saves bitmap to file
 
     Args:
         filename: full path to
@@ -7290,11 +10059,15 @@
                   a bitmap file
     Returns:
         A Bitmap File
-    
 
 
-**def setBMP2monochrome(bmp: array.array, RGBfactors: list[float, float, float]) -> list:**
->Sets a bitmap to use a monochrome palette
+### [`setBMP2monochrome`](#Python_BMP.BITMAPlib.setBMP2monochrome)
+
+```py
+def setBMP2monochrome(bmp: array.array, RGBfactors: list[float, float, float]) -> list:
+```
+
+Sets a bitmap to use a monochrome palette
 
     Args:
         bmp       : unsigned byte array
@@ -7302,28 +10075,36 @@
         RGBfactors: (r, g, b)
                     all values range
                     from 0.0 to 1.0
-
+    
     Returns:
         list of modified RGB values
         byref modified byte array
-    
 
 
-**def setBMPimgbytes(bmp: array.array, buf: array.array):**
->Sets the raw image buffer of a bitmap
+### [`setBMPimgbytes`](#Python_BMP.BITMAPlib.setBMPimgbytes)
+
+```py
+def setBMPimgbytes(bmp: array.array, buf: array.array):
+```
+
+Sets the raw image buffer of a bitmap
 
     Args:
         bmp: unsigned byte array
              with bmp format
         buf: array of unsigned bytes
-
+    
     Returns:
         byref modified  unsigned byte array
-    
 
 
-**def setbmppal(bmp: array.array, pallist: list):**
->Sets the RGB palette of a bitmap
+### [`setbmppal`](#Python_BMP.BITMAPlib.setbmppal)
+
+```py
+def setbmppal(bmp: array.array, pallist: list):
+```
+
+Sets the RGB palette of a bitmap
 
     Args:
         bmp    : unsigned byte array
@@ -7331,56 +10112,72 @@
         pallist: [(r: byte,
                    g: byte,
                    b: byte), ...]
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def setmax(val: numbers.Number, maxval: numbers.Number) -> numbers.Number:**
->Set the value of val to maxval if val > maxval
+### [`setmax`](#Python_BMP.mathlib.setmax)
+
+```py
+def setmax(val: numbers.Number, maxval: numbers.Number) -> numbers.Number:
+```
+
+Set the value of val to maxval if val > maxval
 
     Args:
         val   : numeric variable
         maxval: upper limit of variable
-
+    
     Returns:
         Number
-    
 
 
-**def setmin(val: numbers.Number, minval: numbers.Number) -> numbers.Number:**
->Set the value of val to minval if val < minval
+### [`setmin`](#Python_BMP.mathlib.setmin)
+
+```py
+def setmin(val: numbers.Number, minval: numbers.Number) -> numbers.Number:
+```
+
+Set the value of val to minval if val < minval
 
     Args:
         val   : numeric variable
         minval: lower limit of variable
-
+    
     Returns:
         Number
-    
 
 
-**def setminmax(val: numbers.Number, minval: numbers.Number, maxval: numbers.Number) -> numbers.Number:**
->Set the value of val to minval if val < minval
-    or the value of val to maxval if val > maxval
+### [`setminmax`](#Python_BMP.mathlib.setminmax)
+
+```py
+def setminmax(val: numbers.Number, minval: numbers.Number, maxval: numbers.Number) -> numbers.Number:
+```
+
+Set the value of val to minval if val < minval
+or the value of val to maxval if val > maxval
 
     Args:
         val   : numeric variable
         minval: lower limit of variable
         maxval: upper limit of variable
-
+    
     Returns:
         Number
-    
 
 
-**def setnewpalfromsourcebmp(sourcebmp: array.array, newbmp: array.array, similaritythreshold: float) -> list:**
->Copies the RGB palette info from
-    a source unsigned byte array
-    to a destination unsigned byte array
-    (source and destination
-    can have different bit depths)
+### [`setnewpalfromsourcebmp`](#Python_BMP.BITMAPlib.setnewpalfromsourcebmp)
+
+```py
+def setnewpalfromsourcebmp(sourcebmp: array.array, newbmp: array.array, similaritythreshold: float) -> list:
+```
+
+Copies the RGB palette info from
+a source unsigned byte array
+to a destination unsigned byte array
+(source and destination
+can have different bit depths)
 
     Args:
         sourceBMP, newBMP  : unsigned
@@ -7392,17 +10189,21 @@
                              in a palette
                              entry be to
                              another color
-
+    
     Returns:
         byRef modified newBMP
         (unsigned byte array) and a
         list of new palette entries
         based on source bitmap
-    
 
 
-**def setRGBpal(bmp: array.array, c: int, r: int, g: int, b: int):**
->Sets the r,g,b values of color c in a bitmap
+### [`setRGBpal`](#Python_BMP.BITMAPlib.setRGBpal)
+
+```py
+def setRGBpal(bmp: array.array, c: int, r: int, g: int, b: int):
+```
+
+Sets the r,g,b values of color c in a bitmap
 
     Args:
         bmp    : unsigned byte array
@@ -7411,63 +10212,56 @@
                  for red, green and
                  blue
         c      : unsigned int color
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def showsimilarparts(inputfile1: str, inputfile2: str, diff_file: str):**
->Compares 2 files and saves the similar parts to a BMP
+### [`showsimilarparts`](#Python_BMP.BITMAPlib.showsimilarparts)
+
+```py
+def showsimilarparts(inputfile1: str, inputfile2: str, diff_file: str):
+```
+
+Compares 2 files and saves the similar parts to a BMP
 
     Args:
         inputfile1: Whole paths
         inputfile2  to existing files
-
+    
         diff_file : New file to
                     store similar parts
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def sortrecpoints(x1: int, y1: int, x2: int, y2: int):**
->Sorts the x and y values that sets a rectangular area
+### [`sortrecpoints`](#Python_BMP.primitives2D.sortrecpoints)
+
+```py
+def sortrecpoints(x1: int, y1: int, x2: int, y2: int):
+```
+
+Sorts the x and y values that sets a rectangular area
 
     Args:
         x1, x2: int x coordinates
         y1, y2: int y coordinates
-
+    
     Returns:
         sorted coordinates
         x1, y1, x2, y2
         such that
         x1 < x2 and y1 < y2
-    
 
 
-**def sphere(bmp: array.array, x: int, y: int, r: int, rgbfactors: list[float, float, float]):**
->Draws a Rendered Sphere
+### [`sphere2file`](#Python_BMP.BITMAPlib.sphere2file)
 
-    Args:
-        bmp       : unsigned byte array
-                    with bmp format
-        x, y      : center of sphere
-                    in the image
-        r         : radius of sphere
-                    in pixels
-        rgbfactors: (r,g,b) r, g and b
-                    values range from
-                    0.0 to 1.0
+```py
+def sphere2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, rgbfactors: list[float, float, float]):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def sphere2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, rgbfactors: list[float, float, float]):**
->Renders a sphere
+Renders a sphere
 
     Args:
         ExistingBMPfile: Whole path to
@@ -7480,16 +10274,43 @@
                          values
                          range from
                          0.0 to 1.0
-
+    
     Returns:
         new bitmap file
+
+
+### [`sphere`](#Python_BMP.BITMAPlib.sphere)
+
+```py
+def sphere(bmp: array.array, x: int, y: int, r: int, rgbfactors: list[float, float, float]):
+```
+
+Draws a Rendered Sphere
+
+    Args:
+        bmp       : unsigned byte array
+                    with bmp format
+        x, y      : center of sphere
+                    in the image
+        r         : radius of sphere
+                    in pixels
+        rgbfactors: (r,g,b) r, g and b
+                    values range from
+                    0.0 to 1.0
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def spherevertandsurface(vcen: list[float, float, float], r: float, deganglestep: float) -> tuple:**
->Returns a list of sparse
-        vertices and tiled surfaces
-        for a sphere
+### [`spherevertandsurface`](#Python_BMP.solids3D.spherevertandsurface)
+
+```py
+def spherevertandsurface(vcen: list[float, float, float], r: float, deganglestep: float) -> tuple:
+```
+
+Returns a list of sparse
+    vertices and tiled surfaces
+    for a sphere
 
     Args:
         vcen       : [x: float, center
@@ -7499,17 +10320,21 @@
         deganglestep: angle step between
         vertices that controls how sparse
         the list will be
-
+    
     Returns:
         list of vertices and surfaces
         for plot3Dsolid()
         see Hello_DiscoBall.py
         and Hello_Globe.py
-    
 
 
-**def spiralcontrolpointsvert(x: int, y: int, step: int, growthfactor: float, turns: int):**
->Returns a list of 2D vertices of a Square Spiral
+### [`spiralcontrolpointsvert`](#Python_BMP.primitives2D.spiralcontrolpointsvert)
+
+```py
+def spiralcontrolpointsvert(x: int, y: int, step: int, growthfactor: float, turns: int):
+```
+
+Returns a list of 2D vertices of a Square Spiral
 
     Args:
         x, y: int centerpoint
@@ -7521,19 +10346,23 @@
                       spirals
         turns: number of turns of the
                spiral
-
+    
     Returns:
         list of vertices of the spiral
         list[[x: int, y: int]]
-    
 
 
-**def spirographvert(x: int, y: int, r: int, l: float, k: float, delta: float, lim: float):**
->Returns a list(int, int) of
-    2D vertices along a path defined
-    by a spirograph with scaling factor r
-    and dimensionless parametersl and k
-    with an origin set at (x, y)
+### [`spirographvert`](#Python_BMP.primitives2D.spirographvert)
+
+```py
+def spirographvert(x: int, y: int, r: int, l: float, k: float, delta: float, lim: float):
+```
+
+Returns a list(int, int) of
+2D vertices along a path defined
+by a spirograph with scaling factor r
+and dimensionless parametersl and k
+with an origin set at (x, y)
 
     Args:
         x, y : center of the spirograph
@@ -7541,59 +10370,75 @@
         l, k : spirograph shape parameters
         delta: angle increment in radians
         lim  : angle limit in radians
-
+    
     Returns:
         The vertices of an
         spirograph in a list
         [[x: int, y: int], ...]
-    
 
 
-**def subvect(u: list[numbers.Number], v: list[numbers.Number]) -> list[numbers.Number]:**
->Subtracts vectors u and v by subtracting their components
+### [`subvect`](#Python_BMP.mathlib.subvect)
+
+```py
+def subvect(u: list[numbers.Number], v: list[numbers.Number]) -> list[numbers.Number]:
+```
+
+Subtracts vectors u and v by subtracting their components
 
     Args:
         u, v: list of ints or floats
-
+    
     Returns:
         list of ints or floats
-    
 
 
-**def surfplot3Dvertandsurface(x1: int, y1: int, x2: int, y2: int, step: int, fnxy: Callable) -> tuple:**
->Does a 3D surface plot of a
-        function z = fnxy(x, y)
+### [`surfplot3Dvertandsurface`](#Python_BMP.solids3D.surfplot3Dvertandsurface)
+
+```py
+def surfplot3Dvertandsurface(x1: int, y1: int, x2: int, y2: int, step: int, fnxy: Callable) -> tuple:
+```
+
+Does a 3D surface plot of a
+    function z = fnxy(x, y)
 
     Args:
         x1, y1, x2, y2: set drawing area
         fnxy          : fnxy(x, y)
                         Callable
                         (lambda or fn)
-
+    
     Returns:
         list of vertices and surfaces
         for plot3Dsolid()
         see Hello_3D_surfaceplot.py
-    
 
 
-**def swapcolors(bmp: array.array, p1: list, p2: list):**
->Swaps the colors of two points in a BMP
+### [`swapcolors`](#Python_BMP.BITMAPlib.swapcolors)
+
+```py
+def swapcolors(bmp: array.array, p1: list, p2: list):
+```
+
+Swaps the colors of two points in a BMP
 
     Args:
         bmp   : unsigned byte array
                 with bmp format
         p1, p2: endpoints of the
                 line(x: uint, y: uint)
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def swapif(val1: <built-in function any>, val2: <built-in function any>, boolcond: bool):**
->Swaps val1 and val2 if
-        boolcond is true
+### [`swapif`](#Python_BMP.conditionaltools.swapif)
+
+```py
+def swapif(val1: <built-in function any>, val2: <built-in function any>, boolcond: bool):
+```
+
+Swaps val1 and val2 if
+    boolcond is true
 
     Args:
         boolcond  : an expression that
@@ -7601,39 +10446,51 @@
                     True or False
         val1, val2: values to swap if
                     boolcond is True
-
+    
     Returns:
         values depending on boolcond
-    
 
 
-**def swapxy(v: list) -> list:**
->Swaps the first two values in a list
+### [`swapxy`](#Python_BMP.mathlib.swapxy)
+
+```py
+def swapxy(v: list) -> list:
+```
+
+Swaps the first two values in a list
 
     Args:
         list[x, y]
-
+    
     Returns:
         list[y, x]
-    
 
 
-**def tetrahedravert(x: float) -> list[list[float, float, float]]:**
->Returns a list of vertices
-        for a tetrahedron
+### [`tetrahedravert`](#Python_BMP.solids3D.tetrahedravert)
+
+```py
+def tetrahedravert(x: float) -> list[list[float, float, float]]:
+```
+
+Returns a list of vertices
+    for a tetrahedron
 
     Args:
         x: length of a side
-
+    
     Returns:
         list (x: float,
               y: float,
               z: float)
-    
 
 
-**def thickcircle(bmp: array.array, x: int, y: int, r: int, penradius: int, color: int):**
->Draws a Thick Circle
+### [`thickcircle`](#Python_BMP.BITMAPlib.thickcircle)
+
+```py
+def thickcircle(bmp: array.array, x: int, y: int, r: int, penradius: int, color: int):
+```
+
+Draws a Thick Circle
 
     Args:
         bmp      : unsigned byte array
@@ -7642,14 +10499,18 @@
                    and radius r
         penradius: radius of round pen
         color    : color of the circle
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def thickellipserot(bmp: array.array, x: int, y: int, b: int, a: int, degrot: float, penradius: int, color: int):**
->Draws a Thick Ellipse
+### [`thickellipserot`](#Python_BMP.BITMAPlib.thickellipserot)
+
+```py
+def thickellipserot(bmp: array.array, x: int, y: int, b: int, a: int, degrot: float, penradius: int, color: int):
+```
+
+Draws a Thick Ellipse
 
     Args:
         bmp       : unsigned byte array
@@ -7660,15 +10521,40 @@
                     the ellipse in degrees
         penradius : thickness of the pen
         color     : color of the ellipse
-
+    
     Returns:
         byref modified
         unsigned byte array
+
+
+### [`thickencirclearea2file`](#Python_BMP.BITMAPlib.thickencirclearea2file)
+
+```py
+def thickencirclearea2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, rgbfactors: list[float, float, float]):
+```
+
+"Encircle area with a gradient and save to a file
+
+    Args:
+        bmp       : unsigned byte array
+                    with bmp format
     
+        x, y      : center of circle
+        r         : radius of circle
+        rgbfactors: (r, g, b) values
+                    are from 0.0 to 1.0
+    
+    Returns:
+        new bitmap file
 
 
-**def thickencirclearea(bmp: array.array, x: int, y: int, r: int, rgbfactors: list[float, float, float]):**
->Encircle area with a gradient
+### [`thickencirclearea`](#Python_BMP.BITMAPlib.thickencirclearea)
+
+```py
+def thickencirclearea(bmp: array.array, x: int, y: int, r: int, rgbfactors: list[float, float, float]):
+```
+
+Encircle area with a gradient
 
     Args:
         bmp       : unsigned byte array
@@ -7678,31 +10564,18 @@
         rgbfactors: (r,g,b) r, g and b
                     values are 0 to 1
                     unsigned floats
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def thickencirclearea2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, rgbfactors: list[float, float, float]):**
->"Encircle area with a gradient and save to a file
+### [`thickplotpoly`](#Python_BMP.BITMAPlib.thickplotpoly)
 
-    Args:
-        bmp       : unsigned byte array
-                    with bmp format
+```py
+def thickplotpoly(bmp: array.array, vertlist: list[list[numbers.Number, numbers.Number]], penradius: int, color: int):
+```
 
-        x, y      : center of circle
-        r         : radius of circle
-        rgbfactors: (r, g, b) values
-                    are from 0.0 to 1.0
-
-    Returns:
-        new bitmap file
-
-
-
-**def thickplotpoly(bmp: array.array, vertlist: list[list[numbers.Number, numbers.Number]], penradius: int, color: int):**
->Draws a polygon of a given color and thickness
+Draws a polygon of a given color and thickness
 
     Args:
         bmp      : unsigned byte array
@@ -7711,14 +10584,18 @@
                    list of vertices
         penradius: radius of pen
         color    : color of the polygon
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def thickroundline(bmp: array.array, p1: list, p2: list, penradius: int, color: int):**
->Draw a Thick Rounded Line
+### [`thickroundline`](#Python_BMP.BITMAPlib.thickroundline)
+
+```py
+def thickroundline(bmp: array.array, p1: list, p2: list, penradius: int, color: int):
+```
+
+Draw a Thick Rounded Line
 
     Args:
         bmp       : unsigned byte array
@@ -7728,31 +10605,18 @@
         penradius : radius of pen
                     in pixels
         color     : color of the line
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def thresholdadjcircregion(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int]):**
->Threshold adjustment to a circular area
+### [`thresholdadjcircregion2file`](#Python_BMP.BITMAPlib.thresholdadjcircregion2file)
 
-    Args:
-        bmp      : unsigned byte array
-                   with bmp format
-        x, y, r  : centerpoint (x, y)
-                   and radius r
-        lumrange : (byte: byte)
-                   threshold adjustment
-                   luminosity range
+```py
+def thresholdadjcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, lumrange: list[int, int]):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def thresholdadjcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, lumrange: list[int, int]):**
->Threshold adjustment to a circular region in a 24-bit BMP
+Threshold adjustment to a circular region in a 24-bit BMP
 
     Args:
         ExistingBMPfile: Whole path to
@@ -7763,14 +10627,39 @@
                          and radius r
         lumrange       : (byte:byte)
                          threshold range
-
+    
     Returns:
         new bitmap file
+
+
+### [`thresholdadjcircregion`](#Python_BMP.BITMAPlib.thresholdadjcircregion)
+
+```py
+def thresholdadjcircregion(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int]):
+```
+
+Threshold adjustment to a circular area
+
+    Args:
+        bmp      : unsigned byte array
+                   with bmp format
+        x, y, r  : centerpoint (x, y)
+                   and radius r
+        lumrange : (byte: byte)
+                   threshold adjustment
+                   luminosity range
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def thresholdadjto24bitimage(bmp: array.array, lumrange: list[int, int]):**
->Threshold adjustment to a whole BMP
+### [`thresholdadjto24bitimage`](#Python_BMP.BITMAPlib.thresholdadjto24bitimage)
+
+```py
+def thresholdadjto24bitimage(bmp: array.array, lumrange: list[int, int]):
+```
+
+Threshold adjustment to a whole BMP
 
     Args:
         bmp     : unsigned byte array
@@ -7778,14 +10667,18 @@
         lumrange: (byte: byte)
                   threshold adjustment
                   luminosity range
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def thresholdadjto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):**
->Threshold adjustment to a rectangular area
+### [`thresholdadjto24bitregion`](#Python_BMP.BITMAPlib.thresholdadjto24bitregion)
+
+```py
+def thresholdadjto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):
+```
+
+Threshold adjustment to a rectangular area
 
     Args:
         bmp           : unsigned
@@ -7798,15 +10691,40 @@
                         threshold
                         adjustment
                         luminosity range
-
+    
     Returns:
         byref modified unsigned byte array
+
+
+### [`thresholdadjust2file`](#Python_BMP.BITMAPlib.thresholdadjust2file)
+
+```py
+def thresholdadjust2file(ExistingBMPfile: str, NewBMPfile: str, lumrange: list[int, int]):
+```
+
+Apply a threshold adjustment
+
+    Args:
+        ExistingBMPfile: Whole path to
+                         existing file
+        NewBMPfile     : New file to
+                         save changes in
+        lumrange       : (byte:byte)
+                         threshold
+                         to apply
     
+    Returns:
+        new bitmap file
 
 
-**def thresholdadjust(rgb: list[int, int, int], lumrange: list[int, int]) -> list[int, int, int]:**
->Apply a threshold adjustment
-        to a rgb
+### [`thresholdadjust`](#Python_BMP.colors.thresholdadjust)
+
+```py
+def thresholdadjust(rgb: list[int, int, int], lumrange: list[int, int]) -> list[int, int, int]:
+```
+
+Apply a threshold adjustment
+    to a rgb
 
     Args:
         rgb: color as [r: byte,
@@ -7818,73 +10736,72 @@
                   threshold
                   adjustment
                   limits
-
+    
     Returns:
         a brightness threshold adjusted
         color as [r: byte,
                   g: byte,
                   b: byte]
-    
 
 
-**def thresholdadjust2file(ExistingBMPfile: str, NewBMPfile: str, lumrange: list[int, int]):**
->Apply a threshold adjustment
+### [`trans`](#Python_BMP.mathlib.trans)
 
-    Args:
-        ExistingBMPfile: Whole path to
-                         existing file
-        NewBMPfile     : New file to
-                         save changes in
-        lumrange       : (byte:byte)
-                         threshold
-                         to apply
+```py
+def trans(vlist: list[list[numbers.Number]], u: list[numbers.Number]) -> list[list[numbers.Number]]:
+```
 
-    Returns:
-        new bitmap file
-    
-
-
-**def trans(vlist: list[list[numbers.Number]], u: list[numbers.Number]) -> list[list[numbers.Number]]:**
->Translates list of vectors by adding vector u
-    to all vectors in the list of vectors
+Translates list of vectors by adding vector u
+to all vectors in the list of vectors
 
     Args:
         vlist: list of vectors
         u    : translation vector
-
+    
     Returns:
         list of vectors
-    
 
 
-**def upgradeto24bitimage(bmp: array.array):**
->Upgrade an image to 24-bits
+### [`upgradeto24bitimage2file`](#Python_BMP.BITMAPlib.upgradeto24bitimage2file)
 
-    Args:
-        bmp: unsigned byte array
-             with bmp format
+```py
+def upgradeto24bitimage2file(ExistingBMPfile: str, NewBMPfile: str):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def upgradeto24bitimage2file(ExistingBMPfile: str, NewBMPfile: str):**
->Upgrades a bitmap file to 24-bits
+Upgrades a bitmap file to 24-bits
 
     Args:
         ExistingBMPfile: Whole path to
                          existing file
         NewBMPfile     : New file to
                          save changes in
-
+    
     Returns:
         new bitmap file
+
+
+### [`upgradeto24bitimage`](#Python_BMP.BITMAPlib.upgradeto24bitimage)
+
+```py
+def upgradeto24bitimage(bmp: array.array):
+```
+
+Upgrade an image to 24-bits
+
+    Args:
+        bmp: unsigned byte array
+             with bmp format
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def userdef2Dcooordsys2screenxy(x: int, y: int, lstcooordinfo: list):**
->2D coordinate trans from user to screen
+### [`userdef2Dcooordsys2screenxy`](#Python_BMP.BITMAPlib.userdef2Dcooordsys2screenxy)
+
+```py
+def userdef2Dcooordsys2screenxy(x: int, y: int, lstcooordinfo: list):
+```
+
+2D coordinate trans from user to screen
 
     Args:
         x, y         : user coordinates
@@ -7900,47 +10817,36 @@
                         all
                         (x: int,
                          y: int) pairs
-
+    
     Returns:
         [x: int, y: int] screen coordinates
 
-    
 
+### [`vertBMPbitBLTget`](#Python_BMP.BITMAPlib.vertBMPbitBLTget)
 
-**def vertBMPbitBLTget(bmp: array.array, x: int, y1: int, y2: int) -> array.array:**
->Gets vertical slice to a new array
+```py
+def vertBMPbitBLTget(bmp: array.array, x: int, y1: int, y2: int) -> array.array:
+```
+
+Gets vertical slice to a new array
 
     Args:
         bmp   : unsigned byte array
                 with bmp format
         x     : unsigned int x
         y1, y2  and y coordinates
-
+    
     Returns:
         unsigned byte array
-    
 
 
-**def vertbrightnessgrad2circregion(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int]):**
->Vertical brightness gradient adjustment to a circular area
+### [`vertbrightnessgrad2circregion2file`](#Python_BMP.BITMAPlib.vertbrightnessgrad2circregion2file)
 
-    Args:
-        bmp     : unsigned byte array
-                  with bmp format
-        x, y, r : center (x,y)
-                  and radius r
-        lumrange: [byte,byte]
-                  that define
-                  the range of
-                  luminosity
+```py
+def vertbrightnessgrad2circregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, lumrange: list[int, int]):
+```
 
-    Returns:
-        byref modified unsigned byte array
-    
-
-
-**def vertbrightnessgrad2circregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, lumrange: list[int, int]):**
->Vertical brightness gradient to a circular area
+Vertical brightness gradient to a circular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -7955,14 +10861,40 @@
                          gradient
                          (byte: byte)
                          adjust
-
+    
     Returns:
         new bitmap file
+
+
+### [`vertbrightnessgrad2circregion`](#Python_BMP.BITMAPlib.vertbrightnessgrad2circregion)
+
+```py
+def vertbrightnessgrad2circregion(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int]):
+```
+
+Vertical brightness gradient adjustment to a circular area
+
+    Args:
+        bmp     : unsigned byte array
+                  with bmp format
+        x, y, r : center (x,y)
+                  and radius r
+        lumrange: [byte,byte]
+                  that define
+                  the range of
+                  luminosity
     
+    Returns:
+        byref modified unsigned byte array
 
 
-**def verticalbrightnessgrad2file(ExistingBMPfile: str, NewBMPfile: str, lumrange: list[int, int]):**
->Applies a Vertical brightness gradient
+### [`verticalbrightnessgrad2file`](#Python_BMP.BITMAPlib.verticalbrightnessgrad2file)
+
+```py
+def verticalbrightnessgrad2file(ExistingBMPfile: str, NewBMPfile: str, lumrange: list[int, int]):
+```
+
+Applies a Vertical brightness gradient
 
     Args:
         ExistingBMPfile: Whole path to
@@ -7973,14 +10905,18 @@
                          defines the
                          brightness
                          gradient
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def verticalbrightnessgradregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):**
->Vertical brightness gradient to a rectangular area
+### [`verticalbrightnessgradregion2file`](#Python_BMP.BITMAPlib.verticalbrightnessgradregion2file)
+
+```py
+def verticalbrightnessgradregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):
+```
+
+Vertical brightness gradient to a rectangular area
 
     Args:
         ExistingBMPfile: Whole path to
@@ -7994,29 +10930,37 @@
                          defines the
                          brightness
                          gradient
-
+    
     Returns:
         new bitmap file
-    
 
 
-**def verticalbrightnessgradto24bitimage(bmp: array.array, lumrange: list[int, int]):**
->Applies a vertical brightness gradient
+### [`verticalbrightnessgradto24bitimage`](#Python_BMP.BITMAPlib.verticalbrightnessgradto24bitimage)
+
+```py
+def verticalbrightnessgradto24bitimage(bmp: array.array, lumrange: list[int, int]):
+```
+
+Applies a vertical brightness gradient
 
     Args:
         bmp     : unsigned byte array
                   with bmp format
         lumrange: (byte: byte) the
                   brightness gradient
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def verticalbrightnessgradto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):**
->Apply a vertical brightness gradient
-    to a rectangular area in a 24-bit bitmap
+### [`verticalbrightnessgradto24bitregion`](#Python_BMP.BITMAPlib.verticalbrightnessgradto24bitregion)
+
+```py
+def verticalbrightnessgradto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):
+```
+
+Apply a vertical brightness gradient
+to a rectangular area in a 24-bit bitmap
 
     Args:
         bmp          :  unsigned
@@ -8028,30 +10972,38 @@
         lumrange      : (byte:byte)
                         brightness
                         gradient
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def verticalvert(x: int, y1: int, y2: int, dy: int) -> list[list[int, int]]:**
->Creates a list of int vertices
-    along a vertical line with int step dy
+### [`verticalvert`](#Python_BMP.primitives2D.verticalvert)
+
+```py
+def verticalvert(x: int, y1: int, y2: int, dy: int) -> list[list[int, int]]:
+```
+
+Creates a list of int vertices
+along a vertical line with int step dy
 
     Args:
         x : int constant x
         y1: int start point
         y2: int end point
         dy: int y step increment
-
+    
     Returns:
         list of int vertices
         [(x, y), ...]
-    
 
 
-**def vertline(bmp: array.array, x: int, y1: int, y2: int, color: int):**
->Draw a Vertical Line
+### [`vertline`](#Python_BMP.BITMAPlib.vertline)
+
+```py
+def vertline(bmp: array.array, x: int, y1: int, y2: int, color: int):
+```
+
+Draw a Vertical Line
 
     Args:
         bmp  : unsigned byte array
@@ -8061,14 +11013,18 @@
         y1   : starts at y1
         y2   : ends at y2
         color: color of the line
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def vertlinevert(bmp: array.array, vlist: list[list[int, int]], linelen: int, yadj: int, color: int):**
->Vertical line marks at vertices in vlist
+### [`vertlinevert`](#Python_BMP.BITMAPlib.vertlinevert)
+
+```py
+def vertlinevert(bmp: array.array, vlist: list[list[int, int]], linelen: int, yadj: int, color: int):
+```
+
+Vertical line marks at vertices in vlist
 
     Args:
         bmp    : unsigned byte array
@@ -8080,14 +11036,18 @@
         yadj   : sets an adjustment
                  for y coordinates
         color  : color of the line
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def verttrans(bmp: array.array, trans: str):**
->Do vertical image transforms
+### [`verttrans`](#Python_BMP.BITMAPlib.verttrans)
+
+```py
+def verttrans(bmp: array.array, trans: str):
+```
+
+Do vertical image transforms
 
     Args:
         bmp : unsigned byte array
@@ -8097,17 +11057,21 @@
               'T' - mirror top-half
               'B' - mirror bottom-half
               'F' - flip
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def verttransformincircregion(bmp: array.array, x: int, y: int, r: int, trans: str):**
->Applies a vertical transform to
-    a circular region with a center
-    at (x, y) and radius r
+### [`verttransformincircregion`](#Python_BMP.BITMAPlib.verttransformincircregion)
+
+```py
+def verttransformincircregion(bmp: array.array, x: int, y: int, r: int, trans: str):
+```
+
+Applies a vertical transform to
+a circular region with a center
+at (x, y) and radius r
 
     Args:
         bmp    : unsigned byte array
@@ -8120,15 +11084,19 @@
                 'T' mirror top
                 'B' mirror bottom
                 'F' flip
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def verttransregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, trans: str):**
->Do vertical image transforms
-        in a rectangular region
+### [`verttransregion`](#Python_BMP.BITMAPlib.verttransregion)
+
+```py
+def verttransregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, trans: str):
+```
+
+Do vertical image transforms
+    in a rectangular region
 
     Args:
         bmp            : unsigned
@@ -8143,28 +11111,36 @@
                 'T' - mirror top half
                 'B' - mirror bottom half
                 'F' - flip
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def vmag(v: list[float]) -> float:**
->Compute the Magnitude or length of a vector v
-    of arbitrary dimension n equal to len(v)
+### [`vmag`](#Python_BMP.mathlib.vmag)
+
+```py
+def vmag(v: list[float]) -> float:
+```
+
+Compute the Magnitude or length of a vector v
+of arbitrary dimension n equal to len(v)
 
     Args:
         v: list of ints or floats
-
+    
     Returns:
         float
-    
 
 
-**def writeint(offset: int, cnt: int, arr: array.array, value: int):**
->Writes an integer value to an
-        unsigned byte array
+### [`writeint`](#Python_BMP.inttools.writeint)
+
+```py
+def writeint(offset: int, cnt: int, arr: array.array, value: int):
+```
+
+Writes an integer value to an
+    unsigned byte array
 
     Args:
         offset: uint starting offset in
@@ -8177,27 +11153,35 @@
         value : value of uint data to
                 write in buffer or
                 array
-
+    
     Returns:
         byref unsigned byte array
-    
 
 
-**def xorvect(u: list[int], v: list[int]) -> list[int]:**
->Applies a xor operation of between the elements of
-    two lists of ints
+### [`xorvect`](#Python_BMP.mathlib.xorvect)
+
+```py
+def xorvect(u: list[int], v: list[int]) -> list[int]:
+```
+
+Applies a xor operation of between the elements of
+two lists of ints
 
     Args:
         v      : list[int]
         bitmask: int
-
+    
     Returns:
         list[int]
-    
 
 
-**def XYaxis(bmp: array.array, origin: list[int, int], steps: list[int, int], xylimits: list[int, int], xyvalstarts: list[numbers.Number, numbers.Number], xysteps: list[numbers.Number, numbers.Number], color: int, textcolor: int, showgrid: bool, gridcolor: int):**
->XY axis with tick marks and numbers
+### [`XYaxis`](#Python_BMP.BITMAPlib.XYaxis)
+
+```py
+def XYaxis(bmp: array.array, origin: list[int, int], steps: list[int, int], xylimits: list[int, int], xyvalstarts: list[numbers.Number, numbers.Number], xysteps: list[numbers.Number, numbers.Number], color: int, textcolor: int, showgrid: bool, gridcolor: int):
+```
+
+XY axis with tick marks and numbers
 
     Args:
         bmp      : unsigned byte array
@@ -8224,15 +11208,19 @@
                            gridline
                    False -> no grid
         gridcolor: color of the grid
-
+    
     Returns:
         byref modified
         unsigned byte array
-    
 
 
-**def xygrid(bmp: array.array, x1: int, y1: int, x2: int, y2: int, xysteps: list[int, int], color: int):**
->Draws a grid
+### [`xygrid`](#Python_BMP.BITMAPlib.xygrid)
+
+```py
+def xygrid(bmp: array.array, x1: int, y1: int, x2: int, y2: int, xysteps: list[int, int], color: int):
+```
+
+Draws a grid
 
     Args:
         bmp           : unsigned
@@ -8244,14 +11232,18 @@
                         increments
         color         : sets the color
                         of the grid
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def xygridvec(bmp: array.array, u: list[int, int], v: list[int, int], steps: list[int, int], gridcolor: int):**
->Grid using (x, y) point pairs u and v
+### [`xygridvec`](#Python_BMP.BITMAPlib.xygridvec)
+
+```py
+def xygridvec(bmp: array.array, u: list[int, int], v: list[int, int], steps: list[int, int], gridcolor: int):
+```
+
+Grid using (x, y) point pairs u and v
 
     Args:
         bmp  : unsigned byte array
@@ -8262,14 +11254,18 @@
                increments for x and y
         color: sets the color
                of the grid
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 
-**def XYscatterplot(bmp: array.array, XYdata: list, XYcoordinfo: list, showLinearRegLine: bool, reglinecolor: int):**
->Create a XY scatterplot
+### [`XYscatterplot`](#Python_BMP.BITMAPlib.XYscatterplot)
+
+```py
+def XYscatterplot(bmp: array.array, XYdata: list, XYcoordinfo: list, showLinearRegLine: bool, reglinecolor: int):
+```
+
+Create a XY scatterplot
 
     Args:
         bmp             : unsigned
@@ -8302,9 +11298,8 @@
                                   regression line
         reglinecolor    : color of linear
                           regression line
-
+    
     Returns:
         byref modified unsigned byte array
-    
 
 

--- a/docs/BitmapLib_Doc.md
+++ b/docs/BitmapLib_Doc.md
@@ -1,6 +1,6 @@
 # Python BMP Public API
 
-### [`_1bmof`](#Python_BMP.BITMAPlib._1bmof)
+### [`_1bmof`](#_1bmof)
 
 ```py
 def _1bmof(bmp: array.array, x: int, y: int) -> int:
@@ -20,7 +20,7 @@ with 1 bit color data given x and y data
         int value of offset to that data in byte array
 
 
-### [`_1bmofhd`](#Python_BMP.BITMAPlib._1bmofhd)
+### [`_1bmofhd`](#_1bmofhd)
 
 ```py
 def _1bmofhd(bmp: array.array, x: int, y: int) -> int:
@@ -42,7 +42,7 @@ Get the offset in a byte array
         int value of offset to that data in byte array
 
 
-### [`_24bmof`](#Python_BMP.BITMAPlib._24bmof)
+### [`_24bmof`](#_24bmof)
 
 ```py
 def _24bmof(bmp: array.array, x: int, y: int) -> int:
@@ -61,7 +61,7 @@ Get the offset in a byte array with RGB data given x and y
         int value of offset to that data in byte array
 
 
-### [`_24bmofhd`](#Python_BMP.BITMAPlib._24bmofhd)
+### [`_24bmofhd`](#_24bmofhd)
 
 ```py
 def _24bmofhd(bmp: array.array, x: int, y: int) -> int:
@@ -81,7 +81,7 @@ with RGB data given x and y with bmp header
         int value of offset to that data in byte array
 
 
-### [`_4bmof`](#Python_BMP.BITMAPlib._4bmof)
+### [`_4bmof`](#_4bmof)
 
 ```py
 def _4bmof(bmp: array.array, x: int, y: int) -> int:
@@ -101,7 +101,7 @@ with 4 bit color data given x and y data
         int value of offset to that data in byte array
 
 
-### [`_4bmofhd`](#Python_BMP.BITMAPlib._4bmofhd)
+### [`_4bmofhd`](#_4bmofhd)
 
 ```py
 def _4bmofhd(bmp: array.array, x: int, y: int) -> int:
@@ -123,7 +123,7 @@ made due to a header
         int value of offset to that data in byte array
 
 
-### [`_8bmof`](#Python_BMP.BITMAPlib._8bmof)
+### [`_8bmof`](#_8bmof)
 
 ```py
 def _8bmof(bmp: array.array, x: int, y: int) -> int:
@@ -144,7 +144,7 @@ with 8 bit color data given x and y data
         that data in byte array
 
 
-### [`_8bmofhd`](#Python_BMP.BITMAPlib._8bmofhd)
+### [`_8bmofhd`](#_8bmofhd)
 
 ```py
 def _8bmofhd(bmp: array.array, x: int, y: int) -> int:
@@ -167,7 +167,7 @@ made for a bmp header
         that data in byte array
 
 
-### [`_bmmeta`](#Python_BMP.BITMAPlib._bmmeta)
+### [`_bmmeta`](#_bmmeta)
 
 ```py
 def _bmmeta(x: int, y: int, bits: int) -> tuple:
@@ -187,7 +187,7 @@ Computes bitmap meta data
         xdim, ydim, bitdepth)
 
 
-### [`_BMoffset`](#Python_BMP.BITMAPlib._BMoffset)
+### [`_BMoffset`](#_BMoffset)
 
 ```py
 def _BMoffset(bmp: array.array, x: int, y: int) -> int:
@@ -205,7 +205,7 @@ Returns the offset given a bmp and (x, y) coordinates
         unsigned int offset to data in buffer
 
 
-### [`_BMoffsethd`](#Python_BMP.BITMAPlib._BMoffsethd)
+### [`_BMoffsethd`](#_BMoffsethd)
 
 ```py
 def _BMoffsethd(bmp: array.array, x: int, y: int) -> int:
@@ -224,7 +224,7 @@ and (x, y) coordinates with header considered
         unsigned int offset to data in buffer
 
 
-### [`_cmpimglines`](#Python_BMP.BITMAPlib._cmpimglines)
+### [`_cmpimglines`](#_cmpimglines)
 
 ```py
 def _cmpimglines(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Callable):
@@ -235,7 +235,7 @@ def _cmpimglines(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Cal
     
 
 
-### [`_flsz`](#Python_BMP.BITMAPlib._flsz)
+### [`_flsz`](#_flsz)
 
 ```py
 def _flsz(bmp: array.array) -> int:
@@ -253,7 +253,7 @@ Get the file size of a win bmp
         of the bmp header
 
 
-### [`_fnwithpar2vertslice`](#Python_BMP.BITMAPlib._fnwithpar2vertslice)
+### [`_fnwithpar2vertslice`](#_fnwithpar2vertslice)
 
 ```py
 def _fnwithpar2vertslice(bmp: array.array, x: int, y1: int, y2: int, func: Callable, funcparam):
@@ -275,7 +275,7 @@ Apply a user defined function to vertical slices
         byref modified unsigned byte array
 
 
-### [`_getbmflsz`](#Python_BMP.BITMAPlib._getbmflsz)
+### [`_getbmflsz`](#_getbmflsz)
 
 ```py
 def _getbmflsz(x: int, y: int, bits: int) -> int:
@@ -292,7 +292,7 @@ Computes bitmap file size
         int value of file size
 
 
-### [`_getBMofffunc`](#Python_BMP.BITMAPlib._getBMofffunc)
+### [`_getBMofffunc`](#_getBMofffunc)
 
 ```py
 def _getBMofffunc(bmp: array.array):
@@ -310,7 +310,7 @@ in a given bitmap
         function to compute offsets
 
 
-### [`_getBMoffhdfunc`](#Python_BMP.BITMAPlib._getBMoffhdfunc)
+### [`_getBMoffhdfunc`](#_getBMoffhdfunc)
 
 ```py
 def _getBMoffhdfunc(bmp: array.array):
@@ -328,7 +328,7 @@ with headers in a given bmp
         function to compute offsets with headers
 
 
-### [`_getclrbits`](#Python_BMP.BITMAPlib._getclrbits)
+### [`_getclrbits`](#_getclrbits)
 
 ```py
 def _getclrbits(bmp: array.array) -> int:
@@ -345,7 +345,7 @@ Get the bit depth of BMP
         (1, 4, 8, 24) bits
 
 
-### [`_hdsz`](#Python_BMP.BITMAPlib._hdsz)
+### [`_hdsz`](#_hdsz)
 
 ```py
 def _hdsz(bmp: array.array) -> int:
@@ -361,7 +361,7 @@ Get the header size of a BMP
         int value of header size
 
 
-### [`_pdbytes`](#Python_BMP.BITMAPlib._pdbytes)
+### [`_pdbytes`](#_pdbytes)
 
 ```py
 def _pdbytes(x: int, bits: int) -> int:
@@ -380,7 +380,7 @@ Get the number of bytes used to pad for
         int value of number of pad bytes
 
 
-### [`_setflsz`](#Python_BMP.BITMAPlib._setflsz)
+### [`_setflsz`](#_setflsz)
 
 ```py
 def _setflsz(bmp: array.array, size: int):
@@ -400,7 +400,7 @@ Set the file size of a BMP
         with new file size
 
 
-### [`_sethdsz`](#Python_BMP.BITMAPlib._sethdsz)
+### [`_sethdsz`](#_sethdsz)
 
 ```py
 def _sethdsz(bmp: array.array, hdsize: int):
@@ -420,7 +420,7 @@ Set the header size of a win bmp
         with new header size
 
 
-### [`_setmeta`](#Python_BMP.BITMAPlib._setmeta)
+### [`_setmeta`](#_setmeta)
 
 ```py
 def _setmeta(bmpmeta: list) -> array.array:
@@ -439,7 +439,7 @@ Creates a new bitmap
         unsigned byte array with bmp format
 
 
-### [`_setx`](#Python_BMP.BITMAPlib._setx)
+### [`_setx`](#_setx)
 
 ```py
 def _setx(bmp: array.array, xmax: int):
@@ -456,7 +456,7 @@ Sets the x value stored in the windows bmp header
         byref modified unsigned byte array
 
 
-### [`_sety`](#Python_BMP.BITMAPlib._sety)
+### [`_sety`](#_sety)
 
 ```py
 def _sety(bmp: array.array, ymax: int):
@@ -473,7 +473,7 @@ Sets the y value stored in the windows bmp header
         byref modified unsigned byte array
 
 
-### [`_use24bitfn2reg`](#Python_BMP.BITMAPlib._use24bitfn2reg)
+### [`_use24bitfn2reg`](#_use24bitfn2reg)
 
 ```py
 def _use24bitfn2reg(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Callable, funcparam):
@@ -497,7 +497,7 @@ in a 24-bit bitmap
         byref modified unsigned byte array
 
 
-### [`_use24btbyrefclrfn2regnsv`](#Python_BMP.BITMAPlib._use24btbyrefclrfn2regnsv)
+### [`_use24btbyrefclrfn2regnsv`](#_use24btbyrefclrfn2regnsv)
 
 ```py
 def _use24btbyrefclrfn2regnsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable, funcparam):
@@ -523,7 +523,7 @@ to a rectangular area and save
         new bitmap file
 
 
-### [`_use24btclrfn`](#Python_BMP.BITMAPlib._use24btclrfn)
+### [`_use24btclrfn`](#_use24btclrfn)
 
 ```py
 def _use24btclrfn(ExistingBMPfile: str, NewBMPfile: str, func: Callable, funcparam):
@@ -547,7 +547,7 @@ to a 24-bit bitmap
         new bitmap file
 
 
-### [`_use24btclrfntocircregion`](#Python_BMP.BITMAPlib._use24btclrfntocircregion)
+### [`_use24btclrfntocircregion`](#_use24btclrfntocircregion)
 
 ```py
 def _use24btclrfntocircregion(ExistingBMPfile: str, NewBMPfile: str, func: Callable, x: int, y: int, r: int):
@@ -570,7 +570,7 @@ to a circular area (24-bit only)
         new bitmap file
 
 
-### [`_use24btclrfnwithpar2circreg`](#Python_BMP.BITMAPlib._use24btclrfnwithpar2circreg)
+### [`_use24btclrfnwithpar2circreg`](#_use24btclrfnwithpar2circreg)
 
 ```py
 def _use24btclrfnwithpar2circreg(ExistingBMPfile: str, NewBMPfile: str, func: Callable, x: int, y: int, r: int, funcparam):
@@ -595,7 +595,7 @@ to a circular area (24-bit only)
         new bitmap file
 
 
-### [`_use24btfn2circreg`](#Python_BMP.BITMAPlib._use24btfn2circreg)
+### [`_use24btfn2circreg`](#_use24btfn2circreg)
 
 ```py
 def _use24btfn2circreg(bmp: array.array, x: int, y: int, r: int, func: Callable, funcparam):
@@ -621,7 +621,7 @@ within a 24-bit bitmap
         unsigned byte array
 
 
-### [`_use24btfnwithparnsv`](#Python_BMP.BITMAPlib._use24btfnwithparnsv)
+### [`_use24btfnwithparnsv`](#_use24btfnwithparnsv)
 
 ```py
 def _use24btfnwithparnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable, funcparam):
@@ -643,7 +643,7 @@ Apply a 24-bit only function with parameters and save
         new bitmap file
 
 
-### [`_usebyref24btfn2reg`](#Python_BMP.BITMAPlib._usebyref24btfn2reg)
+### [`_usebyref24btfn2reg`](#_usebyref24btfn2reg)
 
 ```py
 def _usebyref24btfn2reg(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Callable, funcparam):
@@ -667,7 +667,7 @@ in a 24-bit bitmap
         byref modified unsigned byte array
 
 
-### [`_usebyref24btfn2regnsv`](#Python_BMP.BITMAPlib._usebyref24btfn2regnsv)
+### [`_usebyref24btfn2regnsv`](#_usebyref24btfn2regnsv)
 
 ```py
 def _usebyref24btfn2regnsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable):
@@ -692,7 +692,7 @@ rectangular area and save
         new bitmap file
 
 
-### [`_usebyreffn2regnsv`](#Python_BMP.BITMAPlib._usebyreffn2regnsv)
+### [`_usebyreffn2regnsv`](#_usebyreffn2regnsv)
 
 ```py
 def _usebyreffn2regnsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable):
@@ -717,7 +717,7 @@ rectangular region and save
         new bitmap file
 
 
-### [`_usebyreffnsv`](#Python_BMP.BITMAPlib._usebyreffnsv)
+### [`_usebyreffnsv`](#_usebyreffnsv)
 
 ```py
 def _usebyreffnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable):
@@ -737,7 +737,7 @@ Apply a by-ref function with no parameters and save
         new bitmap file
 
 
-### [`_usebyreffnwithpar2regnsv`](#Python_BMP.BITMAPlib._usebyreffnwithpar2regnsv)
+### [`_usebyreffnwithpar2regnsv`](#_usebyreffnwithpar2regnsv)
 
 ```py
 def _usebyreffnwithpar2regnsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable, funcparam):
@@ -762,7 +762,7 @@ to a rectangular area and save
         new bitmap file
 
 
-### [`_usebyreffnwithparnsv`](#Python_BMP.BITMAPlib._usebyreffnwithparnsv)
+### [`_usebyreffnwithparnsv`](#_usebyreffnwithparnsv)
 
 ```py
 def _usebyreffnwithparnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable, funcparam):
@@ -773,7 +773,7 @@ def _usebyreffnwithparnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable,
     
 
 
-### [`_usebyrefnopar24bitfn2reg`](#Python_BMP.BITMAPlib._usebyrefnopar24bitfn2reg)
+### [`_usebyrefnopar24bitfn2reg`](#_usebyrefnopar24bitfn2reg)
 
 ```py
 def _usebyrefnopar24bitfn2reg(bmp: array.array, x1: int, y1: int, x2: int, y2: int, func: Callable):
@@ -794,7 +794,7 @@ Apply a func to a rectangular area in a 24-bit bitmap
         byref modified unsigned byte array
 
 
-### [`_useclradjfn`](#Python_BMP.BITMAPlib._useclradjfn)
+### [`_useclradjfn`](#_useclradjfn)
 
 ```py
 def _useclradjfn(ExistingBMPfile: str, NewBMPfile: str, func: Callable, funcparam):
@@ -817,7 +817,7 @@ to an existing bitmap
         new bitmap file
 
 
-### [`_usefn2circreg`](#Python_BMP.BITMAPlib._usefn2circreg)
+### [`_usefn2circreg`](#_usefn2circreg)
 
 ```py
 def _usefn2circreg(ExistingBMPfile: str, NewBMPfile: str, func: Callable, x: int, y: int, r: int):
@@ -840,7 +840,7 @@ to a circular area
         new bitmap file
 
 
-### [`_usefn2regsv`](#Python_BMP.BITMAPlib._usefn2regsv)
+### [`_usefn2regsv`](#_usefn2regsv)
 
 ```py
 def _usefn2regsv(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, func: Callable):
@@ -864,7 +864,7 @@ rectangular area and save
         new bitmap file
 
 
-### [`_usefnsv`](#Python_BMP.BITMAPlib._usefnsv)
+### [`_usefnsv`](#_usefnsv)
 
 ```py
 def _usefnsv(ExistingBMPfile: str, NewBMPfile: str, func: Callable):
@@ -884,7 +884,7 @@ Apply a function with no parameters and save
         new bitmap file
 
 
-### [`_usefnwithpar2circreg`](#Python_BMP.BITMAPlib._usefnwithpar2circreg)
+### [`_usefnwithpar2circreg`](#_usefnwithpar2circreg)
 
 ```py
 def _usefnwithpar2circreg(ExistingBMPfile: str, NewBMPfile: str, func: Callable, x: int, y: int, r: int, funcparam):
@@ -909,7 +909,7 @@ to a circular area
         new bitmap file
 
 
-### [`_usenopar24btfn2circreg`](#Python_BMP.BITMAPlib._usenopar24btfn2circreg)
+### [`_usenopar24btfn2circreg`](#_usenopar24btfn2circreg)
 
 ```py
 def _usenopar24btfn2circreg(bmp: array.array, x: int, y: int, r: int, func: Callable):
@@ -932,7 +932,7 @@ in a 24-bit bitmap
         byref modified unsigned byte array
 
 
-### [`_usenoparclradjfn`](#Python_BMP.BITMAPlib._usenoparclradjfn)
+### [`_usenoparclradjfn`](#_usenoparclradjfn)
 
 ```py
 def _usenoparclradjfn(ExistingBMPfile: str, NewBMPfile: str, func: Callable):
@@ -953,7 +953,7 @@ Apply a user provided no parameter color
         new bitmap file
 
 
-### [`_usenoparfn2circreg`](#Python_BMP.BITMAPlib._usenoparfn2circreg)
+### [`_usenoparfn2circreg`](#_usenoparfn2circreg)
 
 ```py
 def _usenoparfn2circreg(bmp: array.array, x: int, y: int, r: int, func: Callable):
@@ -978,7 +978,7 @@ center at (x,y) and a radius r
         byref modified unsigned byte array
 
 
-### [`_xbytes`](#Python_BMP.BITMAPlib._xbytes)
+### [`_xbytes`](#_xbytes)
 
 ```py
 def _xbytes(x: int, bits: int) -> int:
@@ -997,7 +997,7 @@ a bmp row given x dimension and bit depth
         int value of number of bytes in a row
 
 
-### [`_xchrcnt`](#Python_BMP.BITMAPlib._xchrcnt)
+### [`_xchrcnt`](#_xchrcnt)
 
 ```py
 def _xchrcnt(bmp: array.array) -> int:
@@ -1014,7 +1014,7 @@ Get the chars or bytes in row of a BMP
         chars in a row (x dim)
 
 
-### [`addvect`](#Python_BMP.mathlib.addvect)
+### [`addvect`](#addvect)
 
 ```py
 def addvect(u: list[numbers.Number], v: list[numbers.Number]) -> list[numbers.Number]:
@@ -1029,7 +1029,7 @@ Add vectors u and v by adding their components
         list of ints or floats
 
 
-### [`addvectinlist`](#Python_BMP.mathlib.addvectinlist)
+### [`addvectinlist`](#addvectinlist)
 
 ```py
 def addvectinlist(vlist: list[list[numbers.Number]]) -> numbers.Number:
@@ -1044,7 +1044,7 @@ Gets the sum of the vectors in a list of vectors
         list or vector
 
 
-### [`adjustbrightness2file`](#Python_BMP.BITMAPlib.adjustbrightness2file)
+### [`adjustbrightness2file`](#adjustbrightness2file)
 
 ```py
 def adjustbrightness2file(ExistingBMPfile: str, NewBMPfile: str, percentadj: float):
@@ -1066,7 +1066,7 @@ Apply a brightness adjustment to the image in a BMP
         new bitmap file
 
 
-### [`adjustbrightnessinregion2file`](#Python_BMP.BITMAPlib.adjustbrightnessinregion2file)
+### [`adjustbrightnessinregion2file`](#adjustbrightnessinregion2file)
 
 ```py
 def adjustbrightnessinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, percentadj: float):
@@ -1092,7 +1092,7 @@ Brightness adjustment to rectangular area in a 24-bit BMP
         new bitmap file
 
 
-### [`adjustcolordicttopal`](#Python_BMP.BITMAPlib.adjustcolordicttopal)
+### [`adjustcolordicttopal`](#adjustcolordicttopal)
 
 ```py
 def adjustcolordicttopal(bmp: array.array, colordict: dict):
@@ -1110,7 +1110,7 @@ as closely as possible a bitmap palette
         byref modified dictionary of colors
 
 
-### [`adjustthresholdinregion2file`](#Python_BMP.BITMAPlib.adjustthresholdinregion2file)
+### [`adjustthresholdinregion2file`](#adjustthresholdinregion2file)
 
 ```py
 def adjustthresholdinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, lumrange: list):
@@ -1134,7 +1134,7 @@ Threshold adjust in a rectangular area in a 24-bit BMP
         new bitmap file
 
 
-### [`adjustxbufsize`](#Python_BMP.bufresize.adjustxbufsize)
+### [`adjustxbufsize`](#adjustxbufsize)
 
 ```py
 def adjustxbufsize(bmp: array.array, x1: int, x2: int) -> int:
@@ -1158,7 +1158,7 @@ Returns a 32 -bit padded
         int adjusted buffer size
 
 
-### [`andvect`](#Python_BMP.mathlib.andvect)
+### [`andvect`](#andvect)
 
 ```py
 def andvect(u: list[int], v: list[int]) -> list[int]:
@@ -1175,7 +1175,7 @@ the elements of two lists of ints
         list[int]
 
 
-### [`anglebetween2Dlines`](#Python_BMP.mathlib.anglebetween2Dlines)
+### [`anglebetween2Dlines`](#anglebetween2Dlines)
 
 ```py
 def anglebetween2Dlines(u: list[numbers.Number, numbers.Number], v: list[numbers.Number, numbers.Number]) -> float:
@@ -1190,7 +1190,7 @@ Compute the angle between two lines of vectors
         float angle in radians
 
 
-### [`applybrightnessadjtoBGRbuf`](#Python_BMP.colors.applybrightnessadjtoBGRbuf)
+### [`applybrightnessadjtoBGRbuf`](#applybrightnessadjtoBGRbuf)
 
 ```py
 def applybrightnessadjtoBGRbuf(buf: array.array, percentadj: float) -> array.array:
@@ -1214,7 +1214,7 @@ Apply a brightness adjustment
         BGR data
 
 
-### [`applycolorfiltertoBGRbuf`](#Python_BMP.colors.applycolorfiltertoBGRbuf)
+### [`applycolorfiltertoBGRbuf`](#applycolorfiltertoBGRbuf)
 
 ```py
 def applycolorfiltertoBGRbuf(buf: array.array, rgbfactors: list[float, float, float]):
@@ -1237,7 +1237,7 @@ Apply a color filter to a
         holding color BGR data
 
 
-### [`applygammaBGRbuf`](#Python_BMP.colors.applygammaBGRbuf)
+### [`applygammaBGRbuf`](#applygammaBGRbuf)
 
 ```py
 def applygammaBGRbuf(buf: array.array, gamma: float):
@@ -1258,7 +1258,7 @@ Apply a gamma adjustment to a
         BGR data
 
 
-### [`applymonochromefiltertoBGRbuf`](#Python_BMP.colors.applymonochromefiltertoBGRbuf)
+### [`applymonochromefiltertoBGRbuf`](#applymonochromefiltertoBGRbuf)
 
 ```py
 def applymonochromefiltertoBGRbuf(buf: array.array):
@@ -1281,7 +1281,7 @@ Apply a monochrome filter to a
         holding mono BGR data
 
 
-### [`applythresholdadjtoBGRbuf`](#Python_BMP.colors.applythresholdadjtoBGRbuf)
+### [`applythresholdadjtoBGRbuf`](#applythresholdadjtoBGRbuf)
 
 ```py
 def applythresholdadjtoBGRbuf(buf: array.array, lumrange: list) -> array.array:
@@ -1303,7 +1303,7 @@ Apply a threshold adjustment
         BGR data
 
 
-### [`arcvert`](#Python_BMP.primitives2D.arcvert)
+### [`arcvert`](#arcvert)
 
 ```py
 def arcvert(x: int, y: int, r: int, startdegangle: float, enddegangle: float):
@@ -1326,7 +1326,7 @@ traces an arc with origin set at (x, y)
         list[[x: int, y: int]]
 
 
-### [`autocropimg2file`](#Python_BMP.BITMAPlib.autocropimg2file)
+### [`autocropimg2file`](#autocropimg2file)
 
 ```py
 def autocropimg2file(ExistingBMPfile: str, NewBMPfile: str, similaritythreshold: float):
@@ -1346,7 +1346,7 @@ Perform an auto crop to the image in a bitmap file
         new bitmap file
 
 
-### [`beziercurve`](#Python_BMP.BITMAPlib.beziercurve)
+### [`beziercurve`](#beziercurve)
 
 ```py
 def beziercurve(bmp: array.array, pntlist: list[list[numbers.Number, numbers.Number]], penradius: int, color: int):
@@ -1367,7 +1367,7 @@ Draws a Bezier Curve
         byref modified unsigned byte array
 
 
-### [`BMPbitBLTget`](#Python_BMP.BITMAPlib.BMPbitBLTget)
+### [`BMPbitBLTget`](#BMPbitBLTget)
 
 ```py
 def BMPbitBLTget(bmp: array.array, offset: int, bufsize: int) -> array.array:
@@ -1387,7 +1387,7 @@ Gets [offset: offset + bufsize] to a new array
         unsigned byte array
 
 
-### [`BMPbitBLTput`](#Python_BMP.BITMAPlib.BMPbitBLTput)
+### [`BMPbitBLTput`](#BMPbitBLTput)
 
 ```py
 def BMPbitBLTput(bmp: array.array, offset: int, arraybuf: array.array):
@@ -1406,7 +1406,7 @@ Sets offset in array to arraybuf
         byref modified unsigned byte array
 
 
-### [`bottomrightcoord`](#Python_BMP.BITMAPlib.bottomrightcoord)
+### [`bottomrightcoord`](#bottomrightcoord)
 
 ```py
 def bottomrightcoord(bmp: array.array) -> tuple:
@@ -1422,7 +1422,7 @@ Gets the maximum bottom right coordinates of a bmp
         tuple (x:int,y:int)
 
 
-### [`brightnessadjcircregion2file`](#Python_BMP.BITMAPlib.brightnessadjcircregion2file)
+### [`brightnessadjcircregion2file`](#brightnessadjcircregion2file)
 
 ```py
 def brightnessadjcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, percentadj: float):
@@ -1451,7 +1451,7 @@ Brightness gradient to a circular area
         new bitmap file
 
 
-### [`brightnessadjcircregion`](#Python_BMP.BITMAPlib.brightnessadjcircregion)
+### [`brightnessadjcircregion`](#brightnessadjcircregion)
 
 ```py
 def brightnessadjcircregion(bmp: array.array, x: int, y: int, r: int, percentadj: float):
@@ -1472,7 +1472,7 @@ Brightness adjustment to a circular area
         byref modified unsigned byte array
 
 
-### [`brightnessadjust`](#Python_BMP.colors.brightnessadjust)
+### [`brightnessadjust`](#brightnessadjust)
 
 ```py
 def brightnessadjust(rgb: list[int, int, int], percentadj: float) -> list[int, int, int]:
@@ -1496,7 +1496,7 @@ Apply a brightness adjustment
         [r: byte, g: byte, b: byte]
 
 
-### [`brightnesseadjto24bitimage`](#Python_BMP.BITMAPlib.brightnesseadjto24bitimage)
+### [`brightnesseadjto24bitimage`](#brightnesseadjto24bitimage)
 
 ```py
 def brightnesseadjto24bitimage(bmp: array.array, percentadj: float):
@@ -1517,7 +1517,7 @@ Brightness adjustment to a whole BMP
         byref modified unsigned byte array
 
 
-### [`brightnesseadjto24bitregion`](#Python_BMP.BITMAPlib.brightnesseadjto24bitregion)
+### [`brightnesseadjto24bitregion`](#brightnesseadjto24bitregion)
 
 ```py
 def brightnesseadjto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, percentadj: float):
@@ -1540,7 +1540,7 @@ Brightness adjustment to a rectangular area
         byref modified unsigned byte array
 
 
-### [`bspline`](#Python_BMP.BITMAPlib.bspline)
+### [`bspline`](#bspline)
 
 ```py
 def bspline(bmp: array.array, pntlist: list, penradius: int, color: int, isclosed: bool, curveback: bool):
@@ -1566,7 +1566,7 @@ Draws a Bspline
         byref modified unsigned byte array
 
 
-### [`bsplinevert`](#Python_BMP.primitives2D.bsplinevert)
+### [`bsplinevert`](#bsplinevert)
 
 ```py
 def bsplinevert(pntlist: list[list[int, int]], isclosed: bool, curveback: bool) -> list[list[int, int]]:
@@ -1585,7 +1585,7 @@ Creates a list of vertices for a bspline curve
         list[list[x: int, y: int]]
 
 
-### [`buf2int`](#Python_BMP.inttools.buf2int)
+### [`buf2int`](#buf2int)
 
 ```py
 def buf2int(buf: array.array) -> int:
@@ -1601,7 +1601,7 @@ Converts an unsigned byte array
         unsigned int value
 
 
-### [`centercoord`](#Python_BMP.BITMAPlib.centercoord)
+### [`centercoord`](#centercoord)
 
 ```py
 def centercoord(bmp: array.array) -> tuple:
@@ -1617,7 +1617,7 @@ Gets the central coordinates of a BMP
         tuple (x:int,y:int)
 
 
-### [`centerpoint`](#Python_BMP.mathlib.centerpoint)
+### [`centerpoint`](#centerpoint)
 
 ```py
 def centerpoint(x1: int, y1: int, x2: int, y2: int):
@@ -1633,7 +1633,7 @@ Returns the centerpoint x, y in rectangular area
         x: int, y: int centerpoint
 
 
-### [`char2int`](#Python_BMP.chartools.char2int)
+### [`char2int`](#char2int)
 
 ```py
 def char2int(charcodestr: str) -> int:
@@ -1649,7 +1649,7 @@ Packs a string into an int
         int value
 
 
-### [`checklink`](#Python_BMP.fileutils.checklink)
+### [`checklink`](#checklink)
 
 ```py
 def checklink(func: Callable):
@@ -1666,7 +1666,7 @@ Decorator to test if the first
         caller function
 
 
-### [`checklinks`](#Python_BMP.fileutils.checklinks)
+### [`checklinks`](#checklinks)
 
 ```py
 def checklinks(func: Callable):
@@ -1683,7 +1683,7 @@ Decorator to test if the two
         caller function
 
 
-### [`circle2file`](#Python_BMP.BITMAPlib.circle2file)
+### [`circle2file`](#circle2file)
 
 ```py
 def circle2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, color: int):
@@ -1704,7 +1704,7 @@ Draws a Circle
         new bitmap file
 
 
-### [`circle`](#Python_BMP.BITMAPlib.circle)
+### [`circle`](#circle)
 
 ```py
 def circle(bmp: array.array, x: int, y: int, r: int, color: int, isfilled: bool = None):
@@ -1728,7 +1728,7 @@ Draws a Circle
         byref modified unsigned byte array
 
 
-### [`circleinvolutevert`](#Python_BMP.primitives2D.circleinvolutevert)
+### [`circleinvolutevert`](#circleinvolutevert)
 
 ```py
 def circleinvolutevert(x: int, y: int, a: float, delta: float, lim: float):
@@ -1759,7 +1759,7 @@ and an origin set at (x, y)
         [[x: int, y: int], ...]
 
 
-### [`circlevec`](#Python_BMP.BITMAPlib.circlevec)
+### [`circlevec`](#circlevec)
 
 ```py
 def circlevec(bmp: array.array, v: list, r: int, color: int, isfilled: bool = None):
@@ -1782,7 +1782,7 @@ Draws a circle
         byref modified unsigned byte array
 
 
-### [`colorfilter2file`](#Python_BMP.BITMAPlib.colorfilter2file)
+### [`colorfilter2file`](#colorfilter2file)
 
 ```py
 def colorfilter2file(ExistingBMPfile: str, NewBMPfile: str, rgbfactors: list[float, float, float]):
@@ -1803,7 +1803,7 @@ Applies Color Filter rgbfactors to a BMP
         new bitmap file
 
 
-### [`colorfilter`](#Python_BMP.colors.colorfilter)
+### [`colorfilter`](#colorfilter)
 
 ```py
 def colorfilter(rgb: list[int, int, int], rgbfactors: list[float, float, float]) -> list[int, int, int]:
@@ -1829,7 +1829,7 @@ Apply a color filter
                   b: byte]
 
 
-### [`colorfiltercircregion2file`](#Python_BMP.BITMAPlib.colorfiltercircregion2file)
+### [`colorfiltercircregion2file`](#colorfiltercircregion2file)
 
 ```py
 def colorfiltercircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, rgbfactors: list[float, float, float]):
@@ -1851,7 +1851,7 @@ Applies a color filter to a circular area in a BMP
         new bitmap file
 
 
-### [`colorfiltercircregion`](#Python_BMP.BITMAPlib.colorfiltercircregion)
+### [`colorfiltercircregion`](#colorfiltercircregion)
 
 ```py
 def colorfiltercircregion(bmp: array.array, x: int, y: int, r: int, rgbfactors: list[float, float, float]):
@@ -1873,7 +1873,7 @@ Color Filter to a circular area
         byref modified unsigned byte array
 
 
-### [`colorfilterinregion2file`](#Python_BMP.BITMAPlib.colorfilterinregion2file)
+### [`colorfilterinregion2file`](#colorfilterinregion2file)
 
 ```py
 def colorfilterinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, rgbfactors: list[float, float, float]):
@@ -1898,7 +1898,7 @@ Color Filter to a Rectangular Area in a 24-bit BMP
         new bitmap file
 
 
-### [`colorfilterto24bitimage`](#Python_BMP.BITMAPlib.colorfilterto24bitimage)
+### [`colorfilterto24bitimage`](#colorfilterto24bitimage)
 
 ```py
 def colorfilterto24bitimage(bmp: array.array, rgbfactors: list[float, float, float]):
@@ -1920,7 +1920,7 @@ Applies a color filter
         unsigned byte array
 
 
-### [`colorfilterto24bitregion`](#Python_BMP.BITMAPlib.colorfilterto24bitregion)
+### [`colorfilterto24bitregion`](#colorfilterto24bitregion)
 
 ```py
 def colorfilterto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, rgbfactors: list[float, float, float]):
@@ -1948,7 +1948,7 @@ Applies a color filter to
         unsigned byte array
 
 
-### [`colorfiltertoBGRbuf`](#Python_BMP.colors.colorfiltertoBGRbuf)
+### [`colorfiltertoBGRbuf`](#colorfiltertoBGRbuf)
 
 ```py
 def colorfiltertoBGRbuf(buf: array.array, rgbfactors: list[float, float, float]) -> array.array:
@@ -1971,7 +1971,7 @@ Apply a color filter to a
         holding color BGR data
 
 
-### [`colorhistorgram`](#Python_BMP.BITMAPlib.colorhistorgram)
+### [`colorhistorgram`](#colorhistorgram)
 
 ```py
 def colorhistorgram(bmp: array.array) -> list:
@@ -1987,7 +1987,7 @@ Creates a color histogram
         list sorted in descending order of color frequencies
 
 
-### [`colormix`](#Python_BMP.colors.colormix)
+### [`colormix`](#colormix)
 
 ```py
 def colormix(lum: int, RGBfactors: list[float, float, float]) -> int:
@@ -2013,7 +2013,7 @@ Mix a byte luminosity value to
         int color val
 
 
-### [`conevertandsurface`](#Python_BMP.solids3D.conevertandsurface)
+### [`conevertandsurface`](#conevertandsurface)
 
 ```py
 def conevertandsurface(vcen: list[float, float, float], r: float, zlen: float, deganglestep: float) -> tuple:
@@ -2041,7 +2041,7 @@ Returns a list of sparse
         see Hello_Cone.py
 
 
-### [`convertbufto24bit`](#Python_BMP.BITMAPlib.convertbufto24bit)
+### [`convertbufto24bit`](#convertbufto24bit)
 
 ```py
 def convertbufto24bit(buf: array.array, bgrpalbuf: array.array, bits: int) -> array.array:
@@ -2059,7 +2059,7 @@ Converts 1, 4 and 8-bit buffers to a BGR buffer
         unsigned byte array
 
 
-### [`convertselection2BMP`](#Python_BMP.BITMAPlib.convertselection2BMP)
+### [`convertselection2BMP`](#convertselection2BMP)
 
 ```py
 def convertselection2BMP(buf: array.array):
@@ -2074,7 +2074,7 @@ Converts custom unsigned byte array to bmp format
         unsigned byte array with bmp format
 
 
-### [`copyBMPhdr`](#Python_BMP.BITMAPlib.copyBMPhdr)
+### [`copyBMPhdr`](#copyBMPhdr)
 
 ```py
 def copyBMPhdr(bmp: array.array) -> array.array:
@@ -2091,7 +2091,7 @@ to a new unsigned byte array
         unsigned byte array with bmp format
 
 
-### [`CopyBMPxydim2newBMP`](#Python_BMP.BITMAPlib.CopyBMPxydim2newBMP)
+### [`CopyBMPxydim2newBMP`](#CopyBMPxydim2newBMP)
 
 ```py
 def CopyBMPxydim2newBMP(bmp: array.array, newbits: int) -> array.array:
@@ -2109,7 +2109,7 @@ Creates a new bitmap with the same dimensions as bmp
         unsigned byte array with bitmap layout
 
 
-### [`copycircregion2buf`](#Python_BMP.BITMAPlib.copycircregion2buf)
+### [`copycircregion2buf`](#copycircregion2buf)
 
 ```py
 def copycircregion2buf(bmp: array.array, x: int, y: int, r: int) -> list:
@@ -2130,7 +2130,7 @@ centerpoint at (x, y) and radius r
         list with buffer of circular region
 
 
-### [`copycircregion2file`](#Python_BMP.BITMAPlib.copycircregion2file)
+### [`copycircregion2file`](#copycircregion2file)
 
 ```py
 def copycircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, newxycenterpoint: list):
@@ -2152,7 +2152,7 @@ Copy/Paste of a circular area in a BMP
         new bitmap file
 
 
-### [`copycircregion`](#Python_BMP.BITMAPlib.copycircregion)
+### [`copycircregion`](#copycircregion)
 
 ```py
 def copycircregion(bmp: array.array, x: int, y: int, r: int, newxy: list):
@@ -2178,7 +2178,7 @@ newxy [x, y]
         byref modified unsigned byte array
 
 
-### [`copyrect`](#Python_BMP.BITMAPlib.copyrect)
+### [`copyrect`](#copyrect)
 
 ```py
 def copyrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int) -> array.array:
@@ -2194,7 +2194,7 @@ Copy a rectangular region to a custom buffer
         custom unsigned byte array
 
 
-### [`copyRGBpal`](#Python_BMP.BITMAPlib.copyRGBpal)
+### [`copyRGBpal`](#copyRGBpal)
 
 ```py
 def copyRGBpal(sourceBMP: array.array, destBMP: array.array):
@@ -2213,7 +2213,7 @@ a destination unsigned byte array
         (unsigned byte array)
 
 
-### [`cosaffin`](#Python_BMP.mathlib.cosaffin)
+### [`cosaffin`](#cosaffin)
 
 ```py
 def cosaffin(u: list[numbers.Number], v: list[numbers.Number]) -> float:
@@ -2232,7 +2232,7 @@ Compute Cosine Similarity or Cosine Affinity
             and values in between
 
 
-### [`crop`](#Python_BMP.BITMAPlib.crop)
+### [`crop`](#crop)
 
 ```py
 def crop(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -2254,7 +2254,7 @@ Crops the image to a rectangular
         with bitmap layout
 
 
-### [`cropBMPandsave`](#Python_BMP.BITMAPlib.cropBMPandsave)
+### [`cropBMPandsave`](#cropBMPandsave)
 
 ```py
 def cropBMPandsave(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -2275,7 +2275,7 @@ Crops and saves a rectangular area to a BMP
         new bitmap file
 
 
-### [`cropBMPandsaveusingrectbnd`](#Python_BMP.BITMAPlib.cropBMPandsaveusingrectbnd)
+### [`cropBMPandsaveusingrectbnd`](#cropBMPandsaveusingrectbnd)
 
 ```py
 def cropBMPandsaveusingrectbnd(ExistingBMPfile: str, NewBMPfile: str, rectbnd: list):
@@ -2300,7 +2300,7 @@ Crops and saves a rectangular area to a BMP
         new bitmap file
 
 
-### [`cubevert`](#Python_BMP.solids3D.cubevert)
+### [`cubevert`](#cubevert)
 
 ```py
 def cubevert(x: float) -> list[list[float, float, float]]:
@@ -2318,7 +2318,7 @@ Returns a list of vertices
               z: float)
 
 
-### [`cylindervertandsurface`](#Python_BMP.solids3D.cylindervertandsurface)
+### [`cylindervertandsurface`](#cylindervertandsurface)
 
 ```py
 def cylindervertandsurface(vcen: list[float, float, float], r: float, zlen: float, deganglestep: float) -> tuple:
@@ -2344,7 +2344,7 @@ Returns a list of sparse vertices
         see Hello_Coin.py
 
 
-### [`decahedvertandsurface`](#Python_BMP.solids3D.decahedvertandsurface)
+### [`decahedvertandsurface`](#decahedvertandsurface)
 
 ```py
 def decahedvertandsurface(x: float) -> list[list[float, float, float]]:
@@ -2364,7 +2364,7 @@ Returns a list of vertices
               z: float)
 
 
-### [`dict2descorderlist`](#Python_BMP.dicttools.dict2descorderlist)
+### [`dict2descorderlist`](#dict2descorderlist)
 
 ```py
 def dict2descorderlist(d: dict) -> list:
@@ -2382,7 +2382,7 @@ Creates a sorted list in
         list
 
 
-### [`distance`](#Python_BMP.mathlib.distance)
+### [`distance`](#distance)
 
 ```py
 def distance(u: list[float], v: list[float]) -> float:
@@ -2400,7 +2400,7 @@ with n components
         float
 
 
-### [`drawarc`](#Python_BMP.BITMAPlib.drawarc)
+### [`drawarc`](#drawarc)
 
 ```py
 def drawarc(bmp: array.array, x: int, y: int, r: int, startdegangle: float, enddegangle: float, color: int, showoutline: bool, fillcolor: int, isfilled: bool):
@@ -2429,7 +2429,7 @@ Draws an Arc
         byref modified unsigned byte array
 
 
-### [`drawvec`](#Python_BMP.BITMAPlib.drawvec)
+### [`drawvec`](#drawvec)
 
 ```py
 def drawvec(bmp: array.array, u: list, v: list, headsize: int, color: int, penradius: int = None):
@@ -2454,7 +2454,7 @@ Draws a vector (line segment with arrow head)
         byref modified unsigned byte array
 
 
-### [`ellipse`](#Python_BMP.BITMAPlib.ellipse)
+### [`ellipse`](#ellipse)
 
 ```py
 def ellipse(bmp: array.array, x: int, y: int, b: int, a: int, color: int, isfilled: bool = None):
@@ -2478,7 +2478,7 @@ Draws an Ellipse
         byref modified unsigned byte array
 
 
-### [`ellipsevert`](#Python_BMP.primitives2D.ellipsevert)
+### [`ellipsevert`](#ellipsevert)
 
 ```py
 def ellipsevert(x: int, y: int, b: int, a: int) -> list[int, int]:
@@ -2499,7 +2499,7 @@ an ellipse with origin set at (x, y)
         [[x: int, y: int], ...]
 
 
-### [`entirecircleinboundary`](#Python_BMP.paramchecks.entirecircleinboundary)
+### [`entirecircleinboundary`](#entirecircleinboundary)
 
 ```py
 def entirecircleinboundary(func):
@@ -2519,7 +2519,7 @@ Decorator to ensure that the 2nd,
         caller function
 
 
-### [`entirecircleisinboundary`](#Python_BMP.primitives2D.entirecircleisinboundary)
+### [`entirecircleisinboundary`](#entirecircleisinboundary)
 
 ```py
 def entirecircleisinboundary(x: int, y: int, minx: int, maxx: int, miny: int, maxy: int, r: int):
@@ -2542,7 +2542,7 @@ is within a rectagular area
                  is in bounds
 
 
-### [`entireellipseisinboundary`](#Python_BMP.primitives2D.entireellipseisinboundary)
+### [`entireellipseisinboundary`](#entireellipseisinboundary)
 
 ```py
 def entireellipseisinboundary(x: int, y: int, minx: int, maxx: int, miny: int, maxy: int, b: int, a: int):
@@ -2565,7 +2565,7 @@ is within a rectagular area
                  is in bounds
 
 
-### [`entirerectinboundary`](#Python_BMP.paramchecks.entirerectinboundary)
+### [`entirerectinboundary`](#entirerectinboundary)
 
 ```py
 def entirerectinboundary(func):
@@ -2586,7 +2586,7 @@ Decorator to ensure that the
         caller function
 
 
-### [`enumbits`](#Python_BMP.mathlib.enumbits)
+### [`enumbits`](#enumbits)
 
 ```py
 def enumbits(byteval: int):
@@ -2603,7 +2603,7 @@ Yields the 8 bits in a byte
         int 0 or int 1
 
 
-### [`enumletters`](#Python_BMP.chartools.enumletters)
+### [`enumletters`](#enumletters)
 
 ```py
 def enumletters(st: str) -> str:
@@ -2619,7 +2619,7 @@ Enumerates the characters
         individual characters
 
 
-### [`enumreverseletters`](#Python_BMP.chartools.enumreverseletters)
+### [`enumreverseletters`](#enumreverseletters)
 
 ```py
 def enumreverseletters(st: str) -> str:
@@ -2635,7 +2635,7 @@ Enumerates the characters in a
         individual characters
 
 
-### [`epicycloidvert`](#Python_BMP.primitives2D.epicycloidvert)
+### [`epicycloidvert`](#epicycloidvert)
 
 ```py
 def epicycloidvert(x: int, y: int, a: float, b: float, delta: float, lim: float):
@@ -2660,7 +2660,7 @@ with an origin set at (x, y)
         [[x: int, y: int], ...]
 
 
-### [`erasealternatehorizontallines`](#Python_BMP.BITMAPlib.erasealternatehorizontallines)
+### [`erasealternatehorizontallines`](#erasealternatehorizontallines)
 
 ```py
 def erasealternatehorizontallines(bmp: array.array, int_eraseeverynline: int, int_eraseNthline: int, bytepat: int):
@@ -2691,7 +2691,7 @@ Erase every nth line
         byref modified unsigned byte array
 
 
-### [`erasealternatehorizontallinesincircregion`](#Python_BMP.BITMAPlib.erasealternatehorizontallinesincircregion)
+### [`erasealternatehorizontallinesincircregion`](#erasealternatehorizontallinesincircregion)
 
 ```py
 def erasealternatehorizontallinesincircregion(bmp: array.array, x: int, y: int, r: int, int_eraseeverynline: int, int_eraseNthline: int, bytepat: int):
@@ -2728,7 +2728,7 @@ Erase every nth line
         byref modified unsigned byte array
 
 
-### [`erasealternatehorizontallinesinregion`](#Python_BMP.BITMAPlib.erasealternatehorizontallinesinregion)
+### [`erasealternatehorizontallinesinregion`](#erasealternatehorizontallinesinregion)
 
 ```py
 def erasealternatehorizontallinesinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, int_eraseeverynline: int, int_eraseNthline: int, bytepat: int):
@@ -2761,7 +2761,7 @@ Erase every nth line in a rectangular region
         byref modified unsigned byte array
 
 
-### [`eraseeverynthhoriline2file`](#Python_BMP.BITMAPlib.eraseeverynthhoriline2file)
+### [`eraseeverynthhoriline2file`](#eraseeverynthhoriline2file)
 
 ```py
 def eraseeverynthhoriline2file(ExistingBMPfile: str, NewBMPfile: str, n: int):
@@ -2781,7 +2781,7 @@ Erase every nth line
         new bitmap file
 
 
-### [`eraseeverynthhorilineinccircregion2file`](#Python_BMP.BITMAPlib.eraseeverynthhorilineinccircregion2file)
+### [`eraseeverynthhorilineinccircregion2file`](#eraseeverynthhorilineinccircregion2file)
 
 ```py
 def eraseeverynthhorilineinccircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, n: int):
@@ -2804,7 +2804,7 @@ Erase every nth horzontal line in a circular area
         new bitmap file
 
 
-### [`eraseeverynthhorilineinregion2file`](#Python_BMP.BITMAPlib.eraseeverynthhorilineinregion2file)
+### [`eraseeverynthhorilineinregion2file`](#eraseeverynthhorilineinregion2file)
 
 ```py
 def eraseeverynthhorilineinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, n: int):
@@ -2828,7 +2828,7 @@ Erase every nth line in a rectangular region
         new bitmap file
 
 
-### [`eraseeverynthhorilineinregion`](#Python_BMP.BITMAPlib.eraseeverynthhorilineinregion)
+### [`eraseeverynthhorilineinregion`](#eraseeverynthhorilineinregion)
 
 ```py
 def eraseeverynthhorilineinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, n: int):
@@ -2853,7 +2853,7 @@ Erase every nth line in a
         unsigned byte array
 
 
-### [`eraseeverynthhorizontalline`](#Python_BMP.BITMAPlib.eraseeverynthhorizontalline)
+### [`eraseeverynthhorizontalline`](#eraseeverynthhorizontalline)
 
 ```py
 def eraseeverynthhorizontalline(bmp: array.array, n: int):
@@ -2870,7 +2870,7 @@ Erase every nth horizontal line
         byref modified unsigned byte array
 
 
-### [`eraseeverynthhorizontallineinccircregion`](#Python_BMP.BITMAPlib.eraseeverynthhorizontallineinccircregion)
+### [`eraseeverynthhorizontallineinccircregion`](#eraseeverynthhorizontallineinccircregion)
 
 ```py
 def eraseeverynthhorizontallineinccircregion(bmp: array.array, x: int, y: int, r: int, n: int):
@@ -2890,7 +2890,7 @@ Erase every nth horizontal line in a circular region
         byref modified unsigned byte array
 
 
-### [`fern2file`](#Python_BMP.BITMAPlib.fern2file)
+### [`fern2file`](#fern2file)
 
 ```py
 def fern2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, color: int):
@@ -2912,7 +2912,7 @@ Fern Fractal in a bounding rectangle
         new bitmap file
 
 
-### [`fern`](#Python_BMP.BITMAPlib.fern)
+### [`fern`](#fern)
 
 ```py
 def fern(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):
@@ -2934,7 +2934,7 @@ Draws an IFS fern fractal
         byref modified unsigned byte array
 
 
-### [`fillbackgroundwithgrad`](#Python_BMP.BITMAPlib.fillbackgroundwithgrad)
+### [`fillbackgroundwithgrad`](#fillbackgroundwithgrad)
 
 ```py
 def fillbackgroundwithgrad(bmp: array.array, lumrange: list[int, int], RGBfactors: list[float, float, float], direction: int):
@@ -2958,7 +2958,7 @@ Fills entire bitmap with a linear gradient
         byref modified unsigned byte array
 
 
-### [`fillboundary`](#Python_BMP.BITMAPlib.fillboundary)
+### [`fillboundary`](#fillboundary)
 
 ```py
 def fillboundary(bmp: array.array, bndfilldic: dict, color: int):
@@ -2976,7 +2976,7 @@ Draws lines in a boundary to fill it
         byref modified unsigned byte array
 
 
-### [`filledcircle2file`](#Python_BMP.BITMAPlib.filledcircle2file)
+### [`filledcircle2file`](#filledcircle2file)
 
 ```py
 def filledcircle2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, color: int):
@@ -2998,7 +2998,7 @@ Draws a Filled Circle
         new bitmap file
 
 
-### [`filledcircle`](#Python_BMP.BITMAPlib.filledcircle)
+### [`filledcircle`](#filledcircle)
 
 ```py
 def filledcircle(bmp: array.array, x: int, y: int, r: int, color: int):
@@ -3019,7 +3019,7 @@ Draws a Filled Circle
         byref modified unsigned byte array
 
 
-### [`filledellipse`](#Python_BMP.BITMAPlib.filledellipse)
+### [`filledellipse`](#filledellipse)
 
 ```py
 def filledellipse(bmp: array.array, x: int, y: int, b: int, a: int, color: int):
@@ -3038,7 +3038,7 @@ Filled Ellipse
         byref modified unsigned byte array
 
 
-### [`filledgradrect`](#Python_BMP.BITMAPlib.filledgradrect)
+### [`filledgradrect`](#filledgradrect)
 
 ```py
 def filledgradrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int], RGBfactors: list[float, float, float], direction: int):
@@ -3070,7 +3070,7 @@ Draw a filled rectangle with a linear gradient
         unsigned byte array
 
 
-### [`filledparallelogram`](#Python_BMP.BITMAPlib.filledparallelogram)
+### [`filledparallelogram`](#filledparallelogram)
 
 ```py
 def filledparallelogram(bmp: array.array, p1: list, p2: list, p3: list, color: int):
@@ -3091,7 +3091,7 @@ Creates a filled parallelogram defined by 3 points
         byref unsigned modified byte array
 
 
-### [`filledrect`](#Python_BMP.BITMAPlib.filledrect)
+### [`filledrect`](#filledrect)
 
 ```py
 def filledrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):
@@ -3113,7 +3113,7 @@ Draws a Filled Rectangle
         byref modified unsigned byte array
 
 
-### [`fillpolydata`](#Python_BMP.solids3D.fillpolydata)
+### [`fillpolydata`](#fillpolydata)
 
 ```py
 def fillpolydata(polybnd: list[list[int, int]], xlim: int, ylim: int) -> list:
@@ -3142,7 +3142,7 @@ Generates a list of x values per
         bounds
 
 
-### [`fliphoricircregion2file`](#Python_BMP.BITMAPlib.fliphoricircregion2file)
+### [`fliphoricircregion2file`](#fliphoricircregion2file)
 
 ```py
 def fliphoricircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -3162,7 +3162,7 @@ Horizontal Flip of a circular area
         new bitmap file
 
 
-### [`fliphoricircregion`](#Python_BMP.BITMAPlib.fliphoricircregion)
+### [`fliphoricircregion`](#fliphoricircregion)
 
 ```py
 def fliphoricircregion(bmp: array.array, x: int, y: int, r: int):
@@ -3182,7 +3182,7 @@ Flips horizontally a circular area
         unsigned byte array
 
 
-### [`fliphorizontal2file`](#Python_BMP.BITMAPlib.fliphorizontal2file)
+### [`fliphorizontal2file`](#fliphorizontal2file)
 
 ```py
 def fliphorizontal2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -3200,7 +3200,7 @@ Flips horizontally the image in a BMP
         new bitmap file
 
 
-### [`fliphorizontal`](#Python_BMP.BITMAPlib.fliphorizontal)
+### [`fliphorizontal`](#fliphorizontal)
 
 ```py
 def fliphorizontal(bmp: array.array):
@@ -3218,7 +3218,7 @@ Does a horizontal flip of an
         unsigned byte array
 
 
-### [`fliphorizontalregion2file`](#Python_BMP.BITMAPlib.fliphorizontalregion2file)
+### [`fliphorizontalregion2file`](#fliphorizontalregion2file)
 
 ```py
 def fliphorizontalregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -3238,7 +3238,7 @@ Flips horizontally a rectangular area in a BMP
         new bitmap file
 
 
-### [`fliphorizontalregion`](#Python_BMP.BITMAPlib.fliphorizontalregion)
+### [`fliphorizontalregion`](#fliphorizontalregion)
 
 ```py
 def fliphorizontalregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -3260,7 +3260,7 @@ Does a horizontal flip
         unsigned byte array
 
 
-### [`fliphorzontalpixelbased`](#Python_BMP.BITMAPlib.fliphorzontalpixelbased)
+### [`fliphorzontalpixelbased`](#fliphorzontalpixelbased)
 
 ```py
 def fliphorzontalpixelbased(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -3284,7 +3284,7 @@ Flips horizontal
         unsigned byte array
 
 
-### [`fliphverticalalpixelbased`](#Python_BMP.BITMAPlib.fliphverticalalpixelbased)
+### [`fliphverticalalpixelbased`](#fliphverticalalpixelbased)
 
 ```py
 def fliphverticalalpixelbased(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -3307,7 +3307,7 @@ Flips vertical
         unsigned byte array
 
 
-### [`flipnibbleinbuf`](#Python_BMP.bufferflip.flipnibbleinbuf)
+### [`flipnibbleinbuf`](#flipnibbleinbuf)
 
 ```py
 def flipnibbleinbuf(buf: array.array) -> array.array:
@@ -3322,7 +3322,7 @@ Flips a 4-bit image buffer
         unsigned byte array
 
 
-### [`flipvertcircregion2file`](#Python_BMP.BITMAPlib.flipvertcircregion2file)
+### [`flipvertcircregion2file`](#flipvertcircregion2file)
 
 ```py
 def flipvertcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -3342,7 +3342,7 @@ Vertical Flip of a circular area
         new bitmap file
 
 
-### [`flipvertcircregion`](#Python_BMP.BITMAPlib.flipvertcircregion)
+### [`flipvertcircregion`](#flipvertcircregion)
 
 ```py
 def flipvertcircregion(bmp: array.array, x: int, y: int, r: int):
@@ -3361,7 +3361,7 @@ Vertical Flip of a circular area
         byref modified unsigned byte array
 
 
-### [`flipvertical2file`](#Python_BMP.BITMAPlib.flipvertical2file)
+### [`flipvertical2file`](#flipvertical2file)
 
 ```py
 def flipvertical2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -3379,7 +3379,7 @@ Flips a bitmap file vertically
         new bitmap file
 
 
-### [`flipvertical`](#Python_BMP.BITMAPlib.flipvertical)
+### [`flipvertical`](#flipvertical)
 
 ```py
 def flipvertical(bmp: array.array):
@@ -3396,7 +3396,7 @@ Does an vertical flip of a bmp
         unsigned byte array
 
 
-### [`flipverticalregion2file`](#Python_BMP.BITMAPlib.flipverticalregion2file)
+### [`flipverticalregion2file`](#flipverticalregion2file)
 
 ```py
 def flipverticalregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -3417,7 +3417,7 @@ Flips vertically a rectangular area in a BMP
         new bitmap file
 
 
-### [`flipverticalregion`](#Python_BMP.BITMAPlib.flipverticalregion)
+### [`flipverticalregion`](#flipverticalregion)
 
 ```py
 def flipverticalregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -3437,7 +3437,7 @@ Flips vertical a rectangular area
         unsigned byte array
 
 
-### [`flipXY2file`](#Python_BMP.BITMAPlib.flipXY2file)
+### [`flipXY2file`](#flipXY2file)
 
 ```py
 def flipXY2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -3455,7 +3455,7 @@ Flips the x and y coordinates to rotate by 90 degrees
         new bitmap file
 
 
-### [`flipXY`](#Python_BMP.BITMAPlib.flipXY)
+### [`flipXY`](#flipXY)
 
 ```py
 def flipXY(bmp: array.array):
@@ -3474,7 +3474,7 @@ Flips the x and y coordinates of
         unsigned byte array
 
 
-### [`flipXYcircregion2file`](#Python_BMP.BITMAPlib.flipXYcircregion2file)
+### [`flipXYcircregion2file`](#flipXYcircregion2file)
 
 ```py
 def flipXYcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -3494,7 +3494,7 @@ Flips the x and y coordinates of a circular area
         new bitmap file
 
 
-### [`flipXYcircregion`](#Python_BMP.BITMAPlib.flipXYcircregion)
+### [`flipXYcircregion`](#flipXYcircregion)
 
 ```py
 def flipXYcircregion(bmp: array.array, x: int, y: int, r: int):
@@ -3512,7 +3512,7 @@ Flip the X and Y coordinates of a circular area
         byref modified unsigned byte array
 
 
-### [`flowervert`](#Python_BMP.primitives2D.flowervert)
+### [`flowervert`](#flowervert)
 
 ```py
 def flowervert(cx: int, cy: int, r: int, petals: int, angrot: float):
@@ -3530,7 +3530,7 @@ Returns a list of 2D points for a flower
         list[(x: int, y: int)]
 
 
-### [`func24bitonly`](#Python_BMP.paramchecks.func24bitonly)
+### [`func24bitonly`](#func24bitonly)
 
 ```py
 def func24bitonly(func):
@@ -3548,7 +3548,7 @@ Decorator to restrict the
         caller function
 
 
-### [`func24bitonlyandentirecircleinboundary`](#Python_BMP.paramchecks.func24bitonlyandentirecircleinboundary)
+### [`func24bitonlyandentirecircleinboundary`](#func24bitonlyandentirecircleinboundary)
 
 ```py
 def func24bitonlyandentirecircleinboundary(func):
@@ -3570,7 +3570,7 @@ Decorator to restrict the
         caller function
 
 
-### [`func24bitonlyandentirerectinboundary`](#Python_BMP.paramchecks.func24bitonlyandentirerectinboundary)
+### [`func24bitonlyandentirerectinboundary`](#func24bitonlyandentirerectinboundary)
 
 ```py
 def func24bitonlyandentirerectinboundary(func):
@@ -3593,7 +3593,7 @@ Decorator to restrict the
         caller function
 
 
-### [`func8and24bitonlyandentirecircleinboundary`](#Python_BMP.paramchecks.func8and24bitonlyandentirecircleinboundary)
+### [`func8and24bitonlyandentirecircleinboundary`](#func8and24bitonlyandentirecircleinboundary)
 
 ```py
 def func8and24bitonlyandentirecircleinboundary(func):
@@ -3616,7 +3616,7 @@ Decorator to restrict the
         caller function
 
 
-### [`func8and24bitonlyandentirerectinboundary`](#Python_BMP.paramchecks.func8and24bitonlyandentirerectinboundary)
+### [`func8and24bitonlyandentirerectinboundary`](#func8and24bitonlyandentirerectinboundary)
 
 ```py
 def func8and24bitonlyandentirerectinboundary(func):
@@ -3640,7 +3640,7 @@ Decorator to restrict the
         caller function
 
 
-### [`functimer`](#Python_BMP.proctimer.functimer)
+### [`functimer`](#functimer)
 
 ```py
 def functimer(func):
@@ -3655,7 +3655,7 @@ Function timer Decorator
         caller function
 
 
-### [`gammaadj2file`](#Python_BMP.BITMAPlib.gammaadj2file)
+### [`gammaadj2file`](#gammaadj2file)
 
 ```py
 def gammaadj2file(ExistingBMPfile: str, NewBMPfile: str, gamma: float):
@@ -3675,7 +3675,7 @@ Applies a Gamma Correction
         new bitmap file
 
 
-### [`gammaadjto24bitimage`](#Python_BMP.BITMAPlib.gammaadjto24bitimage)
+### [`gammaadjto24bitimage`](#gammaadjto24bitimage)
 
 ```py
 def gammaadjto24bitimage(bmp: array.array, gamma: float):
@@ -3692,7 +3692,7 @@ Gamma correction to an in-memory 24-bit BMP
         byref modified unsigned byte array
 
 
-### [`gammaadjto24bitregion`](#Python_BMP.BITMAPlib.gammaadjto24bitregion)
+### [`gammaadjto24bitregion`](#gammaadjto24bitregion)
 
 ```py
 def gammaadjto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, gamma: float):
@@ -3713,7 +3713,7 @@ Gamma correction to a rectangular area in a 24-bit BMP
         byref modified unsigned byte array
 
 
-### [`gammaadjtoregion2file`](#Python_BMP.BITMAPlib.gammaadjtoregion2file)
+### [`gammaadjtoregion2file`](#gammaadjtoregion2file)
 
 ```py
 def gammaadjtoregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, gamma: float):
@@ -3736,7 +3736,7 @@ Gamma Correction to a Rectangular Region
         new bitmap file
 
 
-### [`gammaBGRbuf`](#Python_BMP.colors.gammaBGRbuf)
+### [`gammaBGRbuf`](#gammaBGRbuf)
 
 ```py
 def gammaBGRbuf(buf: array.array, gamma: float) -> array.array:
@@ -3757,7 +3757,7 @@ Apply a gamma adjustment to a
         BGR data
 
 
-### [`gammacorrect`](#Python_BMP.colors.gammacorrect)
+### [`gammacorrect`](#gammacorrect)
 
 ```py
 def gammacorrect(rgb: list[int, int, int], gamma: float) -> list[int, int, int]:
@@ -3776,7 +3776,7 @@ Apply a gamma factor to a rgb
         [r: byte, g: byte, b: byte]
 
 
-### [`gammacorrectcircregion2file`](#Python_BMP.BITMAPlib.gammacorrectcircregion2file)
+### [`gammacorrectcircregion2file`](#gammacorrectcircregion2file)
 
 ```py
 def gammacorrectcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, gamma: float):
@@ -3800,7 +3800,7 @@ Gamma Adjust to a circular area in a BMP
         new bitmap file
 
 
-### [`gammacorrectcircregion`](#Python_BMP.BITMAPlib.gammacorrectcircregion)
+### [`gammacorrectcircregion`](#gammacorrectcircregion)
 
 ```py
 def gammacorrectcircregion(bmp: array.array, x: int, y: int, r: int, gamma: float):
@@ -3821,7 +3821,7 @@ Gamma correction to a circular area
         byref modified unsigned byte array
 
 
-### [`genpiechartdata`](#Python_BMP.charts.genpiechartdata)
+### [`genpiechartdata`](#genpiechartdata)
 
 ```py
 def genpiechartdata(dlist: list):
@@ -3839,7 +3839,7 @@ Preprocess data to make
         list and large value (if any)
 
 
-### [`gensides`](#Python_BMP.solids3D.gensides)
+### [`gensides`](#gensides)
 
 ```py
 def gensides(pointlists: list[list, list], transvect: list[float, float, float], sides: list[list[float]]) -> tuple:
@@ -3859,7 +3859,7 @@ positioning
     
 
 
-### [`getallRGBpal`](#Python_BMP.BITMAPlib.getallRGBpal)
+### [`getallRGBpal`](#getallRGBpal)
 
 ```py
 def getallRGBpal(bmp: array.array) -> list[list[int, int, int]]:
@@ -3875,7 +3875,7 @@ Gets the RGB palette of a bitmap
         [(r: byte, g: byte, b: byte), ...]
 
 
-### [`getBGRpalbuf`](#Python_BMP.BITMAPlib.getBGRpalbuf)
+### [`getBGRpalbuf`](#getBGRpalbuf)
 
 ```py
 def getBGRpalbuf(bmp: array.array):
@@ -3891,7 +3891,7 @@ Gets bitmap palette as stored in the bitmap
         unsigned byte array (BGR)
 
 
-### [`getBMPimgbytes`](#Python_BMP.BITMAPlib.getBMPimgbytes)
+### [`getBMPimgbytes`](#getBMPimgbytes)
 
 ```py
 def getBMPimgbytes(bmp: array.array) -> list:
@@ -3907,7 +3907,7 @@ Gets the raw image buffer of a bmp without the header
         list of unsigned bytes
 
 
-### [`getcharfont`](#Python_BMP.fonts.getcharfont)
+### [`getcharfont`](#getcharfont)
 
 ```py
 def getcharfont(charbuf: list, character: str) -> list:
@@ -3918,7 +3918,7 @@ def getcharfont(charbuf: list, character: str) -> list:
     
 
 
-### [`getcolorname2HSLdict`](#Python_BMP.colordict.getcolorname2HSLdict)
+### [`getcolorname2HSLdict`](#getcolorname2HSLdict)
 
 ```py
 def getcolorname2HSLdict() -> dict:
@@ -3929,7 +3929,7 @@ def getcolorname2HSLdict() -> dict:
     
 
 
-### [`getcolorname2RGBdict`](#Python_BMP.colordict.getcolorname2RGBdict)
+### [`getcolorname2RGBdict`](#getcolorname2RGBdict)
 
 ```py
 def getcolorname2RGBdict() -> dict:
@@ -3940,7 +3940,7 @@ def getcolorname2RGBdict() -> dict:
     
 
 
-### [`getdatalisttotal`](#Python_BMP.charts.getdatalisttotal)
+### [`getdatalisttotal`](#getdatalisttotal)
 
 ```py
 def getdatalisttotal(dlist: list[numbers.Number]) -> numbers.Number:
@@ -3956,7 +3956,7 @@ Returns the total of a
         float or int
 
 
-### [`getdefaultbitpal`](#Python_BMP.colors.getdefaultbitpal)
+### [`getdefaultbitpal`](#getdefaultbitpal)
 
 ```py
 def getdefaultbitpal(bits: int) -> list:
@@ -3972,7 +3972,7 @@ Gets the standard bitmap palette
         list of palette entries
 
 
-### [`getdefaultlumrange`](#Python_BMP.colors.getdefaultlumrange)
+### [`getdefaultlumrange`](#getdefaultlumrange)
 
 ```py
 def getdefaultlumrange() -> dict:
@@ -3986,7 +3986,7 @@ Gets the default luminosity
         luminosity ranges
 
 
-### [`getfuncmetastr`](#Python_BMP.funcmeta.getfuncmetastr)
+### [`getfuncmetastr`](#getfuncmetastr)
 
 ```py
 def getfuncmetastr(f: Callable):
@@ -3997,7 +3997,7 @@ def getfuncmetastr(f: Callable):
     
 
 
-### [`getIFSparams`](#Python_BMP.fractals.getIFSparams)
+### [`getIFSparams`](#getIFSparams)
 
 ```py
 def getIFSparams() -> dict:
@@ -4008,7 +4008,7 @@ def getIFSparams() -> dict:
     
 
 
-### [`getimagedgevert`](#Python_BMP.BITMAPlib.getimagedgevert)
+### [`getimagedgevert`](#getimagedgevert)
 
 ```py
 def getimagedgevert(bmp: array.array, similaritythreshold: int):
@@ -4030,7 +4030,7 @@ Find edges in an image
         [(x: int, y: int),...]
 
 
-### [`getimageregionbyRGB`](#Python_BMP.BITMAPlib.getimageregionbyRGB)
+### [`getimageregionbyRGB`](#getimageregionbyRGB)
 
 ```py
 def getimageregionbyRGB(bmp: array.array, rgb: list[int, int, int], similaritythreshold: int):
@@ -4055,7 +4055,7 @@ Select a region by color
         list of vertices
 
 
-### [`getmaxcolors`](#Python_BMP.BITMAPlib.getmaxcolors)
+### [`getmaxcolors`](#getmaxcolors)
 
 ```py
 def getmaxcolors(bmp: array.array) -> int:
@@ -4071,7 +4071,7 @@ Get the maximum number of colors supported by a BMP
         int value
 
 
-### [`getmaxx`](#Python_BMP.BITMAPlib.getmaxx)
+### [`getmaxx`](#getmaxx)
 
 ```py
 def getmaxx(bmp: array.array) -> int:
@@ -4087,7 +4087,7 @@ Gets the x value stored in the windows bmp header
         int value of x bmp dimension
 
 
-### [`getmaxxy`](#Python_BMP.BITMAPlib.getmaxxy)
+### [`getmaxxy`](#getmaxxy)
 
 ```py
 def getmaxxy(bmp: array.array) -> tuple:
@@ -4103,7 +4103,7 @@ Gets the max x and y values stored in the bmp header
         tuple (x:int,y:int)
 
 
-### [`getmaxxyandbits`](#Python_BMP.BITMAPlib.getmaxxyandbits)
+### [`getmaxxyandbits`](#getmaxxyandbits)
 
 ```py
 def getmaxxyandbits(bmp: array.array) -> tuple:
@@ -4120,7 +4120,7 @@ Returns bitmap metadata
         (x-dimension, y-dimension, bit depth)
 
 
-### [`getmaxy`](#Python_BMP.BITMAPlib.getmaxy)
+### [`getmaxy`](#getmaxy)
 
 ```py
 def getmaxy(bmp: array.array) -> int:
@@ -4136,7 +4136,7 @@ Gets the y value stored in the windows bmp header
         int value of y bmp dimension
 
 
-### [`getneighborcolorlist`](#Python_BMP.BITMAPlib.getneighborcolorlist)
+### [`getneighborcolorlist`](#getneighborcolorlist)
 
 ```py
 def getneighborcolorlist(bmp: array.array, v: list):
@@ -4147,7 +4147,7 @@ def getneighborcolorlist(bmp: array.array, v: list):
     
 
 
-### [`getRGBfactors`](#Python_BMP.colordict.getRGBfactors)
+### [`getRGBfactors`](#getRGBfactors)
 
 ```py
 def getRGBfactors() -> dict:
@@ -4158,7 +4158,7 @@ def getRGBfactors() -> dict:
     
 
 
-### [`getRGBpal`](#Python_BMP.BITMAPlib.getRGBpal)
+### [`getRGBpal`](#getRGBpal)
 
 ```py
 def getRGBpal(bmp: array.array, c: int) -> list[int, int, int]:
@@ -4176,7 +4176,7 @@ Gets the [R, G, B] values
         [R: byte, G: byte, B:byte]
 
 
-### [`getRGBxybit`](#Python_BMP.BITMAPlib.getRGBxybit)
+### [`getRGBxybit`](#getRGBxybit)
 
 ```py
 def getRGBxybit(bmp: array.array, x: int, y: int) -> list[int, int, int]:
@@ -4195,7 +4195,7 @@ of pixel at (x, y) in a bitmap
         [R: byte, G: byte, B: byte]
 
 
-### [`getRGBxybitvec`](#Python_BMP.BITMAPlib.getRGBxybitvec)
+### [`getRGBxybitvec`](#getRGBxybitvec)
 
 ```py
 def getRGBxybitvec(bmp: array.array, v: list) -> list:
@@ -4213,7 +4213,7 @@ Gets the RGB of a pixel at (x,y) in a BMP
         [R: byte, G: byte, B: byte]
 
 
-### [`getshapesidedict`](#Python_BMP.solids3D.getshapesidedict)
+### [`getshapesidedict`](#getshapesidedict)
 
 ```py
 def getshapesidedict() -> dict:
@@ -4228,7 +4228,7 @@ Returns a dictionary of side
         definitions for basic solids
 
 
-### [`getX11colorname2HSLdict`](#Python_BMP.X11colordict.getX11colorname2HSLdict)
+### [`getX11colorname2HSLdict`](#getX11colorname2HSLdict)
 
 ```py
 def getX11colorname2HSLdict() -> dict:
@@ -4239,7 +4239,7 @@ def getX11colorname2HSLdict() -> dict:
     
 
 
-### [`getX11colorname2RGBdict`](#Python_BMP.X11colordict.getX11colorname2RGBdict)
+### [`getX11colorname2RGBdict`](#getX11colorname2RGBdict)
 
 ```py
 def getX11colorname2RGBdict() -> dict:
@@ -4250,7 +4250,7 @@ def getX11colorname2RGBdict() -> dict:
     
 
 
-### [`getX11RGBfactors`](#Python_BMP.X11colordict.getX11RGBfactors)
+### [`getX11RGBfactors`](#getX11RGBfactors)
 
 ```py
 def getX11RGBfactors() -> dict:
@@ -4261,7 +4261,7 @@ def getX11RGBfactors() -> dict:
     
 
 
-### [`getXKCDcolorname2HSLdict`](#Python_BMP.XKCDcolordict.getXKCDcolorname2HSLdict)
+### [`getXKCDcolorname2HSLdict`](#getXKCDcolorname2HSLdict)
 
 ```py
 def getXKCDcolorname2HSLdict() -> dict:
@@ -4272,7 +4272,7 @@ def getXKCDcolorname2HSLdict() -> dict:
     
 
 
-### [`getXKCDcolorname2RGBdict`](#Python_BMP.XKCDcolordict.getXKCDcolorname2RGBdict)
+### [`getXKCDcolorname2RGBdict`](#getXKCDcolorname2RGBdict)
 
 ```py
 def getXKCDcolorname2RGBdict() -> dict:
@@ -4283,7 +4283,7 @@ def getXKCDcolorname2RGBdict() -> dict:
     
 
 
-### [`getXKCDRGBfactors`](#Python_BMP.XKCDcolordict.getXKCDRGBfactors)
+### [`getXKCDRGBfactors`](#getXKCDRGBfactors)
 
 ```py
 def getXKCDRGBfactors() -> dict:
@@ -4294,7 +4294,7 @@ def getXKCDRGBfactors() -> dict:
     
 
 
-### [`getxybit`](#Python_BMP.BITMAPlib.getxybit)
+### [`getxybit`](#getxybit)
 
 ```py
 def getxybit(bmp: array.array, x: int, y: int) -> int:
@@ -4312,7 +4312,7 @@ Gets color of pixel at (x, y) in a BMP
         unsigned int color value
 
 
-### [`getxybitvec`](#Python_BMP.BITMAPlib.getxybitvec)
+### [`getxybitvec`](#getxybitvec)
 
 ```py
 def getxybitvec(bmp: array.array, v: list) -> int:
@@ -4330,7 +4330,7 @@ Gets color of pixel at (x, y)
         unsigned int color value
 
 
-### [`gradcircle`](#Python_BMP.BITMAPlib.gradcircle)
+### [`gradcircle`](#gradcircle)
 
 ```py
 def gradcircle(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
@@ -4352,7 +4352,7 @@ Filled Circle with Gradient
         byref modified unsigned byte array
 
 
-### [`gradellipse`](#Python_BMP.BITMAPlib.gradellipse)
+### [`gradellipse`](#gradellipse)
 
 ```py
 def gradellipse(bmp: array.array, x: int, y: int, b: int, a: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
@@ -4375,7 +4375,7 @@ Ellipical gradient
         byref modified unsigned byte array
 
 
-### [`gradthickcircle`](#Python_BMP.BITMAPlib.gradthickcircle)
+### [`gradthickcircle`](#gradthickcircle)
 
 ```py
 def gradthickcircle(bmp: array.array, x: int, y: int, r: int, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
@@ -4400,7 +4400,7 @@ Thick Circle with a Gradient
         byref modified unsigned byte array
 
 
-### [`gradthickellipserot`](#Python_BMP.BITMAPlib.gradthickellipserot)
+### [`gradthickellipserot`](#gradthickellipserot)
 
 ```py
 def gradthickellipserot(bmp: array.array, x: int, y: int, b: int, a: int, degrot: float, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
@@ -4427,7 +4427,7 @@ Thick Ellipse with a Gradient fill
         byref modified unsigned byte array
 
 
-### [`gradthickplotpoly`](#Python_BMP.BITMAPlib.gradthickplotpoly)
+### [`gradthickplotpoly`](#gradthickplotpoly)
 
 ```py
 def gradthickplotpoly(bmp: array.array, vertlist: list, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
@@ -4451,7 +4451,7 @@ Draws a polygon of a given gradient and thickness
         byref modified unsigned byte array
 
 
-### [`gradthickroundline`](#Python_BMP.BITMAPlib.gradthickroundline)
+### [`gradthickroundline`](#gradthickroundline)
 
 ```py
 def gradthickroundline(bmp: array.array, p1: list, p2: list, penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
@@ -4482,7 +4482,7 @@ Draw a Thick Rounded Line with a Gradient
         unsigned byte array
 
 
-### [`gradvert`](#Python_BMP.BITMAPlib.gradvert)
+### [`gradvert`](#gradvert)
 
 ```py
 def gradvert(bmp: array.array, vertlist: list[list[int, int]], penradius: int, lumrange: list[int, int], RGBfactors: list[float, float, float]):
@@ -4509,7 +4509,7 @@ List of 2d vertices as spheres of a given color
         unsigned byte array
 
 
-### [`hexahedravert`](#Python_BMP.solids3D.hexahedravert)
+### [`hexahedravert`](#hexahedravert)
 
 ```py
 def hexahedravert(x: float) -> list[list[float, float, float]]:
@@ -4527,7 +4527,7 @@ Returns a list of vertices
               z: float)
 
 
-### [`horibrightnessgrad2circregion2file`](#Python_BMP.BITMAPlib.horibrightnessgrad2circregion2file)
+### [`horibrightnessgrad2circregion2file`](#horibrightnessgrad2circregion2file)
 
 ```py
 def horibrightnessgrad2circregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, lumrange: list[int, int]):
@@ -4552,7 +4552,7 @@ Horizontal brightness gradient to a circular area
         new bitmap file
 
 
-### [`horibrightnessgrad2circregion`](#Python_BMP.BITMAPlib.horibrightnessgrad2circregion)
+### [`horibrightnessgrad2circregion`](#horibrightnessgrad2circregion)
 
 ```py
 def horibrightnessgrad2circregion(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int]):
@@ -4573,7 +4573,7 @@ Horizontal brightness gradient adjustment to a circular area
         byref modified unsigned byte array
 
 
-### [`horiline`](#Python_BMP.BITMAPlib.horiline)
+### [`horiline`](#horiline)
 
 ```py
 def horiline(bmp: array.array, y: int, x1: int, x2: int, color: int):
@@ -4594,7 +4594,7 @@ Draw a Horizontal Line
         byref modified unsigned byte array
 
 
-### [`horilinevert`](#Python_BMP.BITMAPlib.horilinevert)
+### [`horilinevert`](#horilinevert)
 
 ```py
 def horilinevert(bmp: array.array, vlist: list[list[int, int]], linelen: int, xadj: int, color: int):
@@ -4618,7 +4618,7 @@ Horizontal line marks at vertices in vlist
         byref modified unsigned byte array
 
 
-### [`horitransformincircregion`](#Python_BMP.BITMAPlib.horitransformincircregion)
+### [`horitransformincircregion`](#horitransformincircregion)
 
 ```py
 def horitransformincircregion(bmp: array.array, x: int, y: int, r: int, trans: str):
@@ -4642,7 +4642,7 @@ Horizontal transform to a circular area
         unsigned byte array
 
 
-### [`horizontalbrightnessgrad2file`](#Python_BMP.BITMAPlib.horizontalbrightnessgrad2file)
+### [`horizontalbrightnessgrad2file`](#horizontalbrightnessgrad2file)
 
 ```py
 def horizontalbrightnessgrad2file(ExistingBMPfile: str, NewBMPfile: str, lumrange: list[int, int]):
@@ -4664,7 +4664,7 @@ Horizontal brightness gradient to a BMP
         new bitmap file
 
 
-### [`horizontalbrightnessgradregion2file`](#Python_BMP.BITMAPlib.horizontalbrightnessgradregion2file)
+### [`horizontalbrightnessgradregion2file`](#horizontalbrightnessgradregion2file)
 
 ```py
 def horizontalbrightnessgradregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):
@@ -4688,7 +4688,7 @@ Horizontal brightness gradient to a rectangular area
         new bitmap file
 
 
-### [`horizontalbrightnessgradto24bitimage`](#Python_BMP.BITMAPlib.horizontalbrightnessgradto24bitimage)
+### [`horizontalbrightnessgradto24bitimage`](#horizontalbrightnessgradto24bitimage)
 
 ```py
 def horizontalbrightnessgradto24bitimage(bmp: array.array, lumrange: list[int, int]):
@@ -4709,7 +4709,7 @@ Applies a horizontal brightness
         unsigned byte array
 
 
-### [`horizontalbrightnessgradto24bitregion`](#Python_BMP.BITMAPlib.horizontalbrightnessgradto24bitregion)
+### [`horizontalbrightnessgradto24bitregion`](#horizontalbrightnessgradto24bitregion)
 
 ```py
 def horizontalbrightnessgradto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):
@@ -4734,7 +4734,7 @@ to a rectangular area in a 24-bit bitmap
         byref modified unsigned byte array
 
 
-### [`horizontalbulkswap`](#Python_BMP.BITMAPlib.horizontalbulkswap)
+### [`horizontalbulkswap`](#horizontalbulkswap)
 
 ```py
 def horizontalbulkswap(bmp: array.array, x1: int, y1: int, x2: int, y2: int, swapfunc: Callable):
@@ -4755,7 +4755,7 @@ Applies function swapfunc
         unsigned byte array
 
 
-### [`horizontalvert`](#Python_BMP.primitives2D.horizontalvert)
+### [`horizontalvert`](#horizontalvert)
 
 ```py
 def horizontalvert(y: int, x1: int, x2: int, dx: int) -> list[list[int, int]]:
@@ -4775,7 +4775,7 @@ a horizontal line with int step dx
         [(x, y), ...]
 
 
-### [`hypotrochoidvert`](#Python_BMP.primitives2D.hypotrochoidvert)
+### [`hypotrochoidvert`](#hypotrochoidvert)
 
 ```py
 def hypotrochoidvert(x: int, y: int, a: float, b: float, c: float, delta: float, lim: float):
@@ -4804,7 +4804,7 @@ with an origin set at (x, y)
         [[x: int, y: int], ...]
 
 
-### [`icosahedvertandsurface`](#Python_BMP.solids3D.icosahedvertandsurface)
+### [`icosahedvertandsurface`](#icosahedvertandsurface)
 
 ```py
 def icosahedvertandsurface(x: float) -> list[list[list[float, float, float]], tuple]:
@@ -4824,7 +4824,7 @@ Returns a list of vertices
               z: float)
 
 
-### [`IFS`](#Python_BMP.BITMAPlib.IFS)
+### [`IFS`](#IFS)
 
 ```py
 def IFS(bmp: array.array, IFStransparam: tuple, x1: int, y1: int, x2: int, y2: int, xscale: int, yscale: int, xoffset: int, yoffset: int, color: int, maxiter: int):
@@ -4851,7 +4851,7 @@ Draw an Interated Function System Fractal
         byref modified unsigned byte array
 
 
-### [`iif`](#Python_BMP.conditionaltools.iif)
+### [`iif`](#iif)
 
 ```py
 def iif(boolcond: bool, trueval: <built-in function any>, falseval: <built-in function any>) -> <built-in function any>:
@@ -4876,7 +4876,7 @@ Returns trueval if
         a value depending on boolcond
 
 
-### [`imagecomp`](#Python_BMP.BITMAPlib.imagecomp)
+### [`imagecomp`](#imagecomp)
 
 ```py
 def imagecomp(inputfile1: str, inputfile2: str, diff_file: str, func: Callable):
@@ -4898,7 +4898,7 @@ using a user defined bitwise comparator function
         new bitmap file
 
 
-### [`imagediff`](#Python_BMP.BITMAPlib.imagediff)
+### [`imagediff`](#imagediff)
 
 ```py
 def imagediff(inputfile1: str, inputfile2: str, diff_file: str):
@@ -4917,7 +4917,7 @@ Compares 2 files and saves diff to a bitmap file
         new bitmap file
 
 
-### [`imgregionbyRGB2file`](#Python_BMP.BITMAPlib.imgregionbyRGB2file)
+### [`imgregionbyRGB2file`](#imgregionbyRGB2file)
 
 ```py
 def imgregionbyRGB2file(ExistingBMPfile: str, NewBMPfile: str, edgeradius: int, edgecolor: int, rgb: list[int, int, int], similaritythreshold: float, showedgeonly: bool):
@@ -4949,7 +4949,7 @@ Gets an image region by rgb in a bitmap file
         new bitmap file
 
 
-### [`int2BGRarr`](#Python_BMP.colors.int2BGRarr)
+### [`int2BGRarr`](#int2BGRarr)
 
 ```py
 def int2BGRarr(i: int) -> array.array:
@@ -4965,7 +4965,7 @@ Returns a bgr array from
         unsigned byte BGR array
 
 
-### [`int2buf`](#Python_BMP.inttools.int2buf)
+### [`int2buf`](#int2buf)
 
 ```py
 def int2buf(cnt: int, value: int) -> array.array:
@@ -4982,7 +4982,7 @@ Converts an integer value to an
         unsigned byte array
 
 
-### [`int2RGB`](#Python_BMP.colors.int2RGB)
+### [`int2RGB`](#int2RGB)
 
 ```py
 def int2RGB(i: int):
@@ -4999,7 +4999,7 @@ Break down int color i to its
         r: byte, g: byte, b: byte
 
 
-### [`int2RGBarr`](#Python_BMP.colors.int2RGBarr)
+### [`int2RGBarr`](#int2RGBarr)
 
 ```py
 def int2RGBarr(i: int) -> array.array:
@@ -5016,7 +5016,7 @@ Returns a rgb array from
         unsigned byte RGB array
 
 
-### [`int2RGBlist`](#Python_BMP.colors.int2RGBlist)
+### [`int2RGBlist`](#int2RGBlist)
 
 ```py
 def int2RGBlist(i: int) -> list[int, int, int]:
@@ -5033,7 +5033,7 @@ Break down int color i to its
         [r: byte, g: byte, b: byte]
 
 
-### [`intcircleparam24bitonly`](#Python_BMP.paramchecks.intcircleparam24bitonly)
+### [`intcircleparam24bitonly`](#intcircleparam24bitonly)
 
 ```py
 def intcircleparam24bitonly(func):
@@ -5053,7 +5053,7 @@ Decorator to test if 2nd, 3rd,
         caller function
 
 
-### [`intcircleparam`](#Python_BMP.paramchecks.intcircleparam)
+### [`intcircleparam`](#intcircleparam)
 
 ```py
 def intcircleparam(func):
@@ -5071,7 +5071,7 @@ Decorator to test if the
         caller function
 
 
-### [`intlinevec`](#Python_BMP.BITMAPlib.intlinevec)
+### [`intlinevec`](#intlinevec)
 
 ```py
 def intlinevec(bmp: array.array, u: list, v: list, color: int):
@@ -5090,7 +5090,7 @@ Draw a line in a bitmap
         byref modified unsigned byte array
 
 
-### [`intplotvecxypoint`](#Python_BMP.BITMAPlib.intplotvecxypoint)
+### [`intplotvecxypoint`](#intplotvecxypoint)
 
 ```py
 def intplotvecxypoint(bmp: array.array, v: list[int, int], c: int):
@@ -5110,7 +5110,7 @@ Sets the color of a pixel at (x, y)
         byref modified unsigned byte array
 
 
-### [`intscalarmulvect`](#Python_BMP.mathlib.intscalarmulvect)
+### [`intscalarmulvect`](#intscalarmulvect)
 
 ```py
 def intscalarmulvect(vec: list[numbers.Number], scalarval: numbers.Number) -> list[int]:
@@ -5131,7 +5131,7 @@ then rounds off values in the list to a whole number
         list of ints
 
 
-### [`invertbits2file`](#Python_BMP.BITMAPlib.invertbits2file)
+### [`invertbits2file`](#invertbits2file)
 
 ```py
 def invertbits2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -5149,7 +5149,7 @@ Inverts the bits in a bmp file
         new bitmap file
 
 
-### [`invertbitsinbuffer`](#Python_BMP.colors.invertbitsinbuffer)
+### [`invertbitsinbuffer`](#invertbitsinbuffer)
 
 ```py
 def invertbitsinbuffer(buf: array.array) -> array.array:
@@ -5165,7 +5165,7 @@ Flips all the bits in an
         bit flipped unsigned byte array
 
 
-### [`invertbitsincircregion2file`](#Python_BMP.BITMAPlib.invertbitsincircregion2file)
+### [`invertbitsincircregion2file`](#invertbitsincircregion2file)
 
 ```py
 def invertbitsincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -5185,7 +5185,7 @@ Inverts bits in a circular area
         new bitmap file
 
 
-### [`invertbitsincircregion`](#Python_BMP.BITMAPlib.invertbitsincircregion)
+### [`invertbitsincircregion`](#invertbitsincircregion)
 
 ```py
 def invertbitsincircregion(bmp: array.array, x: int, y: int, r: int):
@@ -5204,7 +5204,7 @@ Inverts the bits in a circular area
         byref modified unsigned byte array
 
 
-### [`invertimagebits`](#Python_BMP.BITMAPlib.invertimagebits)
+### [`invertimagebits`](#invertimagebits)
 
 ```py
 def invertimagebits(bmp: array.array):
@@ -5220,7 +5220,7 @@ Inverts the bits in a bitmap
         byref modified unsigned byte array
 
 
-### [`invertregion2file`](#Python_BMP.BITMAPlib.invertregion2file)
+### [`invertregion2file`](#invertregion2file)
 
 ```py
 def invertregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -5240,7 +5240,7 @@ Inverts the bits in a rectangular area in a BMP
         new bitmap file
 
 
-### [`invertregion`](#Python_BMP.BITMAPlib.invertregion)
+### [`invertregion`](#invertregion)
 
 ```py
 def invertregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -5261,7 +5261,7 @@ Inverts the bits in a
         unsigned byte array
 
 
-### [`isdefaultpal`](#Python_BMP.BITMAPlib.isdefaultpal)
+### [`isdefaultpal`](#isdefaultpal)
 
 ```py
 def isdefaultpal(bmp: array.array) -> bool:
@@ -5278,7 +5278,7 @@ Checks if bitmap has a default RGB color palette
         False if not default
 
 
-### [`isinBMPrectbnd`](#Python_BMP.BITMAPlib.isinBMPrectbnd)
+### [`isinBMPrectbnd`](#isinBMPrectbnd)
 
 ```py
 def isinBMPrectbnd(bmp: array.array, x: int, y: int) -> bool:
@@ -5298,7 +5298,7 @@ Checks if (x,y) coordinates are within the BMP
         False if out of bounds
 
 
-### [`isinrange`](#Python_BMP.mathlib.isinrange)
+### [`isinrange`](#isinrange)
 
 ```py
 def isinrange(value: numbers.Number, highlimit: numbers.Number, lowlimit: numbers.Number) -> bool:
@@ -5318,7 +5318,7 @@ Checks is value is within high and low limits
         True if within bounds
 
 
-### [`isinrectbnd`](#Python_BMP.primitives2D.isinrectbnd)
+### [`isinrectbnd`](#isinrectbnd)
 
 ```py
 def isinrectbnd(x: int, y: int, xmin: int, ymin: int, xmax: int, ymax: int) -> bool:
@@ -5339,7 +5339,7 @@ defined by xmin, ymin and xmax, ymax
         False -> (x, y) is out of bounds
 
 
-### [`isvalidcolorbit`](#Python_BMP.colors.isvalidcolorbit)
+### [`isvalidcolorbit`](#isvalidcolorbit)
 
 ```py
 def isvalidcolorbit(bits: int) -> bool:
@@ -5357,7 +5357,7 @@ Checks if bits is in the valid
               the list above
 
 
-### [`iterbeziercurve`](#Python_BMP.primitives2D.iterbeziercurve)
+### [`iterbeziercurve`](#iterbeziercurve)
 
 ```py
 def iterbeziercurve(pntlist: list[list[int, int]]) -> list[int, int]:
@@ -5376,7 +5376,7 @@ based on 2D control points in pntlist
         vertices as list[x: int, y: int]
 
 
-### [`iterbspline`](#Python_BMP.primitives2D.iterbspline)
+### [`iterbspline`](#iterbspline)
 
 ```py
 def iterbspline(pntlist: list[list[int, int]], isclosed: bool, curveback: bool) -> list[int, int]:
@@ -5395,7 +5395,7 @@ based on 2D control points in pntlist
         vertices as list[x: int, y: int]
 
 
-### [`itercircle`](#Python_BMP.primitives2D.itercircle)
+### [`itercircle`](#itercircle)
 
 ```py
 def itercircle(x: int, y: int, r: int) -> list[int, int]:
@@ -5414,7 +5414,7 @@ a circle with origin set at (x, y)
         [x: int, y: int]
 
 
-### [`itercircleinvolute`](#Python_BMP.primitives2D.itercircleinvolute)
+### [`itercircleinvolute`](#itercircleinvolute)
 
 ```py
 def itercircleinvolute(x: int, y: int, a: float, delta: float, lim: float):
@@ -5445,7 +5445,7 @@ and an origin set at (x, y)
         [[x: int, y: int], ...]
 
 
-### [`itercirclepart`](#Python_BMP.primitives2D.itercirclepart)
+### [`itercirclepart`](#itercirclepart)
 
 ```py
 def itercirclepart(r: int) -> list[int, int]:
@@ -5463,7 +5463,7 @@ at (0, 0)
         [x: int, y: int]
 
 
-### [`itercirclepartlineedge`](#Python_BMP.primitives2D.itercirclepartlineedge)
+### [`itercirclepartlineedge`](#itercirclepartlineedge)
 
 ```py
 def itercirclepartlineedge(r: int) -> list[int, int]:
@@ -5483,7 +5483,7 @@ filled circles with horizontal lines
         [x: int, y: int]
 
 
-### [`itercirclepartvertlineedge`](#Python_BMP.primitives2D.itercirclepartvertlineedge)
+### [`itercirclepartvertlineedge`](#itercirclepartvertlineedge)
 
 ```py
 def itercirclepartvertlineedge(r: int) -> list[int, int]:
@@ -5503,7 +5503,7 @@ and other tasks involving circular areas
         [x: int, y: int]
 
 
-### [`itercopyrect`](#Python_BMP.BITMAPlib.itercopyrect)
+### [`itercopyrect`](#itercopyrect)
 
 ```py
 def itercopyrect(bmp: array.array, x1: int, y1: int, x2: int, y2: int) -> array.array:
@@ -5523,7 +5523,7 @@ Scan a rectangular area and yield scan lines
         scanlines of the area
 
 
-### [`iterdrawvec`](#Python_BMP.primitives2D.iterdrawvec)
+### [`iterdrawvec`](#iterdrawvec)
 
 ```py
 def iterdrawvec(u: list, v: list, headsize: int):
@@ -5543,7 +5543,7 @@ Yields a vector (line segment with arrow head)
         ((x1: int, y1: int), (x2: int, y2: int))
 
 
-### [`iterellipse`](#Python_BMP.primitives2D.iterellipse)
+### [`iterellipse`](#iterellipse)
 
 ```py
 def iterellipse(x: int, y: int, b: int, a: int):
@@ -5561,7 +5561,7 @@ origin set at (x, y)
         [x: int, y: int]
 
 
-### [`iterellipsepart`](#Python_BMP.primitives2D.iterellipsepart)
+### [`iterellipsepart`](#iterellipsepart)
 
 ```py
 def iterellipsepart(b: int, a: int):
@@ -5579,7 +5579,7 @@ ellipse with origin set at (0, 0)
         [x: int, y: int]
 
 
-### [`iterellipserot`](#Python_BMP.primitives2D.iterellipserot)
+### [`iterellipserot`](#iterellipserot)
 
 ```py
 def iterellipserot(x: int, y: int, b: int, a: int, degrot: float):
@@ -5598,7 +5598,7 @@ set at (x, y) rotated by degrot degrees
         [x: int, y: int]
 
 
-### [`iterepicycloid`](#Python_BMP.primitives2D.iterepicycloid)
+### [`iterepicycloid`](#iterepicycloid)
 
 ```py
 def iterepicycloid(x: int, y: int, a: float, b: float, delta: float, lim: float):
@@ -5623,7 +5623,7 @@ with an origin set at (x, y)
         [[x: int, y: int], ...]
 
 
-### [`iterflower`](#Python_BMP.primitives2D.iterflower)
+### [`iterflower`](#iterflower)
 
 ```py
 def iterflower(cx: int, cy: int, r: int, petals: int, angrot: float):
@@ -5641,7 +5641,7 @@ Yields 2D points for a flower
         (x: int, y: int)
 
 
-### [`itergetcolorfromrectregion`](#Python_BMP.BITMAPlib.itergetcolorfromrectregion)
+### [`itergetcolorfromrectregion`](#itergetcolorfromrectregion)
 
 ```py
 def itergetcolorfromrectregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -5662,7 +5662,7 @@ Yields color info of
         for all points in area
 
 
-### [`itergetneighbors`](#Python_BMP.primitives2D.itergetneighbors)
+### [`itergetneighbors`](#itergetneighbors)
 
 ```py
 def itergetneighbors(v: list[int, int], mx: int, my: int, includecenter: bool) -> list[int, int]:
@@ -5681,7 +5681,7 @@ Yields the neighboring pixels of point v
         [x: int, y: int]
 
 
-### [`iterhypotrochoid`](#Python_BMP.primitives2D.iterhypotrochoid)
+### [`iterhypotrochoid`](#iterhypotrochoid)
 
 ```py
 def iterhypotrochoid(x: int, y: int, a: float, b: float, c: float, delta: float, lim: float):
@@ -5710,7 +5710,7 @@ with an origin set at (x, y)
         [[x: int, y: int], ...]
 
 
-### [`iterIFS`](#Python_BMP.fractals.iterIFS)
+### [`iterIFS`](#iterIFS)
 
 ```py
 def iterIFS(IFStransparam: tuple, x1: int, y1: int, x2: int, y2: int, xscale: int, yscale: int, xoffset: int, yoffset: int, maxiter: int):
@@ -5733,7 +5733,7 @@ Yield 2D points for an Interated Function System Fractal
         (x: int, y: int)
 
 
-### [`iterimagecolor`](#Python_BMP.BITMAPlib.iterimagecolor)
+### [`iterimagecolor`](#iterimagecolor)
 
 ```py
 def iterimagecolor(bmp: array.array, waitmsg: str, rowprocind: str, finishmsg: str):
@@ -5759,7 +5759,7 @@ Yields color information for entire bitmap
         ((x: int, y: int), color: int)
 
 
-### [`iterimagedgevert`](#Python_BMP.BITMAPlib.iterimagedgevert)
+### [`iterimagedgevert`](#iterimagedgevert)
 
 ```py
 def iterimagedgevert(bmp: array.array, similaritythreshold: float):
@@ -5781,7 +5781,7 @@ Find edges in an image
         (x: int, y: int)
 
 
-### [`iterimageregionvertbyRGB`](#Python_BMP.BITMAPlib.iterimageregionvertbyRGB)
+### [`iterimageregionvertbyRGB`](#iterimageregionvertbyRGB)
 
 ```py
 def iterimageregionvertbyRGB(bmp: array.array, rgb: list[int, int, int], similaritythreshold: int):
@@ -5806,7 +5806,7 @@ RGB Color selection by color similarity
         ((x: int, y: int), (r: byte, g: byte, b: byte))
 
 
-### [`iterimageRGB`](#Python_BMP.BITMAPlib.iterimageRGB)
+### [`iterimageRGB`](#iterimageRGB)
 
 ```py
 def iterimageRGB(bmp: array.array, waitmsg: str, rowprocind: str, finishmsg: str):
@@ -5830,7 +5830,7 @@ Yields (r, g, b) information for the entire bitmap
         ((x: int, y: int), (r: byte, g: byte, b: byte))
 
 
-### [`iterline`](#Python_BMP.primitives2D.iterline)
+### [`iterline`](#iterline)
 
 ```py
 def iterline(p1: list[int, int], p2: list[int, int]) -> list[int, int]:
@@ -5848,7 +5848,7 @@ by endpoints p1 and p2
         [x:int, y:int]
 
 
-### [`iterlissajouscurve`](#Python_BMP.primitives2D.iterlissajouscurve)
+### [`iterlissajouscurve`](#iterlissajouscurve)
 
 ```py
 def iterlissajouscurve(x: int, y: int, a: float, b: float, c: float, d: float, e: float, delta: float, lim: float):
@@ -5875,7 +5875,7 @@ with an origin set at (x, y)
         [x: int, y: int]
 
 
-### [`itermandelbrot`](#Python_BMP.fractals.itermandelbrot)
+### [`itermandelbrot`](#itermandelbrot)
 
 ```py
 def itermandelbrot(x1: int, y1: int, x2: int, y2: int, mandelparam: list[float, float, float, float], maxiter: int):
@@ -5900,7 +5900,7 @@ Yields a Mandelbrot set
         (x:int, y: int, c: int)
 
 
-### [`iterparallelogram`](#Python_BMP.primitives2D.iterparallelogram)
+### [`iterparallelogram`](#iterparallelogram)
 
 ```py
 def iterparallelogram(p1: list[int, int], p2: list[int, int], p3: list[int, int]) -> list[int, int]:
@@ -5911,7 +5911,7 @@ def iterparallelogram(p1: list[int, int], p2: list[int, int], p3: list[int, int]
     
 
 
-### [`iterspirograph`](#Python_BMP.primitives2D.iterspirograph)
+### [`iterspirograph`](#iterspirograph)
 
 ```py
 def iterspirograph(x: int, y: int, r: int, l: float, k: float, delta: float, lim: float):
@@ -5936,7 +5936,7 @@ set at (x, y)
         [[x: int, y: int], ...]
 
 
-### [`line`](#Python_BMP.BITMAPlib.line)
+### [`line`](#line)
 
 ```py
 def line(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):
@@ -5956,7 +5956,7 @@ Draw a Line in a bitmap
         unsigned byte array
 
 
-### [`linevec`](#Python_BMP.BITMAPlib.linevec)
+### [`linevec`](#linevec)
 
 ```py
 def linevec(bmp: array.array, u: list, v: list, color: int):
@@ -5976,7 +5976,7 @@ Draw a line in a bitmap
         byref modified unsigned byte array
 
 
-### [`lissajouscurvevert`](#Python_BMP.primitives2D.lissajouscurvevert)
+### [`lissajouscurvevert`](#lissajouscurvevert)
 
 ```py
 def lissajouscurvevert(x: int, y: int, a: float, b: float, c: float, d: float, e: float, delta: float, lim: float):
@@ -6002,7 +6002,7 @@ with an origin set at (x, y)
         in a list [[x: int, y: int], ...]
 
 
-### [`listinBMPrecbnd`](#Python_BMP.BITMAPlib.listinBMPrecbnd)
+### [`listinBMPrecbnd`](#listinBMPrecbnd)
 
 ```py
 def listinBMPrecbnd(bmp: array.array, xylist: list) -> bool:
@@ -6022,7 +6022,7 @@ Checks if a list of (x, y) coordinates are within the BMP
         False if out of bounds
 
 
-### [`listinrecbnd`](#Python_BMP.primitives2D.listinrecbnd)
+### [`listinrecbnd`](#listinrecbnd)
 
 ```py
 def listinrecbnd(xylist: list[list[numbers.Number, numbers.Number]], xmin: int, ymin: int, xmax: int, ymax: int) -> bool:
@@ -6048,7 +6048,7 @@ defined by xmin, ymin and xmax, ymax
                  is in bounds
 
 
-### [`loadBMP`](#Python_BMP.BITMAPlib.loadBMP)
+### [`loadBMP`](#loadBMP)
 
 ```py
 def loadBMP(filename: str) -> array.array:
@@ -6065,7 +6065,7 @@ Load bitmap to a byte array
         byte array with bmp file contents
 
 
-### [`LSMslope`](#Python_BMP.mathlib.LSMslope)
+### [`LSMslope`](#LSMslope)
 
 ```py
 def LSMslope(XYdata: list) -> float:
@@ -6082,7 +6082,7 @@ Slope of a line obtained by Least Squares Method
         float slope of line
 
 
-### [`LSMYint`](#Python_BMP.mathlib.LSMYint)
+### [`LSMYint`](#LSMYint)
 
 ```py
 def LSMYint(XYdata: list) -> float:
@@ -6100,7 +6100,7 @@ by Least Squares Method
         float y-intercept of line
 
 
-### [`magnifyNtimescircregion2file`](#Python_BMP.BITMAPlib.magnifyNtimescircregion2file)
+### [`magnifyNtimescircregion2file`](#magnifyNtimescircregion2file)
 
 ```py
 def magnifyNtimescircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, intmagfactor: int):
@@ -6122,7 +6122,7 @@ Magnify a circular region by an integer factor n times
         new bitmap file
 
 
-### [`magnifyNtimescircregion`](#Python_BMP.BITMAPlib.magnifyNtimescircregion)
+### [`magnifyNtimescircregion`](#magnifyNtimescircregion)
 
 ```py
 def magnifyNtimescircregion(bmp: array.array, x: int, y: int, r: int, n: int):
@@ -6142,7 +6142,7 @@ Magnify a circular region in a bitmap file by int n
         byref modified unsigned byte array
 
 
-### [`makeBGRbuf`](#Python_BMP.colors.makeBGRbuf)
+### [`makeBGRbuf`](#makeBGRbuf)
 
 ```py
 def makeBGRbuf(bbuf: array.array, gbuf: array.array, rbuf: array.array) -> array.array:
@@ -6164,7 +6164,7 @@ Assemble a BGR buffer from
         holding BGR data
 
 
-### [`makenewpalfromcolorhist`](#Python_BMP.BITMAPlib.makenewpalfromcolorhist)
+### [`makenewpalfromcolorhist`](#makenewpalfromcolorhist)
 
 ```py
 def makenewpalfromcolorhist(chist: list, colors: int, similaritythreshold: float) -> list:
@@ -6187,7 +6187,7 @@ Creates a new palatte based on a color histogram
         unsigned byte array with bmp format
 
 
-### [`mandelbrot`](#Python_BMP.BITMAPlib.mandelbrot)
+### [`mandelbrot`](#mandelbrot)
 
 ```py
 def mandelbrot(bmp: array.array, x1: int, y1: int, x2: int, y2: int, mandelparam: list[float, float, float, float], RGBfactors: list[float, float, float], maxiter: int):
@@ -6212,7 +6212,7 @@ Draw a Mandelbrot set
         byref modified unsigned byte array
 
 
-### [`mandelparamdict`](#Python_BMP.fractals.mandelparamdict)
+### [`mandelparamdict`](#mandelparamdict)
 
 ```py
 def mandelparamdict() -> dict:
@@ -6223,7 +6223,7 @@ def mandelparamdict() -> dict:
     
 
 
-### [`matchRGBtopal`](#Python_BMP.colors.matchRGBtopal)
+### [`matchRGBtopal`](#matchRGBtopal)
 
 ```py
 def matchRGBtopal(RGB: list, pal: list) -> int:
@@ -6247,7 +6247,7 @@ Color matching from a 24-bit
         int color val (4-bit)
 
 
-### [`mirror`](#Python_BMP.mathlib.mirror)
+### [`mirror`](#mirror)
 
 ```py
 def mirror(pt: float, delta: float):
@@ -6263,7 +6263,7 @@ Mirrors a value in a numberline
         pt - delta, pt + delta
 
 
-### [`mirrorbottom2file`](#Python_BMP.BITMAPlib.mirrorbottom2file)
+### [`mirrorbottom2file`](#mirrorbottom2file)
 
 ```py
 def mirrorbottom2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -6282,7 +6282,7 @@ Mirrors the bottom half of a BMP
         new bitmap file
 
 
-### [`mirrorbottom`](#Python_BMP.BITMAPlib.mirrorbottom)
+### [`mirrorbottom`](#mirrorbottom)
 
 ```py
 def mirrorbottom(bmp: array.array):
@@ -6299,7 +6299,7 @@ Mirrors the bottom-half of a bmp
         unsigned byte array
 
 
-### [`mirrorbottomincircregion2file`](#Python_BMP.BITMAPlib.mirrorbottomincircregion2file)
+### [`mirrorbottomincircregion2file`](#mirrorbottomincircregion2file)
 
 ```py
 def mirrorbottomincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -6319,7 +6319,7 @@ Mirror the bottom-half of a circular area
         new bitmap file
 
 
-### [`mirrorbottomincircregion`](#Python_BMP.BITMAPlib.mirrorbottomincircregion)
+### [`mirrorbottomincircregion`](#mirrorbottomincircregion)
 
 ```py
 def mirrorbottomincircregion(bmp: array.array, x: int, y: int, r: int):
@@ -6338,7 +6338,7 @@ Mirror the bottom-half of a circular area
         byref modified unsigned byte array
 
 
-### [`mirrorbottominregion2file`](#Python_BMP.BITMAPlib.mirrorbottominregion2file)
+### [`mirrorbottominregion2file`](#mirrorbottominregion2file)
 
 ```py
 def mirrorbottominregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -6358,7 +6358,7 @@ Mirrors the bottom-half region in a rectangular area in a bmp
         new bitmap file
 
 
-### [`mirrorbottominregion`](#Python_BMP.BITMAPlib.mirrorbottominregion)
+### [`mirrorbottominregion`](#mirrorbottominregion)
 
 ```py
 def mirrorbottominregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -6379,7 +6379,7 @@ Mirror the bottom-half
         unsigned byte array
 
 
-### [`mirrorbottomleft2file`](#Python_BMP.BITMAPlib.mirrorbottomleft2file)
+### [`mirrorbottomleft2file`](#mirrorbottomleft2file)
 
 ```py
 def mirrorbottomleft2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -6397,7 +6397,7 @@ Mirrors the bottom-left of a BMP
         new bitmap file
 
 
-### [`mirrorbottomleft`](#Python_BMP.BITMAPlib.mirrorbottomleft)
+### [`mirrorbottomleft`](#mirrorbottomleft)
 
 ```py
 def mirrorbottomleft(bmp: array.array):
@@ -6415,7 +6415,7 @@ Mirrors the bottom-left part
         unsigned byte array
 
 
-### [`mirrorbottomleftincircregion2file`](#Python_BMP.BITMAPlib.mirrorbottomleftincircregion2file)
+### [`mirrorbottomleftincircregion2file`](#mirrorbottomleftincircregion2file)
 
 ```py
 def mirrorbottomleftincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -6435,7 +6435,7 @@ Mirror the bottom-left of a circular area
         new bitmap file
 
 
-### [`mirrorbottomleftincircregion`](#Python_BMP.BITMAPlib.mirrorbottomleftincircregion)
+### [`mirrorbottomleftincircregion`](#mirrorbottomleftincircregion)
 
 ```py
 def mirrorbottomleftincircregion(bmp: array.array, x: int, y: int, r: int):
@@ -6453,7 +6453,7 @@ Mirror the bottom-left of a circular area
         byref modified unsigned byte array
 
 
-### [`mirrorbottomleftinregion2file`](#Python_BMP.BITMAPlib.mirrorbottomleftinregion2file)
+### [`mirrorbottomleftinregion2file`](#mirrorbottomleftinregion2file)
 
 ```py
 def mirrorbottomleftinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -6473,7 +6473,7 @@ Mirrors the bottom-left region in a rectangular area in a bmp
         new bitmap file
 
 
-### [`mirrorbottomleftinregion`](#Python_BMP.BITMAPlib.mirrorbottomleftinregion)
+### [`mirrorbottomleftinregion`](#mirrorbottomleftinregion)
 
 ```py
 def mirrorbottomleftinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -6495,7 +6495,7 @@ Mirrors the bottom-left of a
         unsigned byte array
 
 
-### [`mirrorbottomright2file`](#Python_BMP.BITMAPlib.mirrorbottomright2file)
+### [`mirrorbottomright2file`](#mirrorbottomright2file)
 
 ```py
 def mirrorbottomright2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -6513,7 +6513,7 @@ Mirrors the bottom-right of a BMP
         new bitmap file
 
 
-### [`mirrorbottomright`](#Python_BMP.BITMAPlib.mirrorbottomright)
+### [`mirrorbottomright`](#mirrorbottomright)
 
 ```py
 def mirrorbottomright(bmp: array.array):
@@ -6531,7 +6531,7 @@ Mirrors the bottom right part
         unsigned byte array
 
 
-### [`mirrorbottomrightincircregion2file`](#Python_BMP.BITMAPlib.mirrorbottomrightincircregion2file)
+### [`mirrorbottomrightincircregion2file`](#mirrorbottomrightincircregion2file)
 
 ```py
 def mirrorbottomrightincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -6551,7 +6551,7 @@ Mirror the bottom-right of a circular area
         new bitmap file
 
 
-### [`mirrorbottomrightincircregion`](#Python_BMP.BITMAPlib.mirrorbottomrightincircregion)
+### [`mirrorbottomrightincircregion`](#mirrorbottomrightincircregion)
 
 ```py
 def mirrorbottomrightincircregion(bmp: array.array, x: int, y: int, r: int):
@@ -6569,7 +6569,7 @@ Mirror the bottom-right of a circular area
         byref modified unsigned byte array
 
 
-### [`mirrorbottomrightinregion2file`](#Python_BMP.BITMAPlib.mirrorbottomrightinregion2file)
+### [`mirrorbottomrightinregion2file`](#mirrorbottomrightinregion2file)
 
 ```py
 def mirrorbottomrightinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -6589,7 +6589,7 @@ Mirrors the bottom-right region in a rectangular area in a BMP
         new bitmap file
 
 
-### [`mirrorbottomrightinregion`](#Python_BMP.BITMAPlib.mirrorbottomrightinregion)
+### [`mirrorbottomrightinregion`](#mirrorbottomrightinregion)
 
 ```py
 def mirrorbottomrightinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -6611,7 +6611,7 @@ Mirrors the bottom-right of a
         unsigned byte array
 
 
-### [`mirrorleft2file`](#Python_BMP.BITMAPlib.mirrorleft2file)
+### [`mirrorleft2file`](#mirrorleft2file)
 
 ```py
 def mirrorleft2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -6629,7 +6629,7 @@ Mirrors the left-half of a BMP
         new bitmap file
 
 
-### [`mirrorleft`](#Python_BMP.BITMAPlib.mirrorleft)
+### [`mirrorleft`](#mirrorleft)
 
 ```py
 def mirrorleft(bmp: array.array):
@@ -6647,7 +6647,7 @@ Mirrors the left-half of an
         unsigned byte array
 
 
-### [`mirrorleftincircregion2file`](#Python_BMP.BITMAPlib.mirrorleftincircregion2file)
+### [`mirrorleftincircregion2file`](#mirrorleftincircregion2file)
 
 ```py
 def mirrorleftincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -6667,7 +6667,7 @@ Mirror the left-half of a circular area
         new bitmap file
 
 
-### [`mirrorleftincircregion`](#Python_BMP.BITMAPlib.mirrorleftincircregion)
+### [`mirrorleftincircregion`](#mirrorleftincircregion)
 
 ```py
 def mirrorleftincircregion(bmp: array.array, x: int, y: int, r: int):
@@ -6685,7 +6685,7 @@ Mirrors the top-left of a circular area
         byref modified unsigned byte array
 
 
-### [`mirrorleftinregion2file`](#Python_BMP.BITMAPlib.mirrorleftinregion2file)
+### [`mirrorleftinregion2file`](#mirrorleftinregion2file)
 
 ```py
 def mirrorleftinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -6706,7 +6706,7 @@ Mirrors the left-half region in a rectangular area in a bmp
         new bitmap file
 
 
-### [`mirrorleftinregion`](#Python_BMP.BITMAPlib.mirrorleftinregion)
+### [`mirrorleftinregion`](#mirrorleftinregion)
 
 ```py
 def mirrorleftinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -6727,7 +6727,7 @@ Mirrors the left-half
         unsigned byte array
 
 
-### [`mirrorright2file`](#Python_BMP.BITMAPlib.mirrorright2file)
+### [`mirrorright2file`](#mirrorright2file)
 
 ```py
 def mirrorright2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -6745,7 +6745,7 @@ Mirrors the right half of a BMP
         new bitmap file
 
 
-### [`mirrorright`](#Python_BMP.BITMAPlib.mirrorright)
+### [`mirrorright`](#mirrorright)
 
 ```py
 def mirrorright(bmp: array.array):
@@ -6763,7 +6763,7 @@ Mirrors the right-half of an
         unsigned byte array
 
 
-### [`mirrorrightincircregion2file`](#Python_BMP.BITMAPlib.mirrorrightincircregion2file)
+### [`mirrorrightincircregion2file`](#mirrorrightincircregion2file)
 
 ```py
 def mirrorrightincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -6783,7 +6783,7 @@ Mirror the right-half of a circular area
         new bitmap file
 
 
-### [`mirrorrightincircregion`](#Python_BMP.BITMAPlib.mirrorrightincircregion)
+### [`mirrorrightincircregion`](#mirrorrightincircregion)
 
 ```py
 def mirrorrightincircregion(bmp: array.array, x: int, y: int, r: int):
@@ -6802,7 +6802,7 @@ Mirrors the right-half of a circular area
         byref modified unsigned byte array
 
 
-### [`mirrorrightinregion2file`](#Python_BMP.BITMAPlib.mirrorrightinregion2file)
+### [`mirrorrightinregion2file`](#mirrorrightinregion2file)
 
 ```py
 def mirrorrightinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -6822,7 +6822,7 @@ Mirrors the right-half region in a rectangular area in a bmp
         new bitmap file
 
 
-### [`mirrorrightinregion`](#Python_BMP.BITMAPlib.mirrorrightinregion)
+### [`mirrorrightinregion`](#mirrorrightinregion)
 
 ```py
 def mirrorrightinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -6843,7 +6843,7 @@ Mirrors the right-half of
         unsigned byte array
 
 
-### [`mirrortop2file`](#Python_BMP.BITMAPlib.mirrortop2file)
+### [`mirrortop2file`](#mirrortop2file)
 
 ```py
 def mirrortop2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -6861,7 +6861,7 @@ Mirrors the top-half of a bitmap
         new bitmap file
 
 
-### [`mirrortop`](#Python_BMP.BITMAPlib.mirrortop)
+### [`mirrortop`](#mirrortop)
 
 ```py
 def mirrortop(bmp: array.array):
@@ -6878,7 +6878,7 @@ Mirrors the top-half of a bitmap
         unsigned byte array
 
 
-### [`mirrortopincircregion2file`](#Python_BMP.BITMAPlib.mirrortopincircregion2file)
+### [`mirrortopincircregion2file`](#mirrortopincircregion2file)
 
 ```py
 def mirrortopincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -6898,7 +6898,7 @@ Mirror the top-half of a circular area
         new bitmap file
 
 
-### [`mirrortopincircregion`](#Python_BMP.BITMAPlib.mirrortopincircregion)
+### [`mirrortopincircregion`](#mirrortopincircregion)
 
 ```py
 def mirrortopincircregion(bmp: array.array, x: int, y: int, r: int):
@@ -6916,7 +6916,7 @@ Mirror the top-half of a circular area
         byref modified unsigned byte array
 
 
-### [`mirrortopinregion2file`](#Python_BMP.BITMAPlib.mirrortopinregion2file)
+### [`mirrortopinregion2file`](#mirrortopinregion2file)
 
 ```py
 def mirrortopinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -6936,7 +6936,7 @@ Mirrors the top-half region in a rectangular area in a bmp
         new bitmap file
 
 
-### [`mirrortopinregion`](#Python_BMP.BITMAPlib.mirrortopinregion)
+### [`mirrortopinregion`](#mirrortopinregion)
 
 ```py
 def mirrortopinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -6958,7 +6958,7 @@ Mirror the top-half of
         unsigned byte array
 
 
-### [`mirrortopleft2file`](#Python_BMP.BITMAPlib.mirrortopleft2file)
+### [`mirrortopleft2file`](#mirrortopleft2file)
 
 ```py
 def mirrortopleft2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -6976,7 +6976,7 @@ Mirrors the top-left of a bitmap
         new bitmap file
 
 
-### [`mirrortopleft`](#Python_BMP.BITMAPlib.mirrortopleft)
+### [`mirrortopleft`](#mirrortopleft)
 
 ```py
 def mirrortopleft(bmp):
@@ -6994,7 +6994,7 @@ Mirrors the top-left part
         unsigned byte array
 
 
-### [`mirrortopleftincircregion2file`](#Python_BMP.BITMAPlib.mirrortopleftincircregion2file)
+### [`mirrortopleftincircregion2file`](#mirrortopleftincircregion2file)
 
 ```py
 def mirrortopleftincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -7014,7 +7014,7 @@ Mirror the top-left of a circular area
         new bitmap file
 
 
-### [`mirrortopleftincircregion`](#Python_BMP.BITMAPlib.mirrortopleftincircregion)
+### [`mirrortopleftincircregion`](#mirrortopleftincircregion)
 
 ```py
 def mirrortopleftincircregion(bmp: array.array, x: int, y: int, r: int):
@@ -7033,7 +7033,7 @@ Mirror the top-left of a circular area
         byref modified unsigned byte array
 
 
-### [`mirrortopleftinregion2file`](#Python_BMP.BITMAPlib.mirrortopleftinregion2file)
+### [`mirrortopleftinregion2file`](#mirrortopleftinregion2file)
 
 ```py
 def mirrortopleftinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -7053,7 +7053,7 @@ Mirrors the top-left region in a rectangular area in a BMP
         new bitmap file
 
 
-### [`mirrortopleftinregion`](#Python_BMP.BITMAPlib.mirrortopleftinregion)
+### [`mirrortopleftinregion`](#mirrortopleftinregion)
 
 ```py
 def mirrortopleftinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -7075,7 +7075,7 @@ Mirrors the top-left of a
         unsigned byte array
 
 
-### [`mirrortopright2file`](#Python_BMP.BITMAPlib.mirrortopright2file)
+### [`mirrortopright2file`](#mirrortopright2file)
 
 ```py
 def mirrortopright2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -7095,7 +7095,7 @@ Mirrors the top-right of a
         new bitmap file
 
 
-### [`mirrortopright`](#Python_BMP.BITMAPlib.mirrortopright)
+### [`mirrortopright`](#mirrortopright)
 
 ```py
 def mirrortopright(bmp: array.array):
@@ -7113,7 +7113,7 @@ Mirrors the top-right part
         unsigned byte array
 
 
-### [`mirrortoprightincircregion2file`](#Python_BMP.BITMAPlib.mirrortoprightincircregion2file)
+### [`mirrortoprightincircregion2file`](#mirrortoprightincircregion2file)
 
 ```py
 def mirrortoprightincircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -7133,7 +7133,7 @@ Mirror the top-right of a circular area
         new bitmap file
 
 
-### [`mirrortoprightincircregion`](#Python_BMP.BITMAPlib.mirrortoprightincircregion)
+### [`mirrortoprightincircregion`](#mirrortoprightincircregion)
 
 ```py
 def mirrortoprightincircregion(bmp: array.array, x: int, y: int, r: int):
@@ -7151,7 +7151,7 @@ Mirror the top-right of a circular area
         byref modified unsigned byte array
 
 
-### [`mirrortoprightinregion2file`](#Python_BMP.BITMAPlib.mirrortoprightinregion2file)
+### [`mirrortoprightinregion2file`](#mirrortoprightinregion2file)
 
 ```py
 def mirrortoprightinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -7171,7 +7171,7 @@ Mirrors the top-right region in a rectangular area in a BMP
         new bitmap file
 
 
-### [`mirrortoprightinregion`](#Python_BMP.BITMAPlib.mirrortoprightinregion)
+### [`mirrortoprightinregion`](#mirrortoprightinregion)
 
 ```py
 def mirrortoprightinregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -7193,7 +7193,7 @@ Mirrors the top-right of a
         unsigned byte array
 
 
-### [`monochrome2file`](#Python_BMP.BITMAPlib.monochrome2file)
+### [`monochrome2file`](#monochrome2file)
 
 ```py
 def monochrome2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -7211,7 +7211,7 @@ Applies a monochrome filter to a BMP
         new bitmap file
 
 
-### [`monochrome`](#Python_BMP.colors.monochrome)
+### [`monochrome`](#monochrome)
 
 ```py
 def monochrome(rgb: list[int, int, int]) -> list[int, int, int]:
@@ -7229,7 +7229,7 @@ Returns a monochrome color
         [r: byte, g: byte, b: byte]
 
 
-### [`monochromecircregion2file`](#Python_BMP.BITMAPlib.monochromecircregion2file)
+### [`monochromecircregion2file`](#monochromecircregion2file)
 
 ```py
 def monochromecircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -7250,7 +7250,7 @@ Monochrome filter to a circular region
         new bitmap file
 
 
-### [`monochromefiltertoBGRbuf`](#Python_BMP.colors.monochromefiltertoBGRbuf)
+### [`monochromefiltertoBGRbuf`](#monochromefiltertoBGRbuf)
 
 ```py
 def monochromefiltertoBGRbuf(buf: array.array) -> array.array:
@@ -7273,7 +7273,7 @@ Apply a monochrome filter to a
         holding mono BGR data
 
 
-### [`monochromepal`](#Python_BMP.colors.monochromepal)
+### [`monochromepal`](#monochromepal)
 
 ```py
 def monochromepal(bits: int, rgbfactors: list[float, float, float]) -> list[list[int, int, int]]:
@@ -7297,7 +7297,7 @@ Returns a monochrome palette
       list[list[r: int, g: int, b int]]
 
 
-### [`monocircle`](#Python_BMP.BITMAPlib.monocircle)
+### [`monocircle`](#monocircle)
 
 ```py
 def monocircle(bmp: array.array, x: int, y: int, r: int):
@@ -7316,7 +7316,7 @@ Monochrome filter to a circular area
         byref modified unsigned byte array
 
 
-### [`monofilterinregion2file`](#Python_BMP.BITMAPlib.monofilterinregion2file)
+### [`monofilterinregion2file`](#monofilterinregion2file)
 
 ```py
 def monofilterinregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -7337,7 +7337,7 @@ Monochrome filter to rectangular area in a 24-bit BMP
         new bitmap file
 
 
-### [`monofilterto24bitimage`](#Python_BMP.BITMAPlib.monofilterto24bitimage)
+### [`monofilterto24bitimage`](#monofilterto24bitimage)
 
 ```py
 def monofilterto24bitimage(bmp: array.array):
@@ -7355,7 +7355,7 @@ Applies a mono filter
         unsigned byte array
 
 
-### [`monofilterto24bitregion`](#Python_BMP.BITMAPlib.monofilterto24bitregion)
+### [`monofilterto24bitregion`](#monofilterto24bitregion)
 
 ```py
 def monofilterto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -7377,7 +7377,7 @@ Applies a monochrome filter
         unsigned byte array
 
 
-### [`newBMP`](#Python_BMP.BITMAPlib.newBMP)
+### [`newBMP`](#newBMP)
 
 ```py
 def newBMP(x: int, y: int, colorbits: int) -> array.array:
@@ -7395,7 +7395,7 @@ Creates a new in-memory bitmap
         unsigned byte array with bitmap layout
 
 
-### [`numbervert`](#Python_BMP.BITMAPlib.numbervert)
+### [`numbervert`](#numbervert)
 
 ```py
 def numbervert(bmp: array.array, vlist: list[list[int, int]], xadj: int, yadj: int, scale: int, valstart: numbers.Number, valstep: numbers.Number, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, suppresszero: bool, suppresslastnum: bool, rightjustify: bool):
@@ -7406,7 +7406,7 @@ def numbervert(bmp: array.array, vlist: list[list[int, int]], xadj: int, yadj: i
     
 
 
-### [`octahedravert`](#Python_BMP.solids3D.octahedravert)
+### [`octahedravert`](#octahedravert)
 
 ```py
 def octahedravert(x: float) -> list[list[float, float, float]]:
@@ -7424,7 +7424,7 @@ Returns a list of vertices
               z: float)
 
 
-### [`outline2file`](#Python_BMP.BITMAPlib.outline2file)
+### [`outline2file`](#outline2file)
 
 ```py
 def outline2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -7442,7 +7442,7 @@ Applies an outline filter
         new bitmap file
 
 
-### [`outline`](#Python_BMP.BITMAPlib.outline)
+### [`outline`](#outline)
 
 ```py
 def outline(bmp: array.array):
@@ -7458,7 +7458,7 @@ Applies an Outline Filter
         byref modified unsigned byte array
 
 
-### [`outlinecircregion2file`](#Python_BMP.BITMAPlib.outlinecircregion2file)
+### [`outlinecircregion2file`](#outlinecircregion2file)
 
 ```py
 def outlinecircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int):
@@ -7478,7 +7478,7 @@ Outlines area in a circular region
         new bitmap file
 
 
-### [`outlinecircregion`](#Python_BMP.BITMAPlib.outlinecircregion)
+### [`outlinecircregion`](#outlinecircregion)
 
 ```py
 def outlinecircregion(bmp: array.array, x: int, y: int, r: int):
@@ -7497,7 +7497,7 @@ Outlines a circular area
         byref modified unsigned byte array
 
 
-### [`outlineregion2file`](#Python_BMP.BITMAPlib.outlineregion2file)
+### [`outlineregion2file`](#outlineregion2file)
 
 ```py
 def outlineregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int):
@@ -7518,7 +7518,7 @@ Outline filter to rectangular area
         new bitmap file
 
 
-### [`outlineregion`](#Python_BMP.BITMAPlib.outlineregion)
+### [`outlineregion`](#outlineregion)
 
 ```py
 def outlineregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int):
@@ -7538,7 +7538,7 @@ Outines a rectangular region in a BMP
         byref modified unsigned byte array
 
 
-### [`pastecirularbuf`](#Python_BMP.BITMAPlib.pastecirularbuf)
+### [`pastecirularbuf`](#pastecirularbuf)
 
 ```py
 def pastecirularbuf(bmp: array.array, x: int, y: int, circbuf: list):
@@ -7559,7 +7559,7 @@ given radius to a centerpoint at (x, y)
         byref modified unsigned byte array
 
 
-### [`pasterect`](#Python_BMP.BITMAPlib.pasterect)
+### [`pasterect`](#pasterect)
 
 ```py
 def pasterect(bmp: array.array, buf: array.array, x1: int, y1: int):
@@ -7579,7 +7579,7 @@ Paste a rectangular area from a buffer to a bmp
         byref modified unsigned byte array
 
 
-### [`perspective`](#Python_BMP.solids3D.perspective)
+### [`perspective`](#perspective)
 
 ```py
 def perspective(vlist: list[list[numbers.Number, numbers.Number, numbers.Number]], rotvec: list[list[float, float], list[float, float], list[float, float]], dispvec: list[numbers.Number, numbers.Number, numbers.Number], d: float) -> tuple:
@@ -7600,7 +7600,7 @@ Projects 3D points to 2D and
         tuple (list, list)
 
 
-### [`piechart`](#Python_BMP.BITMAPlib.piechart)
+### [`piechart`](#piechart)
 
 ```py
 def piechart(bmp: array.array, x: int, y: int, r: int, dataandcolorlist: list):
@@ -7621,7 +7621,7 @@ Draw a piechart
         byref modified unsigned byte array
 
 
-### [`pixelizenxn`](#Python_BMP.BITMAPlib.pixelizenxn)
+### [`pixelizenxn`](#pixelizenxn)
 
 ```py
 def pixelizenxn(bmp: array.array, n: int) -> array.array:
@@ -7639,7 +7639,7 @@ in which colors are averaged
         byref modified unsigned byte array
 
 
-### [`pixelizenxncircregion2file`](#Python_BMP.BITMAPlib.pixelizenxncircregion2file)
+### [`pixelizenxncircregion2file`](#pixelizenxncircregion2file)
 
 ```py
 def pixelizenxncircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, intpixsize: int):
@@ -7661,7 +7661,7 @@ Apply a Pixel Blur in a circular area
         new bitmap file
 
 
-### [`pixelizenxncircregion`](#Python_BMP.BITMAPlib.pixelizenxncircregion)
+### [`pixelizenxncircregion`](#pixelizenxncircregion)
 
 ```py
 def pixelizenxncircregion(bmp: array.array, x: int, y: int, r: int, n: int):
@@ -7681,7 +7681,7 @@ Pixelize a circular region in a BMP by n
         byref modified unsigned byte array
 
 
-### [`pixelizenxntofile`](#Python_BMP.BITMAPlib.pixelizenxntofile)
+### [`pixelizenxntofile`](#pixelizenxntofile)
 
 ```py
 def pixelizenxntofile(ExistingBMPfile: str, NewBMPfile: str, n: int):
@@ -7699,7 +7699,7 @@ Pixellate a bitmap file with n by n pixel areas
         new bitmap file
 
 
-### [`plot3d`](#Python_BMP.BITMAPlib.plot3d)
+### [`plot3d`](#plot3d)
 
 ```py
 def plot3d(bmp: array.array, sides: list[list, list], issolid: bool, RGBfactors: list[float, float], showoutline: bool, outlinecolor: int):
@@ -7726,7 +7726,7 @@ The 3D rendering function
         byref modified unsigned byte array
 
 
-### [`plot3Dsolid`](#Python_BMP.BITMAPlib.plot3Dsolid)
+### [`plot3Dsolid`](#plot3Dsolid)
 
 ```py
 def plot3Dsolid(bmp: array.array, vertandsides: list[list, list], issolid: bool, RGBfactors: list[float, float, float], showoutline: bool, outlinecolor: int, rotvect: list[float, float, float], transvect3D: list[float, float, float], d: int, transvect: list[int, int]):
@@ -7763,7 +7763,7 @@ def plot3Dsolid(bmp: array.array, vertandsides: list[list, list], issolid: bool,
         byref modified unsigned byte array
 
 
-### [`plot8bitpattern`](#Python_BMP.BITMAPlib.plot8bitpattern)
+### [`plot8bitpattern`](#plot8bitpattern)
 
 ```py
 def plot8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -7788,7 +7788,7 @@ Draws a 8-bit pattern
         byref modified unsigned byte array
 
 
-### [`plot8bitpatternasdots`](#Python_BMP.BITMAPlib.plot8bitpatternasdots)
+### [`plot8bitpatternasdots`](#plot8bitpatternasdots)
 
 ```py
 def plot8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -7814,7 +7814,7 @@ Draws a 8-bit pattern as circles
         byref modified unsigned byte array
 
 
-### [`plot8bitpatternastext`](#Python_BMP.textgraphics.plot8bitpatternastext)
+### [`plot8bitpatternastext`](#plot8bitpatternastext)
 
 ```py
 def plot8bitpatternastext(bitpattern: list[int], onechar: str, zerochar: str):
@@ -7834,7 +7834,7 @@ Outputs the bits of a list
         console output
 
 
-### [`plot8bitpatternsideway`](#Python_BMP.BITMAPlib.plot8bitpatternsideway)
+### [`plot8bitpatternsideway`](#plot8bitpatternsideway)
 
 ```py
 def plot8bitpatternsideway(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -7859,7 +7859,7 @@ Draws a 8-bit pattern sideways
         byref modified unsigned byte array
 
 
-### [`plot8bitpatternsidewaywithdots`](#Python_BMP.BITMAPlib.plot8bitpatternsidewaywithdots)
+### [`plot8bitpatternsidewaywithdots`](#plot8bitpatternsidewaywithdots)
 
 ```py
 def plot8bitpatternsidewaywithdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -7884,7 +7884,7 @@ Draws a 8-bit pattern sideways with dots
         byref modified unsigned byte array
 
 
-### [`plot8bitpatternsidewaywithfn`](#Python_BMP.BITMAPlib.plot8bitpatternsidewaywithfn)
+### [`plot8bitpatternsidewaywithfn`](#plot8bitpatternsidewaywithfn)
 
 ```py
 def plot8bitpatternsidewaywithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
@@ -7909,7 +7909,7 @@ Draws a 8-bit pattern sideways with a function
         byref modified unsigned byte array
 
 
-### [`plot8bitpatternupsidedown`](#Python_BMP.BITMAPlib.plot8bitpatternupsidedown)
+### [`plot8bitpatternupsidedown`](#plot8bitpatternupsidedown)
 
 ```py
 def plot8bitpatternupsidedown(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -7935,7 +7935,7 @@ Draws a 8-bit pattern upsidedown
         byref modified unsigned byte array
 
 
-### [`plot8bitpatternupsidedownasdots`](#Python_BMP.BITMAPlib.plot8bitpatternupsidedownasdots)
+### [`plot8bitpatternupsidedownasdots`](#plot8bitpatternupsidedownasdots)
 
 ```py
 def plot8bitpatternupsidedownasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -7960,7 +7960,7 @@ Draws a 8-bit pattern upsidedown with dots
         byref modified unsigned byte array
 
 
-### [`plot8bitpatternupsidedownwithfn`](#Python_BMP.BITMAPlib.plot8bitpatternupsidedownwithfn)
+### [`plot8bitpatternupsidedownwithfn`](#plot8bitpatternupsidedownwithfn)
 
 ```py
 def plot8bitpatternupsidedownwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
@@ -7986,7 +7986,7 @@ Draws a 8-bit pattern upsidedown with a function
         byref modified unsigned byte array
 
 
-### [`plot8bitpatternwithfn`](#Python_BMP.BITMAPlib.plot8bitpatternwithfn)
+### [`plot8bitpatternwithfn`](#plot8bitpatternwithfn)
 
 ```py
 def plot8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
@@ -8012,7 +8012,7 @@ def plot8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, sc
         byref modified unsigned byte array
 
 
-### [`plotbitsastext`](#Python_BMP.textgraphics.plotbitsastext)
+### [`plotbitsastext`](#plotbitsastext)
 
 ```py
 def plotbitsastext(bits: int):
@@ -8029,7 +8029,7 @@ Outputs the bits of byte to
         *     for 1
 
 
-### [`plotbmpastext`](#Python_BMP.BITMAPlib.plotbmpastext)
+### [`plotbmpastext`](#plotbmpastext)
 
 ```py
 def plotbmpastext(bmp: array.array):
@@ -8047,7 +8047,7 @@ Plot a bitmap as text
         for debug and ascii art
 
 
-### [`plotcircinsqr`](#Python_BMP.BITMAPlib.plotcircinsqr)
+### [`plotcircinsqr`](#plotcircinsqr)
 
 ```py
 def plotcircinsqr(bmp, x, y, d, color):
@@ -8071,7 +8071,7 @@ Draws a circle in an
         byref modified unsigned byte array
 
 
-### [`plotfilledflower`](#Python_BMP.BITMAPlib.plotfilledflower)
+### [`plotfilledflower`](#plotfilledflower)
 
 ```py
 def plotfilledflower(bmp: array.array, cx: int, cy: int, r: int, petals: float, angrot: float, lumrange: list[int, int], RGBfactors: list[float, float, float]):
@@ -8097,7 +8097,7 @@ Draw a filled flower
         byref modified unsigned byte array
 
 
-### [`plotflower`](#Python_BMP.BITMAPlib.plotflower)
+### [`plotflower`](#plotflower)
 
 ```py
 def plotflower(bmp: array.array, cx: int, cy: int, r: int, petals: float, angrot: float, lumrange: list[int, int], RGBfactors: list[float, float, float]):
@@ -8123,7 +8123,7 @@ Draw a flower
         byref modified unsigned byte array
 
 
-### [`plotimgedges`](#Python_BMP.BITMAPlib.plotimgedges)
+### [`plotimgedges`](#plotimgedges)
 
 ```py
 def plotimgedges(bmp: array.array, similaritythreshold: int, edgeradius: int, edgecolor: int):
@@ -8151,7 +8151,7 @@ Draw edges
         byref modified unsigned byte array
 
 
-### [`plotitalic8bitpattern`](#Python_BMP.BITMAPlib.plotitalic8bitpattern)
+### [`plotitalic8bitpattern`](#plotitalic8bitpattern)
 
 ```py
 def plotitalic8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -8177,7 +8177,7 @@ Draws a 8-bit italic pattern
         byref modified unsigned byte array
 
 
-### [`plotitalic8bitpatternasdots`](#Python_BMP.BITMAPlib.plotitalic8bitpatternasdots)
+### [`plotitalic8bitpatternasdots`](#plotitalic8bitpatternasdots)
 
 ```py
 def plotitalic8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -8202,7 +8202,7 @@ Draws a 8-bit italic pattern as dots
         byref modified unsigned byte array
 
 
-### [`plotitalic8bitpatternsideway`](#Python_BMP.BITMAPlib.plotitalic8bitpatternsideway)
+### [`plotitalic8bitpatternsideway`](#plotitalic8bitpatternsideway)
 
 ```py
 def plotitalic8bitpatternsideway(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -8227,7 +8227,7 @@ Draws an italic 8-bit pattern sideways
         byref modified unsigned byte array
 
 
-### [`plotitalic8bitpatternsidewayasdots`](#Python_BMP.BITMAPlib.plotitalic8bitpatternsidewayasdots)
+### [`plotitalic8bitpatternsidewayasdots`](#plotitalic8bitpatternsidewayasdots)
 
 ```py
 def plotitalic8bitpatternsidewayasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -8252,7 +8252,7 @@ Draws an italic 8-bit pattern sideways as dots
         byref modified unsigned byte array
 
 
-### [`plotitalic8bitpatternsidewaywithfn`](#Python_BMP.BITMAPlib.plotitalic8bitpatternsidewaywithfn)
+### [`plotitalic8bitpatternsidewaywithfn`](#plotitalic8bitpatternsidewaywithfn)
 
 ```py
 def plotitalic8bitpatternsidewaywithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
@@ -8277,7 +8277,7 @@ Draws an Italic 8-bit pattern sideways with a function
         byref modified unsigned byte array
 
 
-### [`plotitalic8bitpatternupdsidedownasdots`](#Python_BMP.BITMAPlib.plotitalic8bitpatternupdsidedownasdots)
+### [`plotitalic8bitpatternupdsidedownasdots`](#plotitalic8bitpatternupdsidedownasdots)
 
 ```py
 def plotitalic8bitpatternupdsidedownasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -8302,7 +8302,7 @@ Draws a 8-bit italic pattern upsidedown as dots
         byref modified unsigned byte array
 
 
-### [`plotitalic8bitpatternupsidedownwithfn`](#Python_BMP.BITMAPlib.plotitalic8bitpatternupsidedownwithfn)
+### [`plotitalic8bitpatternupsidedownwithfn`](#plotitalic8bitpatternupsidedownwithfn)
 
 ```py
 def plotitalic8bitpatternupsidedownwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
@@ -8328,7 +8328,7 @@ Italic 8-bit pattern upsidedown with a function
         byref modified unsigned byte array
 
 
-### [`plotitalic8bitpatternwithfn`](#Python_BMP.BITMAPlib.plotitalic8bitpatternwithfn)
+### [`plotitalic8bitpatternwithfn`](#plotitalic8bitpatternwithfn)
 
 ```py
 def plotitalic8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
@@ -8354,7 +8354,7 @@ Italic 8-bit pattern with a function
         byref modified unsigned byte array
 
 
-### [`plotitalicstring`](#Python_BMP.BITMAPlib.plotitalicstring)
+### [`plotitalicstring`](#plotitalicstring)
 
 ```py
 def plotitalicstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -8385,7 +8385,7 @@ Draws a string as Italic
         byref modified unsigned byte array
 
 
-### [`plotitalicstringasdots`](#Python_BMP.BITMAPlib.plotitalicstringasdots)
+### [`plotitalicstringasdots`](#plotitalicstringasdots)
 
 ```py
 def plotitalicstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -8416,7 +8416,7 @@ Draws a string as Italic dots
         byref modified unsigned byte array
 
 
-### [`plotitalicstringsideway`](#Python_BMP.BITMAPlib.plotitalicstringsideway)
+### [`plotitalicstringsideway`](#plotitalicstringsideway)
 
 ```py
 def plotitalicstringsideway(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -8449,7 +8449,7 @@ Draws an Italic String Sideways
         byref modified unsigned byte array
 
 
-### [`plotitalicstringsidewayasdots`](#Python_BMP.BITMAPlib.plotitalicstringsidewayasdots)
+### [`plotitalicstringsidewayasdots`](#plotitalicstringsidewayasdots)
 
 ```py
 def plotitalicstringsidewayasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -8479,7 +8479,7 @@ Draws an italic string sideways as dots
         byref modified unsigned byte array
 
 
-### [`plotitalicstringvertical`](#Python_BMP.BITMAPlib.plotitalicstringvertical)
+### [`plotitalicstringvertical`](#plotitalicstringvertical)
 
 ```py
 def plotitalicstringvertical(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -8509,7 +8509,7 @@ Draws an italic string vertically with dots
         byref modified unsigned byte array
 
 
-### [`plotitalicstringverticalasdots`](#Python_BMP.BITMAPlib.plotitalicstringverticalasdots)
+### [`plotitalicstringverticalasdots`](#plotitalicstringverticalasdots)
 
 ```py
 def plotitalicstringverticalasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -8539,7 +8539,7 @@ Draws an italic string vertically with dots
         byref modified unsigned byte array
 
 
-### [`plotlines`](#Python_BMP.BITMAPlib.plotlines)
+### [`plotlines`](#plotlines)
 
 ```py
 def plotlines(bmp: array.array, vertlist: list, color: int):
@@ -8558,7 +8558,7 @@ Draws connected lines defined by a list of vertices
         byref modified unsigned byte array
 
 
-### [`plotpoly`](#Python_BMP.BITMAPlib.plotpoly)
+### [`plotpoly`](#plotpoly)
 
 ```py
 def plotpoly(bmp: array.array, vertlist: list, color: int):
@@ -8577,7 +8577,7 @@ Draws a polygon defined by a list of vertices
         byref modified unsigned byte array
 
 
-### [`plotpolyfill`](#Python_BMP.BITMAPlib.plotpolyfill)
+### [`plotpolyfill`](#plotpolyfill)
 
 ```py
 def plotpolyfill(bmp: array.array, vertlist: list[list[numbers.Number, numbers.Number]], color: int):
@@ -8597,7 +8597,7 @@ Draws a filled polygon with a given color
         byref modified unsigned byte array
 
 
-### [`plotpolyfillist`](#Python_BMP.BITMAPlib.plotpolyfillist)
+### [`plotpolyfillist`](#plotpolyfillist)
 
 ```py
 def plotpolyfillist(bmp: array.array, sides: list[list[list[list]], list[list[float, float, float]]], RGBfactors: list[float, float]):
@@ -8619,7 +8619,7 @@ def plotpolyfillist(bmp: array.array, sides: list[list[list[list]], list[list[fl
         byref modified unsigned byte array
 
 
-### [`plotpolylist`](#Python_BMP.BITMAPlib.plotpolylist)
+### [`plotpolylist`](#plotpolylist)
 
 ```py
 def plotpolylist(bmp: array.array, polylist: list, color: int):
@@ -8639,7 +8639,7 @@ Draws a list of polygons of a given color
         byref modified unsigned byte array
 
 
-### [`plotreverseditalic8bitpattern`](#Python_BMP.BITMAPlib.plotreverseditalic8bitpattern)
+### [`plotreverseditalic8bitpattern`](#plotreverseditalic8bitpattern)
 
 ```py
 def plotreverseditalic8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -8664,7 +8664,7 @@ Draws a 8-bit reversed italic pattern
         byref modified unsigned byte array
 
 
-### [`plotreverseditalic8bitpatternasdots`](#Python_BMP.BITMAPlib.plotreverseditalic8bitpatternasdots)
+### [`plotreverseditalic8bitpatternasdots`](#plotreverseditalic8bitpatternasdots)
 
 ```py
 def plotreverseditalic8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -8689,7 +8689,7 @@ Draws a 8-bit reversed italic pattern as dots
         byref modified unsigned byte array
 
 
-### [`plotreverseditalicstring`](#Python_BMP.BITMAPlib.plotreverseditalicstring)
+### [`plotreverseditalicstring`](#plotreverseditalicstring)
 
 ```py
 def plotreverseditalicstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -8718,7 +8718,7 @@ Draws a reversed string as Italic
         byref modified unsigned byte array
 
 
-### [`plotreverseditalicstringasdots`](#Python_BMP.BITMAPlib.plotreverseditalicstringasdots)
+### [`plotreverseditalicstringasdots`](#plotreverseditalicstringasdots)
 
 ```py
 def plotreverseditalicstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -8749,7 +8749,7 @@ Draws a Reversed String as Italic dots
         byref modified unsigned byte array
 
 
-### [`plotreversestring`](#Python_BMP.BITMAPlib.plotreversestring)
+### [`plotreversestring`](#plotreversestring)
 
 ```py
 def plotreversestring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -8779,7 +8779,7 @@ Draws a string reversed
         byref modified unsigned byte array
 
 
-### [`plotreversestringasdots`](#Python_BMP.BITMAPlib.plotreversestringasdots)
+### [`plotreversestringasdots`](#plotreversestringasdots)
 
 ```py
 def plotreversestringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -8809,7 +8809,7 @@ Draws a string reversed with dots
         byref modified unsigned byte array
 
 
-### [`plotRGBxybit`](#Python_BMP.BITMAPlib.plotRGBxybit)
+### [`plotRGBxybit`](#plotRGBxybit)
 
 ```py
 def plotRGBxybit(bmp: array.array, x: int, y: int, rgb: list):
@@ -8829,7 +8829,7 @@ Sets pixel at (x, y) in a bitmap to color [R, G, B]
         byref modified unsigned byte array
 
 
-### [`plotRGBxybitvec`](#Python_BMP.BITMAPlib.plotRGBxybitvec)
+### [`plotRGBxybitvec`](#plotRGBxybitvec)
 
 ```py
 def plotRGBxybitvec(bmp: array.array, v: list, rgb: list):
@@ -8849,7 +8849,7 @@ Sets [R, G, B] of pixel at (x, y)
         byref modified unsigned byte array
 
 
-### [`plotrotated8bitpattern`](#Python_BMP.BITMAPlib.plotrotated8bitpattern)
+### [`plotrotated8bitpattern`](#plotrotated8bitpattern)
 
 ```py
 def plotrotated8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -8875,7 +8875,7 @@ Draws a 8-bit pattern with the bits rotated
         byref modified unsigned byte array
 
 
-### [`plotrotated8bitpatternwithdots`](#Python_BMP.BITMAPlib.plotrotated8bitpatternwithdots)
+### [`plotrotated8bitpatternwithdots`](#plotrotated8bitpatternwithdots)
 
 ```py
 def plotrotated8bitpatternwithdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -8901,7 +8901,7 @@ Draws a 8-bit pattern with the bits rotated
         byref modified unsigned byte array
 
 
-### [`plotrotated8bitpatternwithfn`](#Python_BMP.BITMAPlib.plotrotated8bitpatternwithfn)
+### [`plotrotated8bitpatternwithfn`](#plotrotated8bitpatternwithfn)
 
 ```py
 def plotrotated8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
@@ -8927,7 +8927,7 @@ the bits rotated with a function
         byref modified unsigned byte array
 
 
-### [`plotrotateditalic8bitpatternwithfn`](#Python_BMP.BITMAPlib.plotrotateditalic8bitpatternwithfn)
+### [`plotrotateditalic8bitpatternwithfn`](#plotrotateditalic8bitpatternwithfn)
 
 ```py
 def plotrotateditalic8bitpatternwithfn(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int, fn: Callable):
@@ -8954,7 +8954,7 @@ with a function
         byref modified unsigned byte array
 
 
-### [`plotstring`](#Python_BMP.BITMAPlib.plotstring)
+### [`plotstring`](#plotstring)
 
 ```py
 def plotstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -8988,7 +8988,7 @@ Draws a string
         byref modified unsigned byte array
 
 
-### [`plotstringasdots`](#Python_BMP.BITMAPlib.plotstringasdots)
+### [`plotstringasdots`](#plotstringasdots)
 
 ```py
 def plotstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -9017,7 +9017,7 @@ Draws a string as Dots
         byref modified unsigned byte array
 
 
-### [`plotstringfunc`](#Python_BMP.BITMAPlib.plotstringfunc)
+### [`plotstringfunc`](#plotstringfunc)
 
 ```py
 def plotstringfunc(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, orderfunc: Callable, fontrenderfunc: Callable):
@@ -9053,7 +9053,7 @@ Draws a string
         byref modified unsigned byte array
 
 
-### [`plotstringsideway`](#Python_BMP.BITMAPlib.plotstringsideway)
+### [`plotstringsideway`](#plotstringsideway)
 
 ```py
 def plotstringsideway(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -9083,7 +9083,7 @@ Draws a string sideways
         byref modified unsigned byte array
 
 
-### [`plotstringsidewayasdots`](#Python_BMP.BITMAPlib.plotstringsidewayasdots)
+### [`plotstringsidewayasdots`](#plotstringsidewayasdots)
 
 ```py
 def plotstringsidewayasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -9113,7 +9113,7 @@ Draws a string sideways as dots
         byref modified unsigned byte array
 
 
-### [`plotstringsidewayfn`](#Python_BMP.BITMAPlib.plotstringsidewayfn)
+### [`plotstringsidewayfn`](#plotstringsidewayfn)
 
 ```py
 def plotstringsidewayfn(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, fn: Callable):
@@ -9143,7 +9143,7 @@ Draws a string sideways with a function
         byref modified unsigned byte array
 
 
-### [`plotstringupsidedown`](#Python_BMP.BITMAPlib.plotstringupsidedown)
+### [`plotstringupsidedown`](#plotstringupsidedown)
 
 ```py
 def plotstringupsidedown(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -9173,7 +9173,7 @@ Draws a string upsidedown
         byref modified unsigned byte array
 
 
-### [`plotstringupsidedownasdots`](#Python_BMP.BITMAPlib.plotstringupsidedownasdots)
+### [`plotstringupsidedownasdots`](#plotstringupsidedownasdots)
 
 ```py
 def plotstringupsidedownasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -9202,7 +9202,7 @@ Draws a string upsidedown as dots
         byref modified unsigned byte array
 
 
-### [`plotstringvertical`](#Python_BMP.BITMAPlib.plotstringvertical)
+### [`plotstringvertical`](#plotstringvertical)
 
 ```py
 def plotstringvertical(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -9232,7 +9232,7 @@ Draws a string vertically
         byref modified unsigned byte array
 
 
-### [`plotstringverticalasdots`](#Python_BMP.BITMAPlib.plotstringverticalasdots)
+### [`plotstringverticalasdots`](#plotstringverticalasdots)
 
 ```py
 def plotstringverticalasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -9262,7 +9262,7 @@ Draws a string vertically with dots
         byref modified unsigned byte array
 
 
-### [`plotstringverticalwithfn`](#Python_BMP.BITMAPlib.plotstringverticalwithfn)
+### [`plotstringverticalwithfn`](#plotstringverticalwithfn)
 
 ```py
 def plotstringverticalwithfn(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list, fn: Callable):
@@ -9292,7 +9292,7 @@ Draws a string vertically using a function
         byref modified unsigned byte array
 
 
-### [`plotupsidedownitalic8bitpattern`](#Python_BMP.BITMAPlib.plotupsidedownitalic8bitpattern)
+### [`plotupsidedownitalic8bitpattern`](#plotupsidedownitalic8bitpattern)
 
 ```py
 def plotupsidedownitalic8bitpattern(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -9317,7 +9317,7 @@ Draws a 8-bit italic pattern upsidedown
         byref modified unsigned byte array
 
 
-### [`plotupsidedownitalic8bitpatternasdots`](#Python_BMP.BITMAPlib.plotupsidedownitalic8bitpatternasdots)
+### [`plotupsidedownitalic8bitpatternasdots`](#plotupsidedownitalic8bitpatternasdots)
 
 ```py
 def plotupsidedownitalic8bitpatternasdots(bmp: array.array, x: int, y: int, bitpattern: list, scale: int, pixspace: int, color: int):
@@ -9342,7 +9342,7 @@ Draws a 8-bit italic pattern upsidedown as dots
         byref modified unsigned byte array
 
 
-### [`plotupsidedownitalicstring`](#Python_BMP.BITMAPlib.plotupsidedownitalicstring)
+### [`plotupsidedownitalicstring`](#plotupsidedownitalicstring)
 
 ```py
 def plotupsidedownitalicstring(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -9373,7 +9373,7 @@ Draw an italic string upsidedown
         byref modified unsigned byte array
 
 
-### [`plotupsidedownitalicstringasdots`](#Python_BMP.BITMAPlib.plotupsidedownitalicstringasdots)
+### [`plotupsidedownitalicstringasdots`](#plotupsidedownitalicstringasdots)
 
 ```py
 def plotupsidedownitalicstringasdots(bmp: array.array, x: int, y: int, str2plot: str, scale: int, pixspace: int, spacebetweenchar: int, color: int, fontbuf: list):
@@ -9404,7 +9404,7 @@ Draw an italic string upsidedown as dots
         byref modified unsigned byte array
 
 
-### [`plotvecxypoint`](#Python_BMP.BITMAPlib.plotvecxypoint)
+### [`plotvecxypoint`](#plotvecxypoint)
 
 ```py
 def plotvecxypoint(bmp: array.array, v: list, c: int):
@@ -9427,7 +9427,7 @@ Sets the color of a pixel
         unsigned byte array
 
 
-### [`plotxybit`](#Python_BMP.BITMAPlib.plotxybit)
+### [`plotxybit`](#plotxybit)
 
 ```py
 def plotxybit(bmp: array.array, x: int, y: int, c: int):
@@ -9446,7 +9446,7 @@ Sets pixel at (x, y) in a bitmap to color c
         byref modified unsigned byte array
 
 
-### [`plotxypointlist`](#Python_BMP.BITMAPlib.plotxypointlist)
+### [`plotxypointlist`](#plotxypointlist)
 
 ```py
 def plotxypointlist(bmp: array.array, vlist: list, penradius: int, color: int):
@@ -9470,7 +9470,7 @@ all points in a point list
         byref modified unsigned byte array
 
 
-### [`polar2rectcoord2D`](#Python_BMP.mathlib.polar2rectcoord2D)
+### [`polar2rectcoord2D`](#polar2rectcoord2D)
 
 ```py
 def polar2rectcoord2D(vpolarcoord: list[float, float]) -> list[float, float]:
@@ -9488,7 +9488,7 @@ origin at (0, 0) to 2D rectangular coordinates
          y: float]
 
 
-### [`polyboundary`](#Python_BMP.solids3D.polyboundary)
+### [`polyboundary`](#polyboundary)
 
 ```py
 def polyboundary(vertlist: list[list[int, int]]) -> list[list[int, int]]:
@@ -9508,7 +9508,7 @@ Generates a polygon boundary
         the boundaries of the polygon
 
 
-### [`probplotRGBto1bit`](#Python_BMP.colors.probplotRGBto1bit)
+### [`probplotRGBto1bit`](#probplotRGBto1bit)
 
 ```py
 def probplotRGBto1bit(rgb: list[int, int, int], brightness: int) -> int:
@@ -9528,7 +9528,7 @@ Use a non deterministic plot
         0 or 1
 
 
-### [`range2baseanddelta`](#Python_BMP.mathlib.range2baseanddelta)
+### [`range2baseanddelta`](#range2baseanddelta)
 
 ```py
 def range2baseanddelta(lst_range: list[int, int]):
@@ -9545,7 +9545,7 @@ Gets the base and range values in a list of numbers
         in lst_range
 
 
-### [`readint`](#Python_BMP.inttools.readint)
+### [`readint`](#readint)
 
 ```py
 def readint(offset: int, cnt: int, arr: int) -> int:
@@ -9567,7 +9567,7 @@ Reads an integer value in an
         unsigned int value
 
 
-### [`rectangle2file`](#Python_BMP.BITMAPlib.rectangle2file)
+### [`rectangle2file`](#rectangle2file)
 
 ```py
 def rectangle2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, color: int):
@@ -9588,7 +9588,7 @@ Draws a Rectangle
         new bitmap file
 
 
-### [`rectangle`](#Python_BMP.BITMAPlib.rectangle)
+### [`rectangle`](#rectangle)
 
 ```py
 def rectangle(bmp: array.array, x1: int, y1: int, x2: int, y2: int, color: int):
@@ -9609,7 +9609,7 @@ Draws a Rectangle
         byref modified unsigned byte array
 
 
-### [`rectboundarycoords`](#Python_BMP.primitives2D.rectboundarycoords)
+### [`rectboundarycoords`](#rectboundarycoords)
 
 ```py
 def rectboundarycoords(vlist: list) -> list:
@@ -9625,7 +9625,7 @@ Returns the rectangular bounds of a list of 2D vertices
          (max(x), max(y)))
 
 
-### [`recvert`](#Python_BMP.primitives2D.recvert)
+### [`recvert`](#recvert)
 
 ```py
 def recvert(x1: int, y1: int, x2: int, y2: int) -> list[list[int, int], list[int, int], list[int, int], list[int, int]]:
@@ -9642,7 +9642,7 @@ Creates a list of vertices for a rectangle
          (x2, y2), (x1, y2)]
 
 
-### [`reduce24bitimagebits`](#Python_BMP.BITMAPlib.reduce24bitimagebits)
+### [`reduce24bitimagebits`](#reduce24bitimagebits)
 
 ```py
 def reduce24bitimagebits(Existing24BMPfile: str, NewBMPfile: str, newbits: int, similaritythreshold: float, usemonopal: bool, RGBfactors: list[float, float, float] = None):
@@ -9674,7 +9674,7 @@ Reduce bits used to encode color in a 24-bit BMP
         new bitmap file
 
 
-### [`regpolygonvert`](#Python_BMP.primitives2D.regpolygonvert)
+### [`regpolygonvert`](#regpolygonvert)
 
 ```py
 def regpolygonvert(cx: int, cy: int, r: int, sides: int, angle: float) -> list[list[int, int]]:
@@ -9698,7 +9698,7 @@ Creates a list of int vertices for a regular polygon
         [(x, y), ...]
 
 
-### [`resizebufNtimesbigger`](#Python_BMP.bufresize.resizebufNtimesbigger)
+### [`resizebufNtimesbigger`](#resizebufNtimesbigger)
 
 ```py
 def resizebufNtimesbigger(buf: array.array, n: int, bits: int) -> array.array:
@@ -9718,7 +9718,7 @@ Resize a buffer n times bigger
         list
 
 
-### [`resizeNtimesbigger2file`](#Python_BMP.BITMAPlib.resizeNtimesbigger2file)
+### [`resizeNtimesbigger2file`](#resizeNtimesbigger2file)
 
 ```py
 def resizeNtimesbigger2file(ExistingBMPfile: str, NewBMPfile: str, n: int):
@@ -9736,7 +9736,7 @@ Resize a bitmap file n times bigger
         new bitmap file
 
 
-### [`resizeNtimesbigger`](#Python_BMP.BITMAPlib.resizeNtimesbigger)
+### [`resizeNtimesbigger`](#resizeNtimesbigger)
 
 ```py
 def resizeNtimesbigger(bmp: array.array, n: int):
@@ -9756,7 +9756,7 @@ Resize an in-memory bmp
         unsigned byte array
 
 
-### [`resizeNtimessmaller2file`](#Python_BMP.BITMAPlib.resizeNtimessmaller2file)
+### [`resizeNtimessmaller2file`](#resizeNtimessmaller2file)
 
 ```py
 def resizeNtimessmaller2file(ExistingBMPfile: str, NewBMPfile: str, n: int):
@@ -9774,7 +9774,7 @@ Resize a bitmap file n times smaller
         new bitmap file
 
 
-### [`resizeNtimessmaller`](#Python_BMP.BITMAPlib.resizeNtimessmaller)
+### [`resizeNtimessmaller`](#resizeNtimessmaller)
 
 ```py
 def resizeNtimessmaller(bmp: array.array, n: int) -> array.array:
@@ -9791,7 +9791,7 @@ Resize a whole image int n times smaller
         byref modified unsigned byte array
 
 
-### [`resizesmaller24bitbuf`](#Python_BMP.bufresize.resizesmaller24bitbuf)
+### [`resizesmaller24bitbuf`](#resizesmaller24bitbuf)
 
 ```py
 def resizesmaller24bitbuf(buf: array.array) -> array.array:
@@ -9808,7 +9808,7 @@ Resize a 24-bit buffer
         unsigned byte array
 
 
-### [`RGB2BGRarr`](#Python_BMP.colors.RGB2BGRarr)
+### [`RGB2BGRarr`](#RGB2BGRarr)
 
 ```py
 def RGB2BGRarr(r: int, g: int, b: int) -> array.array:
@@ -9825,7 +9825,7 @@ Returns a bgr array from
         unsigned byte BGR array
 
 
-### [`RGB2BGRbuf`](#Python_BMP.colors.RGB2BGRbuf)
+### [`RGB2BGRbuf`](#RGB2BGRbuf)
 
 ```py
 def RGB2BGRbuf(buf: array.array):
@@ -9843,7 +9843,7 @@ Convert an RGB buffer
         holding BGR data
 
 
-### [`RGB2HSL`](#Python_BMP.colors.RGB2HSL)
+### [`RGB2HSL`](#RGB2HSL)
 
 ```py
 def RGB2HSL(r: int, g: int, b: int) -> list[int, int, int]:
@@ -9862,7 +9862,7 @@ Converts an RGB value to HSL
          lum: int]  ->  percentage
 
 
-### [`RGB2int`](#Python_BMP.colors.RGB2int)
+### [`RGB2int`](#RGB2int)
 
 ```py
 def RGB2int(r: int, g: int, b: int) -> int:
@@ -9880,7 +9880,7 @@ Pack byte r, g and b color value
         int color val
 
 
-### [`RGBfactors2RGB`](#Python_BMP.colors.RGBfactors2RGB)
+### [`RGBfactors2RGB`](#RGBfactors2RGB)
 
 ```py
 def RGBfactors2RGB(RGBfactors: list[float, float, float], bytelum: int) -> list[int, int, int]:
@@ -9906,7 +9906,7 @@ Mix a byte luminosity value to
         [r: byte, g: byte, b: byte]
 
 
-### [`RGBfactorstoBaseandRange`](#Python_BMP.colors.RGBfactorstoBaseandRange)
+### [`RGBfactorstoBaseandRange`](#RGBfactorstoBaseandRange)
 
 ```py
 def RGBfactorstoBaseandRange(lumrange: list[int, int], rgbfactors: list[float, float, float]):
@@ -9935,7 +9935,7 @@ Get base color luminosity and
         [r: byte, g: byte, b: byte]
 
 
-### [`RGBpalbrightnessadjust`](#Python_BMP.BITMAPlib.RGBpalbrightnessadjust)
+### [`RGBpalbrightnessadjust`](#RGBpalbrightnessadjust)
 
 ```py
 def RGBpalbrightnessadjust(bmp: array.array, percentadj: float) -> list:
@@ -9955,7 +9955,7 @@ a destination unsigned byte array
         list of modified RGB values
 
 
-### [`rotatebits`](#Python_BMP.mathlib.rotatebits)
+### [`rotatebits`](#rotatebits)
 
 ```py
 def rotatebits(bits: int) -> int:
@@ -9970,7 +9970,7 @@ Rotates the bits in a byte
         int value of rotated 8 bits
 
 
-### [`rotatebitsinbuf`](#Python_BMP.bufferflip.rotatebitsinbuf)
+### [`rotatebitsinbuf`](#rotatebitsinbuf)
 
 ```py
 def rotatebitsinbuf(buf: array.array) -> array.array:
@@ -9986,7 +9986,7 @@ Does a bit rotate to the bytes
         unsigned byte array
 
 
-### [`rotvec3D`](#Python_BMP.solids3D.rotvec3D)
+### [`rotvec3D`](#rotvec3D)
 
 ```py
 def rotvec3D(roll: float, pitch: float, yaw: float) -> tuple:
@@ -10004,7 +10004,7 @@ Returns a 3D rotation vector
                (float, float))
 
 
-### [`roundpen`](#Python_BMP.BITMAPlib.roundpen)
+### [`roundpen`](#roundpen)
 
 ```py
 def roundpen(bmp: array.array, point: list, penradius: int, color: int):
@@ -10027,7 +10027,7 @@ with a given color
         byref modified unsigned byte array
 
 
-### [`roundvect`](#Python_BMP.mathlib.roundvect)
+### [`roundvect`](#roundvect)
 
 ```py
 def roundvect(v: list[numbers.Number]) -> list[int]:
@@ -10043,7 +10043,7 @@ Rounds off the components of a vector
         list of ints
 
 
-### [`saveBMP`](#Python_BMP.BITMAPlib.saveBMP)
+### [`saveBMP`](#saveBMP)
 
 ```py
 def saveBMP(filename: str, bmp: array.array):
@@ -10061,7 +10061,7 @@ Saves bitmap to file
         A Bitmap File
 
 
-### [`setBMP2monochrome`](#Python_BMP.BITMAPlib.setBMP2monochrome)
+### [`setBMP2monochrome`](#setBMP2monochrome)
 
 ```py
 def setBMP2monochrome(bmp: array.array, RGBfactors: list[float, float, float]) -> list:
@@ -10081,7 +10081,7 @@ Sets a bitmap to use a monochrome palette
         byref modified byte array
 
 
-### [`setBMPimgbytes`](#Python_BMP.BITMAPlib.setBMPimgbytes)
+### [`setBMPimgbytes`](#setBMPimgbytes)
 
 ```py
 def setBMPimgbytes(bmp: array.array, buf: array.array):
@@ -10098,7 +10098,7 @@ Sets the raw image buffer of a bitmap
         byref modified  unsigned byte array
 
 
-### [`setbmppal`](#Python_BMP.BITMAPlib.setbmppal)
+### [`setbmppal`](#setbmppal)
 
 ```py
 def setbmppal(bmp: array.array, pallist: list):
@@ -10117,7 +10117,7 @@ Sets the RGB palette of a bitmap
         byref modified unsigned byte array
 
 
-### [`setmax`](#Python_BMP.mathlib.setmax)
+### [`setmax`](#setmax)
 
 ```py
 def setmax(val: numbers.Number, maxval: numbers.Number) -> numbers.Number:
@@ -10133,7 +10133,7 @@ Set the value of val to maxval if val > maxval
         Number
 
 
-### [`setmin`](#Python_BMP.mathlib.setmin)
+### [`setmin`](#setmin)
 
 ```py
 def setmin(val: numbers.Number, minval: numbers.Number) -> numbers.Number:
@@ -10149,7 +10149,7 @@ Set the value of val to minval if val < minval
         Number
 
 
-### [`setminmax`](#Python_BMP.mathlib.setminmax)
+### [`setminmax`](#setminmax)
 
 ```py
 def setminmax(val: numbers.Number, minval: numbers.Number, maxval: numbers.Number) -> numbers.Number:
@@ -10167,7 +10167,7 @@ or the value of val to maxval if val > maxval
         Number
 
 
-### [`setnewpalfromsourcebmp`](#Python_BMP.BITMAPlib.setnewpalfromsourcebmp)
+### [`setnewpalfromsourcebmp`](#setnewpalfromsourcebmp)
 
 ```py
 def setnewpalfromsourcebmp(sourcebmp: array.array, newbmp: array.array, similaritythreshold: float) -> list:
@@ -10197,7 +10197,7 @@ can have different bit depths)
         based on source bitmap
 
 
-### [`setRGBpal`](#Python_BMP.BITMAPlib.setRGBpal)
+### [`setRGBpal`](#setRGBpal)
 
 ```py
 def setRGBpal(bmp: array.array, c: int, r: int, g: int, b: int):
@@ -10217,7 +10217,7 @@ Sets the r,g,b values of color c in a bitmap
         byref modified unsigned byte array
 
 
-### [`showsimilarparts`](#Python_BMP.BITMAPlib.showsimilarparts)
+### [`showsimilarparts`](#showsimilarparts)
 
 ```py
 def showsimilarparts(inputfile1: str, inputfile2: str, diff_file: str):
@@ -10236,7 +10236,7 @@ Compares 2 files and saves the similar parts to a BMP
         new bitmap file
 
 
-### [`sortrecpoints`](#Python_BMP.primitives2D.sortrecpoints)
+### [`sortrecpoints`](#sortrecpoints)
 
 ```py
 def sortrecpoints(x1: int, y1: int, x2: int, y2: int):
@@ -10255,7 +10255,7 @@ Sorts the x and y values that sets a rectangular area
         x1 < x2 and y1 < y2
 
 
-### [`sphere2file`](#Python_BMP.BITMAPlib.sphere2file)
+### [`sphere2file`](#sphere2file)
 
 ```py
 def sphere2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, rgbfactors: list[float, float, float]):
@@ -10279,7 +10279,7 @@ Renders a sphere
         new bitmap file
 
 
-### [`sphere`](#Python_BMP.BITMAPlib.sphere)
+### [`sphere`](#sphere)
 
 ```py
 def sphere(bmp: array.array, x: int, y: int, r: int, rgbfactors: list[float, float, float]):
@@ -10302,7 +10302,7 @@ Draws a Rendered Sphere
         byref modified unsigned byte array
 
 
-### [`spherevertandsurface`](#Python_BMP.solids3D.spherevertandsurface)
+### [`spherevertandsurface`](#spherevertandsurface)
 
 ```py
 def spherevertandsurface(vcen: list[float, float, float], r: float, deganglestep: float) -> tuple:
@@ -10328,7 +10328,7 @@ Returns a list of sparse
         and Hello_Globe.py
 
 
-### [`spiralcontrolpointsvert`](#Python_BMP.primitives2D.spiralcontrolpointsvert)
+### [`spiralcontrolpointsvert`](#spiralcontrolpointsvert)
 
 ```py
 def spiralcontrolpointsvert(x: int, y: int, step: int, growthfactor: float, turns: int):
@@ -10352,7 +10352,7 @@ Returns a list of 2D vertices of a Square Spiral
         list[[x: int, y: int]]
 
 
-### [`spirographvert`](#Python_BMP.primitives2D.spirographvert)
+### [`spirographvert`](#spirographvert)
 
 ```py
 def spirographvert(x: int, y: int, r: int, l: float, k: float, delta: float, lim: float):
@@ -10377,7 +10377,7 @@ with an origin set at (x, y)
         [[x: int, y: int], ...]
 
 
-### [`subvect`](#Python_BMP.mathlib.subvect)
+### [`subvect`](#subvect)
 
 ```py
 def subvect(u: list[numbers.Number], v: list[numbers.Number]) -> list[numbers.Number]:
@@ -10392,7 +10392,7 @@ Subtracts vectors u and v by subtracting their components
         list of ints or floats
 
 
-### [`surfplot3Dvertandsurface`](#Python_BMP.solids3D.surfplot3Dvertandsurface)
+### [`surfplot3Dvertandsurface`](#surfplot3Dvertandsurface)
 
 ```py
 def surfplot3Dvertandsurface(x1: int, y1: int, x2: int, y2: int, step: int, fnxy: Callable) -> tuple:
@@ -10413,7 +10413,7 @@ Does a 3D surface plot of a
         see Hello_3D_surfaceplot.py
 
 
-### [`swapcolors`](#Python_BMP.BITMAPlib.swapcolors)
+### [`swapcolors`](#swapcolors)
 
 ```py
 def swapcolors(bmp: array.array, p1: list, p2: list):
@@ -10431,7 +10431,7 @@ Swaps the colors of two points in a BMP
         byref modified unsigned byte array
 
 
-### [`swapif`](#Python_BMP.conditionaltools.swapif)
+### [`swapif`](#swapif)
 
 ```py
 def swapif(val1: <built-in function any>, val2: <built-in function any>, boolcond: bool):
@@ -10451,7 +10451,7 @@ Swaps val1 and val2 if
         values depending on boolcond
 
 
-### [`swapxy`](#Python_BMP.mathlib.swapxy)
+### [`swapxy`](#swapxy)
 
 ```py
 def swapxy(v: list) -> list:
@@ -10466,7 +10466,7 @@ Swaps the first two values in a list
         list[y, x]
 
 
-### [`tetrahedravert`](#Python_BMP.solids3D.tetrahedravert)
+### [`tetrahedravert`](#tetrahedravert)
 
 ```py
 def tetrahedravert(x: float) -> list[list[float, float, float]]:
@@ -10484,7 +10484,7 @@ Returns a list of vertices
               z: float)
 
 
-### [`thickcircle`](#Python_BMP.BITMAPlib.thickcircle)
+### [`thickcircle`](#thickcircle)
 
 ```py
 def thickcircle(bmp: array.array, x: int, y: int, r: int, penradius: int, color: int):
@@ -10504,7 +10504,7 @@ Draws a Thick Circle
         byref modified unsigned byte array
 
 
-### [`thickellipserot`](#Python_BMP.BITMAPlib.thickellipserot)
+### [`thickellipserot`](#thickellipserot)
 
 ```py
 def thickellipserot(bmp: array.array, x: int, y: int, b: int, a: int, degrot: float, penradius: int, color: int):
@@ -10527,7 +10527,7 @@ Draws a Thick Ellipse
         unsigned byte array
 
 
-### [`thickencirclearea2file`](#Python_BMP.BITMAPlib.thickencirclearea2file)
+### [`thickencirclearea2file`](#thickencirclearea2file)
 
 ```py
 def thickencirclearea2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, rgbfactors: list[float, float, float]):
@@ -10548,7 +10548,7 @@ def thickencirclearea2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int
         new bitmap file
 
 
-### [`thickencirclearea`](#Python_BMP.BITMAPlib.thickencirclearea)
+### [`thickencirclearea`](#thickencirclearea)
 
 ```py
 def thickencirclearea(bmp: array.array, x: int, y: int, r: int, rgbfactors: list[float, float, float]):
@@ -10569,7 +10569,7 @@ Encircle area with a gradient
         byref modified unsigned byte array
 
 
-### [`thickplotpoly`](#Python_BMP.BITMAPlib.thickplotpoly)
+### [`thickplotpoly`](#thickplotpoly)
 
 ```py
 def thickplotpoly(bmp: array.array, vertlist: list[list[numbers.Number, numbers.Number]], penradius: int, color: int):
@@ -10589,7 +10589,7 @@ Draws a polygon of a given color and thickness
         byref modified unsigned byte array
 
 
-### [`thickroundline`](#Python_BMP.BITMAPlib.thickroundline)
+### [`thickroundline`](#thickroundline)
 
 ```py
 def thickroundline(bmp: array.array, p1: list, p2: list, penradius: int, color: int):
@@ -10610,7 +10610,7 @@ Draw a Thick Rounded Line
         byref modified unsigned byte array
 
 
-### [`thresholdadjcircregion2file`](#Python_BMP.BITMAPlib.thresholdadjcircregion2file)
+### [`thresholdadjcircregion2file`](#thresholdadjcircregion2file)
 
 ```py
 def thresholdadjcircregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, lumrange: list[int, int]):
@@ -10632,7 +10632,7 @@ Threshold adjustment to a circular region in a 24-bit BMP
         new bitmap file
 
 
-### [`thresholdadjcircregion`](#Python_BMP.BITMAPlib.thresholdadjcircregion)
+### [`thresholdadjcircregion`](#thresholdadjcircregion)
 
 ```py
 def thresholdadjcircregion(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int]):
@@ -10653,7 +10653,7 @@ Threshold adjustment to a circular area
         byref modified unsigned byte array
 
 
-### [`thresholdadjto24bitimage`](#Python_BMP.BITMAPlib.thresholdadjto24bitimage)
+### [`thresholdadjto24bitimage`](#thresholdadjto24bitimage)
 
 ```py
 def thresholdadjto24bitimage(bmp: array.array, lumrange: list[int, int]):
@@ -10672,7 +10672,7 @@ Threshold adjustment to a whole BMP
         byref modified unsigned byte array
 
 
-### [`thresholdadjto24bitregion`](#Python_BMP.BITMAPlib.thresholdadjto24bitregion)
+### [`thresholdadjto24bitregion`](#thresholdadjto24bitregion)
 
 ```py
 def thresholdadjto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):
@@ -10696,7 +10696,7 @@ Threshold adjustment to a rectangular area
         byref modified unsigned byte array
 
 
-### [`thresholdadjust2file`](#Python_BMP.BITMAPlib.thresholdadjust2file)
+### [`thresholdadjust2file`](#thresholdadjust2file)
 
 ```py
 def thresholdadjust2file(ExistingBMPfile: str, NewBMPfile: str, lumrange: list[int, int]):
@@ -10717,7 +10717,7 @@ Apply a threshold adjustment
         new bitmap file
 
 
-### [`thresholdadjust`](#Python_BMP.colors.thresholdadjust)
+### [`thresholdadjust`](#thresholdadjust)
 
 ```py
 def thresholdadjust(rgb: list[int, int, int], lumrange: list[int, int]) -> list[int, int, int]:
@@ -10744,7 +10744,7 @@ Apply a threshold adjustment
                   b: byte]
 
 
-### [`trans`](#Python_BMP.mathlib.trans)
+### [`trans`](#trans)
 
 ```py
 def trans(vlist: list[list[numbers.Number]], u: list[numbers.Number]) -> list[list[numbers.Number]]:
@@ -10761,7 +10761,7 @@ to all vectors in the list of vectors
         list of vectors
 
 
-### [`upgradeto24bitimage2file`](#Python_BMP.BITMAPlib.upgradeto24bitimage2file)
+### [`upgradeto24bitimage2file`](#upgradeto24bitimage2file)
 
 ```py
 def upgradeto24bitimage2file(ExistingBMPfile: str, NewBMPfile: str):
@@ -10779,7 +10779,7 @@ Upgrades a bitmap file to 24-bits
         new bitmap file
 
 
-### [`upgradeto24bitimage`](#Python_BMP.BITMAPlib.upgradeto24bitimage)
+### [`upgradeto24bitimage`](#upgradeto24bitimage)
 
 ```py
 def upgradeto24bitimage(bmp: array.array):
@@ -10795,7 +10795,7 @@ Upgrade an image to 24-bits
         byref modified unsigned byte array
 
 
-### [`userdef2Dcooordsys2screenxy`](#Python_BMP.BITMAPlib.userdef2Dcooordsys2screenxy)
+### [`userdef2Dcooordsys2screenxy`](#userdef2Dcooordsys2screenxy)
 
 ```py
 def userdef2Dcooordsys2screenxy(x: int, y: int, lstcooordinfo: list):
@@ -10822,7 +10822,7 @@ def userdef2Dcooordsys2screenxy(x: int, y: int, lstcooordinfo: list):
         [x: int, y: int] screen coordinates
 
 
-### [`vertBMPbitBLTget`](#Python_BMP.BITMAPlib.vertBMPbitBLTget)
+### [`vertBMPbitBLTget`](#vertBMPbitBLTget)
 
 ```py
 def vertBMPbitBLTget(bmp: array.array, x: int, y1: int, y2: int) -> array.array:
@@ -10840,7 +10840,7 @@ Gets vertical slice to a new array
         unsigned byte array
 
 
-### [`vertbrightnessgrad2circregion2file`](#Python_BMP.BITMAPlib.vertbrightnessgrad2circregion2file)
+### [`vertbrightnessgrad2circregion2file`](#vertbrightnessgrad2circregion2file)
 
 ```py
 def vertbrightnessgrad2circregion2file(ExistingBMPfile: str, NewBMPfile: str, x: int, y: int, r: int, lumrange: list[int, int]):
@@ -10866,7 +10866,7 @@ Vertical brightness gradient to a circular area
         new bitmap file
 
 
-### [`vertbrightnessgrad2circregion`](#Python_BMP.BITMAPlib.vertbrightnessgrad2circregion)
+### [`vertbrightnessgrad2circregion`](#vertbrightnessgrad2circregion)
 
 ```py
 def vertbrightnessgrad2circregion(bmp: array.array, x: int, y: int, r: int, lumrange: list[int, int]):
@@ -10888,7 +10888,7 @@ Vertical brightness gradient adjustment to a circular area
         byref modified unsigned byte array
 
 
-### [`verticalbrightnessgrad2file`](#Python_BMP.BITMAPlib.verticalbrightnessgrad2file)
+### [`verticalbrightnessgrad2file`](#verticalbrightnessgrad2file)
 
 ```py
 def verticalbrightnessgrad2file(ExistingBMPfile: str, NewBMPfile: str, lumrange: list[int, int]):
@@ -10910,7 +10910,7 @@ Applies a Vertical brightness gradient
         new bitmap file
 
 
-### [`verticalbrightnessgradregion2file`](#Python_BMP.BITMAPlib.verticalbrightnessgradregion2file)
+### [`verticalbrightnessgradregion2file`](#verticalbrightnessgradregion2file)
 
 ```py
 def verticalbrightnessgradregion2file(ExistingBMPfile: str, NewBMPfile: str, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):
@@ -10935,7 +10935,7 @@ Vertical brightness gradient to a rectangular area
         new bitmap file
 
 
-### [`verticalbrightnessgradto24bitimage`](#Python_BMP.BITMAPlib.verticalbrightnessgradto24bitimage)
+### [`verticalbrightnessgradto24bitimage`](#verticalbrightnessgradto24bitimage)
 
 ```py
 def verticalbrightnessgradto24bitimage(bmp: array.array, lumrange: list[int, int]):
@@ -10953,7 +10953,7 @@ Applies a vertical brightness gradient
         byref modified unsigned byte array
 
 
-### [`verticalbrightnessgradto24bitregion`](#Python_BMP.BITMAPlib.verticalbrightnessgradto24bitregion)
+### [`verticalbrightnessgradto24bitregion`](#verticalbrightnessgradto24bitregion)
 
 ```py
 def verticalbrightnessgradto24bitregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, lumrange: list[int, int]):
@@ -10977,7 +10977,7 @@ to a rectangular area in a 24-bit bitmap
         byref modified unsigned byte array
 
 
-### [`verticalvert`](#Python_BMP.primitives2D.verticalvert)
+### [`verticalvert`](#verticalvert)
 
 ```py
 def verticalvert(x: int, y1: int, y2: int, dy: int) -> list[list[int, int]]:
@@ -10997,7 +10997,7 @@ along a vertical line with int step dy
         [(x, y), ...]
 
 
-### [`vertline`](#Python_BMP.BITMAPlib.vertline)
+### [`vertline`](#vertline)
 
 ```py
 def vertline(bmp: array.array, x: int, y1: int, y2: int, color: int):
@@ -11018,7 +11018,7 @@ Draw a Vertical Line
         byref modified unsigned byte array
 
 
-### [`vertlinevert`](#Python_BMP.BITMAPlib.vertlinevert)
+### [`vertlinevert`](#vertlinevert)
 
 ```py
 def vertlinevert(bmp: array.array, vlist: list[list[int, int]], linelen: int, yadj: int, color: int):
@@ -11041,7 +11041,7 @@ Vertical line marks at vertices in vlist
         byref modified unsigned byte array
 
 
-### [`verttrans`](#Python_BMP.BITMAPlib.verttrans)
+### [`verttrans`](#verttrans)
 
 ```py
 def verttrans(bmp: array.array, trans: str):
@@ -11063,7 +11063,7 @@ Do vertical image transforms
         unsigned byte array
 
 
-### [`verttransformincircregion`](#Python_BMP.BITMAPlib.verttransformincircregion)
+### [`verttransformincircregion`](#verttransformincircregion)
 
 ```py
 def verttransformincircregion(bmp: array.array, x: int, y: int, r: int, trans: str):
@@ -11089,7 +11089,7 @@ at (x, y) and radius r
         byref modified unsigned byte array
 
 
-### [`verttransregion`](#Python_BMP.BITMAPlib.verttransregion)
+### [`verttransregion`](#verttransregion)
 
 ```py
 def verttransregion(bmp: array.array, x1: int, y1: int, x2: int, y2: int, trans: str):
@@ -11117,7 +11117,7 @@ Do vertical image transforms
         unsigned byte array
 
 
-### [`vmag`](#Python_BMP.mathlib.vmag)
+### [`vmag`](#vmag)
 
 ```py
 def vmag(v: list[float]) -> float:
@@ -11133,7 +11133,7 @@ of arbitrary dimension n equal to len(v)
         float
 
 
-### [`writeint`](#Python_BMP.inttools.writeint)
+### [`writeint`](#writeint)
 
 ```py
 def writeint(offset: int, cnt: int, arr: array.array, value: int):
@@ -11158,7 +11158,7 @@ Writes an integer value to an
         byref unsigned byte array
 
 
-### [`xorvect`](#Python_BMP.mathlib.xorvect)
+### [`xorvect`](#xorvect)
 
 ```py
 def xorvect(u: list[int], v: list[int]) -> list[int]:
@@ -11175,7 +11175,7 @@ two lists of ints
         list[int]
 
 
-### [`XYaxis`](#Python_BMP.BITMAPlib.XYaxis)
+### [`XYaxis`](#XYaxis)
 
 ```py
 def XYaxis(bmp: array.array, origin: list[int, int], steps: list[int, int], xylimits: list[int, int], xyvalstarts: list[numbers.Number, numbers.Number], xysteps: list[numbers.Number, numbers.Number], color: int, textcolor: int, showgrid: bool, gridcolor: int):
@@ -11214,7 +11214,7 @@ XY axis with tick marks and numbers
         unsigned byte array
 
 
-### [`xygrid`](#Python_BMP.BITMAPlib.xygrid)
+### [`xygrid`](#xygrid)
 
 ```py
 def xygrid(bmp: array.array, x1: int, y1: int, x2: int, y2: int, xysteps: list[int, int], color: int):
@@ -11237,7 +11237,7 @@ Draws a grid
         byref modified unsigned byte array
 
 
-### [`xygridvec`](#Python_BMP.BITMAPlib.xygridvec)
+### [`xygridvec`](#xygridvec)
 
 ```py
 def xygridvec(bmp: array.array, u: list[int, int], v: list[int, int], steps: list[int, int], gridcolor: int):
@@ -11259,7 +11259,7 @@ Grid using (x, y) point pairs u and v
         byref modified unsigned byte array
 
 
-### [`XYscatterplot`](#Python_BMP.BITMAPlib.XYscatterplot)
+### [`XYscatterplot`](#XYscatterplot)
 
 ```py
 def XYscatterplot(bmp: array.array, XYdata: list, XYcoordinfo: list, showLinearRegLine: bool, reglinecolor: int):


### PR DESCRIPTION
Tweaks to markdown formatting
- Make a linkified heading
- Split docstring into 
    - `d1`: synopsis (first line)
    - `d2`: details (subsequent)
- Format prototype as python source