### PR TITLE
Make python 3.8 compatible; ensure top directory in PATH etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,5 @@ dmypy.json
 .pyre/
 
 test_output/
+Hello*.bmp
 

--- a/Python_BMP/BITMAPlib.py
+++ b/Python_BMP/BITMAPlib.py
@@ -29,8 +29,12 @@
  -----------------------------------
 """
 
+from . import shims
 from array import array
 from math import(sin, cos, radians, pi)
+from os import environ
+from os.path import pathsep
+from pathlib import Path
 from random import random
 from typing import Callable
 from numbers import Number
@@ -1245,6 +1249,21 @@ def loadBMP(filename: str) -> array:
     return a
 
 
+def ensurePaintWrapperInPath():
+    """
+	Ensure that the parent directory containing 
+    the 'mspaint' wrapper is in the
+    PATH environment var.
+    """
+    # Directory containing `mspaint`
+    d: Path = Path(__file__).parent.parent
+    d_abs = str(d.absolute())
+    entries = environ.get("PATH", "").split(pathsep)
+    if d_abs not in entries:
+        entries.insert(0, d_abs)
+        environ["PATH"] = pathsep.join(entries)
+
+
 def saveBMP(filename: str, bmp: array):
     """Saves bitmap to file
 
@@ -1257,6 +1276,7 @@ def saveBMP(filename: str, bmp: array):
     Returns:
         A Bitmap File
     """
+    ensurePaintWrapperInPath()
     with open(filename, 'wb') as f:
         f.write(bmp)
         f.close()

--- a/Python_BMP/shims.py
+++ b/Python_BMP/shims.py
@@ -1,0 +1,26 @@
+"""
+conftest.py - builtin classes generics shim for python < 3.9
+"""
+from sys import version_info
+
+if version_info < (3, 9):
+    # For each of the following types, add a 
+    # new class function called `__class_getitem__`.
+    # This is called when the type is subscripted,
+    # such as in:
+    #
+    #    list[str]
+    #    dict[int, list[int]]
+    #
+    # This will make these typing expressions work
+    # seamlessly on python versions >= 3.7 and < 3.9
+    # (support was added, but not used out-of-the-box),
+    # in python 3.7).
+    import gc, types, typing
+    from typing import _GenericAlias as GenericAlias
+    for t in (list, dict, set, tuple, frozenset):
+      r = gc.get_referents(t.__dict__)[0]
+      r.update({
+        "__class_getitem__": classmethod(GenericAlias),
+      })
+


### PR DESCRIPTION
- Make python 3.8 compatible
- Ensure top directory is in PATH (so `mspaint` will be properly opened) when calling saveBMP
- ignore `Hello*.bmp` in git